### PR TITLE
fix: fix default Terminal.app location for macOS

### DIFF
--- a/src/platform/uOSUtils.pas
+++ b/src/platform/uOSUtils.pas
@@ -20,7 +20,7 @@
 }
 
 unit uOSUtils;
- 
+
 {$mode delphi}
 
 {$IFDEF DARWIN}
@@ -38,7 +38,7 @@ uses
       {$ENDIF}
     {$ENDIF}
     ;
-    
+
 const
   CnstUserCommand = '{command}';
 
@@ -57,7 +57,7 @@ const
   faFolder = S_IFDIR;
   ReversePathDelim = '\';
   {$IFDEF DARWIN)}
-  RunTermCmd = '/Applications/Utilities/Terminal.app';  // default terminal
+  RunTermCmd = '/System/Applications/Utilities/Terminal.app';  // default terminal
   RunTermParams = '%D';
   RunInTermStayOpenCmd = '%COMMANDER_PATH%/scripts/terminal.sh'; // default run in terminal command AND Stay open after command
   RunInTermStayOpenParams = '''{command}''';


### PR DESCRIPTION
The Terminal.app was moved from `/Applications` into  `/System/Applications` some time ago once Apple decide move internal apps in read-only fs.
Until a new build is created with this path change, macOS users that wants to launch terminal from Doublecmd top icon  can create a symbolic link from  `/System/Applications/Utilities/Terminal.app` to  `/Applications/Utilities/Terminal.app`

```bash
sudo ln -s /System/Applications/Utilities/Terminal.app /Applications/Utilities/Terminal.app
```