### PR TITLE
Find and replace using RegEx in UTF8 encoded files

### DIFF
--- a/src/fFindDlg.pas
+++ b/src/fFindDlg.pas
@@ -29,7 +29,7 @@ interface
 uses
   Graphics, SysUtils, Classes, Controls, Forms, Dialogs, StdCtrls, ComCtrls,
   ExtCtrls, Menus, EditBtn, Spin, Buttons, DateTimePicker, KASComboBox,
-  fAttributesEdit, uDsxModule, DsxPlugin, uFindThread, uFindFiles,
+  fAttributesEdit, uDsxModule, DsxPlugin, uFindThread, uFindFiles, uRegExprU,
   uSearchTemplate, fSearchPlugin, uFileView, types, DCStrUtils,
   ActnList, uOSForms, uShellContextMenu, uExceptions, uFileSystemFileSource,
   uFormCommands, uHotkeyManager, LCLVersion, uWcxModule, uFileSource;
@@ -737,11 +737,19 @@ end;
 { TfrmFindDlg.cmbEncodingSelect }
 procedure TfrmFindDlg.cmbEncodingSelect(Sender: TObject);
 var
-  SingleByte: Boolean;
+  SupportedEncoding: Boolean;
+  Encoding: String;
 begin
-  SingleByte:= SingleByteEncoding(cmbEncoding.Text);
+  Encoding := cmbEncoding.Text;
+  SupportedEncoding:= SingleByteEncoding(Encoding);
+  if (not SupportedEncoding) and TRegExprU.AvailableNew then
+  begin
+    Encoding := NormalizeEncoding(Encoding);
+    if Encoding = EncodingDefault then Encoding := GetDefaultTextEncoding;
+    SupportedEncoding := Encoding = EncodingUTF8;
+  end;
 
-  cbTextRegExp.Enabled := cbFindText.Checked and SingleByte and (not chkHex.Checked);
+  cbTextRegExp.Enabled := cbFindText.Checked and SupportedEncoding and (not chkHex.Checked);
   if not cbTextRegExp.Enabled then cbTextRegExp.Checked := False;
 
   cbCaseSens.Enabled:= cbFindText.Checked and (not cbReplaceText.Checked) and (not chkHex.Checked) and (not cbTextRegExp.Checked);

--- a/src/ufindthread.pas
+++ b/src/ufindthread.pas
@@ -29,7 +29,7 @@ interface
 
 uses
   Classes, SysUtils, DCStringHashListUtf8, uFindFiles, uFindEx, uFindByrMr,
-  uMasks, uRegExprA, uRegExprW, uWcxModule;
+  uMasks, uRegExpr, uRegExprW, uWcxModule;
 
 type
 
@@ -64,7 +64,7 @@ type
     FExcludeDirectories: TMaskList;
     FFilesMasksRegExp: TRegExprW;
     FExcludeFilesRegExp: TRegExprW;
-    FRegExpr: TRegExpr;
+    FRegExpr: TRegExprEx;
     FArchive: TWcxModule;
     FHeader: TWcxHeader;
 
@@ -167,7 +167,7 @@ begin
       end
       else begin
         TextEncoding := NormalizeEncoding(TextEncoding);
-        if TextRegExp then FRegExpr := TRegExpr.Create(TextEncoding);
+        if TextRegExp then FRegExpr := TRegExprEx.Create(TextEncoding, True);
         FindText := ConvertEncoding(FindText, EncodingUTF8, TextEncoding);
         ReplaceText := ConvertEncoding(ReplaceText, EncodingUTF8, TextEncoding);
       end;
@@ -385,7 +385,9 @@ begin
     finally
       fs.Free;
     end;
-    Exit(FRegExpr.ExecRegExpr(sData, S));
+    FRegExpr.Expression := sData;
+    FRegExpr.SetInputString(Pointer(S), Length(S));
+    Exit(FRegExpr.Exec());
   end;
 
   if gUseMmapInSearch then
@@ -496,7 +498,7 @@ begin
   end;
 
   if bRegExp then
-    S := FRegExpr.ReplaceRegExpr(SearchString, S, replaceString, True)
+    S := FRegExpr.ReplaceAll(SearchString, S, replaceString)
   else
     begin
       Include(Flags, rfReplaceAll);

--- a/src/uregexpr.pas
+++ b/src/uregexpr.pas
@@ -118,6 +118,8 @@ end;
 procedure TRegExprEx.ChangeEncoding(const AEncoding: String);
 begin
   FEncoding:= NormalizeEncoding(AEncoding);
+  if FEncoding = EncodingDefault then
+    FEncoding:= GetDefaultTextEncoding;
   if FEncoding = EncodingUTF16LE then
     FType:= retUtf16le
   else if (FEncoding = EncodingUTF8) or (FEncoding = EncodingUTF8BOM) then

--- a/src/uregexpr.pas
+++ b/src/uregexpr.pas
@@ -25,7 +25,7 @@ type
     function GetMatchLen(Idx : Integer): PtrInt;
     function GetMatchPos(Idx : Integer): PtrInt;
   public
-    constructor Create(const AEncoding: String = EncodingDefault);
+    constructor Create(const AEncoding: String = EncodingDefault; ASetEncoding: Boolean = False);
     destructor Destroy; override;
     function Exec(AOffset: UIntPtr = 1): Boolean;
     function ReplaceAll(const AExpression, AStr, AReplacement: String): String;
@@ -71,11 +71,12 @@ begin
   end;
 end;
 
-constructor TRegExprEx.Create(const AEncoding: String);
+constructor TRegExprEx.Create(const AEncoding: String; ASetEncoding: Boolean = False);
 begin
   FRegExpW:= TRegExprW.Create;
   FRegExpU:= TRegExprU.Create;
   FRegExpA:= TRegExpr.Create(AEncoding);
+  if ASetEncoding then ChangeEncoding(AEncoding);
 end;
 
 destructor TRegExprEx.Destroy;


### PR DESCRIPTION
Added the `ReplaceAll` method to the `TRegExprU` class.  
FindThread uses`TRegExprEx` instead of `TRegExpr`.  
In FindDlg the `cbTextRegExp` checkbox is enabled if the file encoding is UTF8 (or Default).  

"Replace all" is implemented only for PCRE2, so functionality is enabled only if the libpcre2 library is available.