### PR TITLE
FIX & UPD: Issues related to "Synchronize directories"

### DIFF
--- a/src/filesources/filesystem/ufilesystemdeleteoperation.pas
+++ b/src/filesources/filesystem/ufilesystemdeleteoperation.pas
@@ -408,6 +408,7 @@ begin
     end;
     UpdateStatistics(FStatistics);
 
+    AppProcessMessages();
     CheckOperationState;
   end;
 end;

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -567,6 +567,7 @@ begin
   DeleteLeftCount := 0; DeleteRightCount := 0;
   CopyLeftCount := 0; CopyRightCount := 0;
   CopyLeftSize := 0;  CopyRightSize := 0;
+
   for i := 0 to FVisibleItems.Count - 1 do
     if Assigned(FVisibleItems.Objects[i]) then
     begin
@@ -642,8 +643,14 @@ begin
       CopyRight := chkLeftToRight.Checked;
       DeleteLeft := chkDeleteLeft.Checked;
       DeleteRight := chkDeleteRight.Checked;
+
+      lblProgress.Caption := rsOperCopying;
+      lblProgressDelete.Caption := rsOperDeleting;
+      ProgressBar.Position:=0;
+      ProgressBarDelete.Position:=0;
       pnlCopyProgress.Visible:= CopyLeft or CopyRight;
       pnlDeleteProgress.Visible:= DeleteLeft or DeleteRight;
+
       i := 0;
       while i < FVisibleItems.Count do
       begin

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -787,6 +787,10 @@ begin
     FIniPropStorage.StoredValues.Add.DisplayName:= Format(GRID_COLUMN_FMT, [Index]);
   end;
 
+  {$IFDEF LCLCOCOA}
+  pnlProgress.Color:=clBtnHighlight;
+  {$ENDIF}
+
   lblProgress.Caption    := rsOperCopying;
   lblProgressDelete.Caption   := rsOperDeleting;
   { settings }

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -1811,20 +1811,38 @@ end;
 
 procedure TfrmSyncDirsDlg.SetProgressBytes(AProgressBar: TKASProgressBar;
   CurrentBytes: Int64; TotalBytes: Int64);
+var
+  BarText : String;
+  CaptionText : String;
 begin
-  AProgressBar.SetProgress(CurrentBytes, TotalBytes,
-                           cnvFormatFileSize(CurrentBytes, uoscOperation) + '/' +
-                           cnvFormatFileSize(TotalBytes, uoscOperation)
-                           );
+  BarText := cnvFormatFileSize(CurrentBytes, uoscOperation) + '/' + cnvFormatFileSize(TotalBytes, uoscOperation);
+  AProgressBar.SetProgress(CurrentBytes, TotalBytes, BarText );
+
+  {$IFDEF LCLCOCOA}
+  if TotalBytes > 0 then
+    CaptionText := rsOperCopying + ': ' + BarText + ' (' + FloatToStrF((CurrentBytes / TotalBytes) * 100, ffFixed, 0, 0) + '%)'
+  else
+    CaptionText := rsOperCopying;
+  lblProgress.Caption := CaptionText;
+  {$ENDIF}
 end;
 
 procedure TfrmSyncDirsDlg.SetProgressFiles(AProgressBar: TKASProgressBar;
   CurrentFiles: Int64; TotalFiles: Int64);
+var
+  BarText : String;
+  CaptionText : String;
 begin
-  AProgressBar.SetProgress(CurrentFiles, TotalFiles,
-                           cnvFormatFileSize(CurrentFiles, uoscNoUnit) + '/' +
-                           cnvFormatFileSize(TotalFiles, uoscNoUnit)
-                           );
+  BarText := cnvFormatFileSize(CurrentFiles, uoscNoUnit) + '/' + cnvFormatFileSize(TotalFiles, uoscNoUnit);
+  AProgressBar.SetProgress(CurrentFiles, TotalFiles, BarText );
+
+  {$IFDEF LCLCOCOA}
+  if TotalFiles > 0 then
+    CaptionText := rsOperDeleting + ': ' + BarText + ' (' + FloatToStrF((CurrentFiles / TotalFiles) * 100, ffFixed, 0, 0) + '%)'
+  else
+    CaptionText := rsOperDeleting;
+  lblProgressDelete.Caption := CaptionText;
+  {$ENDIF}
 end;
 
 procedure TfrmSyncDirsDlg.DoAutoAdjustLayout(const AMode: TLayoutAdjustmentPolicy;


### PR DESCRIPTION
patch for [https://github.com/doublecmd/doublecmd/issues/481](https://github.com/doublecmd/doublecmd/issues/481) 

Cocoa: hard to see in "Synchronize directories" (transparent background by "clDefault" color)