### PR TITLE
FIX: Cocoa: according page not actived after tab moved(dragdrop)

### DIFF
--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -722,7 +722,12 @@ begin
     begin
       // Move within the same panel.
       if ATabIndex <> -1 then
+      begin
         Tabs.Move(FDraggedPageIndex, ATabIndex);
+        {$IFDEF LCLCOCOA}
+        GetPage(ATabIndex).MakeActive;
+        {$ENDIF}
+      end;
     end
     else if (SourceNotebook.FDraggedPageIndex < SourceNotebook.PageCount) then
     begin


### PR DESCRIPTION
FIX the bug reported in DC Forum: [Mac - move tabs](https://doublecmd.h1n.ru/viewtopic.php?p=32839#p32839)