### PR TITLE
FIX: FPC 3.3 compatibility

### DIFF
--- a/components/doublecmd/dcdatetimeutils.pas
+++ b/components/doublecmd/dcdatetimeutils.pas
@@ -31,7 +31,7 @@ uses
   {$IF DEFINED(MSWINDOWS)}
   , Windows
   {$ELSEIF DEFINED(UNIX)}
-  , UnixUtil, DCUnix
+  , Unix, UnixUtil, DCUnix
   {$ENDIF}
   ;
 

--- a/plugins/wcx/unrar/src/unrarfunc.pas
+++ b/plugins/wcx/unrar/src/unrarfunc.pas
@@ -25,6 +25,9 @@
 unit UnRARFunc;
 
 {$mode objfpc}{$H+}
+{$ifndef VER3_2}
+{$modeswitch arraytodynarray}
+{$endif}
 {$include calling.inc}
 
 interface

--- a/src/dmcommondata.pas
+++ b/src/dmcommondata.pas
@@ -40,7 +40,7 @@ type
     SaveDialog: TSaveDialog;
     procedure DataModuleCreate(Sender: TObject);
   private
-    procedure LoadImages(Images: TImageList; ANames: TStringArray);
+    procedure LoadImages(Images: TImageList; const ANames: array of String);
   public
     { public declarations }
   end; 
@@ -145,7 +145,7 @@ begin
   end;
 end;
 
-procedure TdmComData.LoadImages(Images: TImageList; ANames: TStringArray);
+procedure TdmComData.LoadImages(Images: TImageList; const ANames: array of String);
 var
   AName: String;
   ASize16, ASize24: Integer;

--- a/src/filesources/filesystem/ufilesystemutil.pas
+++ b/src/filesources/filesystem/ufilesystemutil.pas
@@ -1610,20 +1610,22 @@ end;
 function TFileSystemOperationHelper.FileExists(aFile: TFile;
   var AbsoluteTargetFileName: String; AllowAppend: Boolean
   ): TFileSourceOperationOptionFileExists;
+type
+  TFileSourceOperationUIResponses = array of TFileSourceOperationUIResponse;
 const
-  Responses: array[0..13] of TFileSourceOperationUIResponse
+  Responses: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourRenameSource, fsourOverwriteAll,
        fsourSkipAll, fsourResume, fsourOverwriteOlder, fsourCancel,
        fsouaCompare, fsourAppend, fsourOverwriteSmaller, fsourOverwriteLarger,
        fsourAutoRenameSource, fsourAutoRenameTarget);
-  ResponsesNoAppend: array[0..11] of TFileSourceOperationUIResponse
+  ResponsesNoAppend: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourRenameSource,  fsourOverwriteAll,
        fsourSkipAll, fsourOverwriteSmaller, fsourOverwriteOlder, fsourCancel,
        fsouaCompare, fsourOverwriteLarger, fsourAutoRenameSource, fsourAutoRenameTarget);
 var
   Answer: Boolean;
   Message: String;
-  PossibleResponses: array of TFileSourceOperationUIResponse;
+  PossibleResponses: TFileSourceOperationUIResponses;
 
   function RenameTarget: TFileSourceOperationOptionFileExists;
   var

--- a/src/filesources/wcxarchive/uwcxarchivecopyoutoperation.pas
+++ b/src/filesources/wcxarchive/uwcxarchivecopyoutoperation.pas
@@ -569,17 +569,19 @@ end;
 
 function TWcxArchiveCopyOutOperation.DoFileExists(Header: TWcxHeader;
   var AbsoluteTargetFileName: String): TFileSourceOperationOptionFileExists;
+type
+  TFileSourceOperationUIResponses = array of TFileSourceOperationUIResponse;
 const
-  Responses: array[0..10] of TFileSourceOperationUIResponse
+  Responses: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourOverwriteLarger, fsourOverwriteAll,
        fsourSkipAll, fsourOverwriteSmaller, fsourOverwriteOlder, fsourCancel,
        fsouaCompare, fsourRenameSource, fsourAutoRenameSource);
-  ResponsesNoCompare: array[0..9] of TFileSourceOperationUIResponse
+  ResponsesNoCompare: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourOverwriteLarger, fsourOverwriteAll,
        fsourSkipAll, fsourOverwriteSmaller, fsourOverwriteOlder, fsourCancel,
        fsourRenameSource, fsourAutoRenameSource);
 var
-  PossibleResponses: array of TFileSourceOperationUIResponse;
+  PossibleResponses: TFileSourceOperationUIResponses;
   Answer: Boolean;
   Message: String;
 

--- a/src/filesources/wfxplugin/uwfxpluginutil.pas
+++ b/src/filesources/wfxplugin/uwfxpluginutil.pas
@@ -438,16 +438,18 @@ end;
 function TWfxPluginOperationHelper.FileExists(aFile: TFile;
   AbsoluteTargetFileName: String; AllowResume: Boolean
   ): TFileSourceOperationOptionFileExists;
+type
+  TFileSourceOperationUIResponses = array of TFileSourceOperationUIResponse;
 const
-  Responses: array[0..6] of TFileSourceOperationUIResponse
+  Responses: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourResume, fsourOverwriteAll, fsourSkipAll,
        fsouaCompare, fsourCancel);
-  ResponsesNoResume: array[0..5] of TFileSourceOperationUIResponse
+  ResponsesNoResume: TFileSourceOperationUIResponses
     = (fsourOverwrite, fsourSkip, fsourOverwriteAll, fsourSkipAll, fsouaCompare,
        fsourCancel);
 var
   Message: String;
-  PossibleResponses: array of TFileSourceOperationUIResponse;
+  PossibleResponses: TFileSourceOperationUIResponses;
 begin
   case FFileExistsOption of
     fsoofeNone:

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -1479,7 +1479,7 @@ begin
     // Button was moved.
     SaveToolBar(Toolbar)
   else
-    if Sender is TKASToolButton and not Draging then
+    if (Sender is TKASToolButton) and not Draging then
       begin
         ToolItem := TKASToolButton(Sender).ToolItem;
         if ToolItem is TKASProgramItem then

--- a/src/ufilefunctions.pas
+++ b/src/ufilefunctions.pas
@@ -255,7 +255,7 @@ begin
       fsfAttr:
         if fpAttributes in AFile.SupportedProperties then
         begin
-          if AFile.Properties[fpAttributes] is TUnixFileAttributesProperty and (AParam = ATTR_OCTAL) then
+          if (AFile.Properties[fpAttributes] is TUnixFileAttributesProperty) and (AParam = ATTR_OCTAL) then
             Result := FormatUnixModeOctal(AFile.Attributes)
           else
             Result := AFile.Properties[fpAttributes].Format(DefaultFilePropertyFormatter);


### PR DESCRIPTION
The source file has been modified to allow doublecmd to be compiled with the current (trunk / main) version of FPC.  
At the same time, the project can also be compiled using FPC 3.2