### PR TITLE
UPD: Dark mode - menu separator lines

### DIFF
--- a/src/platform/win/uwin32widgetsetdark.pas
+++ b/src/platform/win/uwin32widgetsetdark.pas
@@ -964,7 +964,7 @@ begin
         if iPartId = MENU_POPUPSEPARATOR then
         begin
          LRect:= pRect;
-         LCanvas.Pen.Color:= RGBToColor(34, 34, 34);
+         LCanvas.Pen.Color:= RGBToColor(112, 112, 112);
          LRect.Top:= LRect.Top + (LRect.Height div 2);
          LRect.Bottom:= LRect.Top;
 


### PR DESCRIPTION
Make menu separator lines visible in dark mode. The previous color was too dark to be seen.