### PR TITLE
Fix German translation of Menu-Text (Win-Version)

### DIFF
--- a/language/doublecmd.de.po
+++ b/language/doublecmd.de.po
@@ -10766,7 +10766,7 @@ msgstr "Namen mit UNC-Pfad kopieren"
 
 #: ulng.rsmnucreateshortcut
 msgid "Create Shortcut..."
-msgstr "Tastaturkürzel erstellen ..."
+msgstr "Verknüpfung erstellen ..."
 
 #: ulng.rsmnudisconnectnetworkdrive
 msgid "Disconnect Network Drive..."


### PR DESCRIPTION
German translation of 
Menu -> Files -> Create Shortcut
which actually is this
Menü -> Dateien -> Tastaturkürzel erstellen ...
is wrong and should be replaced by:
Menü -> Dateien -> Verknüpfung erstellen ...
Changed text in line 10769