### PR TITLE
FIX: DARWIN: incorrectly setting the AllowDropFiles property, preventing dragdrop files from external apps

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -1086,10 +1086,18 @@ begin
   Application.OnEndSession := @AppEndSession;
   Application.OnQueryEndSession := @AppQueryEndSession;
 
+  {$IF DEFINED(DARWIN)}
+  // in LCL's DARWIN implements, there is no way but to Use LCL's method of dropping files
+  // from external applications
+  frmMain.OnDropFiles := @FormDropFiles;
+  AllowDropFiles := true; // DARWIN support external DragDragSource only, not DragDragTarget
+  {$ELSE}
   // Use LCL's method of dropping files from external
   // applications if we don't support it ourselves.
   if not IsExternalDraggingSupported then
     frmMain.OnDropFiles := @FormDropFiles;
+  AllowDropFiles := not uDragDropEx.IsExternalDraggingSupported;
+  {$ENDIF}
 
   {$IF DEFINED(DARWIN)}
   // MainForm receives in Mac OS closing events on system shortcut Command-Q
@@ -1152,8 +1160,6 @@ begin
   // Initialize actions.
   actShowSysFiles.Checked := uGlobs.gShowSystemFiles;
   actHorizontalFilePanels.Checked := gHorizontalFilePanels;
-
-  AllowDropFiles := not uDragDropEx.IsExternalDraggingSupported;
 
   MainToolBar.AddToolItemExecutor(TKASCommandItem, @ToolbarExecuteCommand);
   MainToolBar.AddToolItemExecutor(TKASProgramItem, @ToolbarExecuteProgram);


### PR DESCRIPTION
FIX: in MacOS, incorrectly setting the AllowDropFiles property, preventing dragdrop files from external apps