### PR TITLE
Feat: Add Version Pubilsher to ARP Entries

### DIFF
--- a/install/create_packages.bat
+++ b/install/create_packages.bat
@@ -57,7 +57,7 @@ call %BUILD_DC_TMP_DIR%\install\windows\install.bat
 
 cd /D %BUILD_PACK_DIR%
 rem Create *.exe package
-%ISCC_EXE% /F"doublecmd-%DC_VER%.%CPU_TARGET%-%OS_TARGET%" doublecmd.iss
+%ISCC_EXE% /F"doublecmd-%DC_VER%.%CPU_TARGET%-%OS_TARGET%" /DDisplayVersion=%DC_VER% doublecmd.iss
 
 rem Move created package
 move release\*.exe %PACK_DIR%

--- a/install/windows/doublecmd.iss
+++ b/install/windows/doublecmd.iss
@@ -3,7 +3,9 @@
 
 [Setup]
 AppName=Double Commander
-AppVerName=Double Commander 1.1.0 beta
+AppVerName=Double Commander Beta {#DisplayVersion}
+AppVersion={#DisplayVersion}
+AppPublisher=Alexander Koblov
 AppPublisherURL=http://doublecmd.sourceforge.net
 AppSupportURL=http://doublecmd.sourceforge.net
 AppUpdatesURL=http://doublecmd.sourceforge.net


### PR DESCRIPTION
Currently, the EXE file does not set the `DisplayVersion` or `Publisher` entries in control panel.
![image](https://user-images.githubusercontent.com/12611259/147678734-75f271f9-ba27-4d6d-8142-7f666f2c11bc.png)

The MSI files do set these values. 
![image](https://user-images.githubusercontent.com/12611259/147678844-78b18d93-bb1e-4e7f-a5d2-82a7aed53a85.png)

This change should update the EXE files that are built to set these additional parameters
