### PR TITLE
ADD: GenericName key to .desktop file

### DIFF
--- a/install/linux/doublecmd.desktop
+++ b/install/linux/doublecmd.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=Double Commander
+GenericName=File Manager
 Comment=Double Commander is a cross platform open source file manager with two panels side by side.
 Terminal=false
 Icon=doublecmd


### PR DESCRIPTION
this 'GenericName' is shown in KDE's Application Launcher
without this key 'Comment' is used instead, and it looks bad, because comment is long
key/value pair was taken from KDE's Krusader