### PR TITLE
CHG: AudioInfo: 'Duration' returns duration as a number in seconds.

### DIFF
--- a/plugins/wdx/audioinfo/audioinfo.lng
+++ b/plugins/wdx/audioinfo/audioinfo.lng
@@ -1,7 +1,7 @@
 [RUS]
 Channels=Каналы
-Duration=Время
-Duration (H/M/S)=Время (Ч/М/С)
+Duration (seconds)=Время (секунды)
+Duration (H:M:S)=Время (Ч:М:С)
 Sample rate=Частота
 Bitrate=Битрейт
 Bitrate type=Тип битрейта
@@ -25,8 +25,8 @@ CBR|VBR|Unknown=CBR|VBR|Неизвестно
 
 [FRA]
 Channels=Canaux
-Duration=Duree
-Duration (H/M/S)=Duree (H/M/S)
+Duration (seconds)=Duree (secondes)
+Duration (H:M:S)=Duree (H:M:S)
 Sample rate=Échantillonnage
 Bitrate=Débit
 Bitrate type=Type de débit

--- a/plugins/wdx/audioinfo/src/AudioInfo.lpr
+++ b/plugins/wdx/audioinfo/src/AudioInfo.lpr
@@ -18,8 +18,8 @@ const
 
   FIELD_NAME: array[0..Pred(FIELD_COUNT)] of String = (
     'Channels',
-    'Duration',
-    'Duration (H/M/S)',
+    'Duration (seconds)',
+    'Duration (H:M:S)',
     'Sample rate',
     'Bitrate',
     'Bitrate type',
@@ -41,7 +41,7 @@ const
 
   FIELD_TYPE: array[0..Pred(FIELD_COUNT)] of Integer = (
     ft_multiplechoice,
-    ft_time,
+    ft_numeric_32,
     ft_string,
     ft_numeric_32,
     ft_numeric_32,
@@ -125,12 +125,7 @@ begin
 
   case FieldIndex of
     0: Value:= DataAudio.Channels;
-    1:
-      begin
-        Time^.wHour:= DataAudio.Duration div 3600;
-        Time^.wMinute:= DataAudio.Duration mod 3600 div 60;
-        Time^.wSecond:= DataAudio.Duration mod 60;
-      end;
+    1: ValueI^:= DataAudio.Duration;
     2: Value:= DataAudio.DurationHMS;
     3:
       case UnitIndex of


### PR DESCRIPTION
The fields 'Duration' and 'Duration (H/M/S)' were renamed.
UPD: audioinfo.lng.