### PR TITLE
RegExpr validation for UTF8 encoded files in TfrmFindDlg.InvalidRegExpr method

### DIFF
--- a/src/fFindDlg.pas
+++ b/src/fFindDlg.pas
@@ -2721,8 +2721,11 @@ begin
     begin
       sMsg:= cmbFindText.Text;
       sEncoding:= NormalizeEncoding(cmbEncoding.Text);
+      if sEncoding = EncodingDefault then sEncoding:= GetDefaultTextEncoding;
       // Use correct RegExp engine
-      if SingleByteEncoding(sEncoding) then
+      if TRegExprU.Available and (sEncoding = EncodingUTF8) then
+        uRegExprU.ExecRegExpr(sMsg, '')
+      else if SingleByteEncoding(sEncoding) then
         uRegExprA.ExecRegExpr(sMsg, '')
       else if (sEncoding = EncodingUTF16LE) then
         uRegExprW.ExecRegExpr(CeUtf8ToUtf16(sMsg), '');

--- a/src/uregexpru.pas
+++ b/src/uregexpru.pas
@@ -140,6 +140,7 @@ var
   error: PAnsiChar;
   errornumber: cint;
   erroroffset: cint;
+  len: cint;
 begin
   FExpression:= AValue;
 
@@ -150,7 +151,9 @@ begin
       FMatch := pcre2_match_data_create_from_pattern(FCode, nil)
     else begin
       SetLength(Message, MAX_PATH + 1);
-      pcre2_get_error_message(errornumber, PAnsiChar(Message), MAX_PATH);
+      len := pcre2_get_error_message(errornumber, PAnsiChar(Message), MAX_PATH);
+      if len < 0 then len := Length(PAnsiChar(Message)); // PCRE2_ERROR_NOMEMORY
+      SetLength(Message, len);
       raise Exception.Create(Message);
     end;
   end

--- a/src/uregexpru.pas
+++ b/src/uregexpru.pas
@@ -64,6 +64,8 @@ type
     property MatchLen [Idx : integer] : PtrInt read GetMatchLen;
   end;
 
+function ExecRegExpr(const ARegExpr, AInputStr: String): Boolean;
+
 implementation
 
 uses
@@ -287,6 +289,20 @@ begin
       PAnsiChar(Replacement), Length(Replacement), PAnsiChar(Output), outlength);
   end;
   Result := res >= 0;
+end;
+
+function ExecRegExpr(const ARegExpr, AInputStr: String): Boolean;
+var
+  r: TRegExprU;
+begin
+  r := TRegExprU.Create;
+  try
+    r.Expression := ARegExpr;
+    r.SetInputString(PChar(AInputStr), Length(AInputStr));
+    Result := r.Exec(1);
+  finally
+    r.Free;
+  end;
 end;
 
 procedure Initialize;


### PR DESCRIPTION
* FIX: Added regexpr validation for UTF8 encoded files in `TfrmFindDlg.InvalidRegExpr` method
* ADD: Added `ExecRegExpr` function to `uregexpru` unit
* FIX: Trimming string length after calling `pcre2_get_error_message`

Related to 9b479b80