### PR TITLE
ADD: DARWIN: copy/cut/paste files perfectly, true file format instead of text string, no matter inside dc or on external apps (MacOs 10.5 compatibility)

### DIFF
--- a/src/platform/uClipboard.pas
+++ b/src/platform/uClipboard.pas
@@ -1,8 +1,11 @@
 unit uClipboard;
 
 {$mode objfpc}{$H+}
+{$IFDEF DARWIN}
+{$modeswitch objectivec1}
+{$ENDIF}
 
-{$IF DEFINED(UNIX)}
+{$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
   {$Define UNIX_not_DARWIN}
 {$ENDIF}
 
@@ -103,7 +106,7 @@ uses
 {$ELSEIF DEFINED(UNIX_not_DARWIN)}
   Clipbrd, LCLIntf
 {$ELSEIF DEFINED(DARWIN)}
-
+  DCStrUtils, CocoaAll, CocoaUtils, uMyDarwin
 {$ENDIF}
   ;
 
@@ -739,6 +742,17 @@ begin
 end;
 {$ENDIF}
 
+{$IFDEF DARWIN}
+procedure ClearClipboard( pb:NSPasteboard );
+begin
+  pb.clearContents;
+end;
+
+procedure ClearClipboard;
+begin
+  ClearClipboard( NSPasteboard.generalPasteboard );
+end;
+{$ENDIF}
 
 {$IF DEFINED(MSWINDOWS)}
 procedure ClipboardSetText(AText: String);
@@ -764,6 +778,13 @@ begin
 end;
 {$ENDIF}
 
+{$IFDEF DARWIN}
+procedure ClipboardSetText(AText: String);
+begin
+  ClearClipboard;
+  NSPasteboardAddString(AText);
+end;
+{$ENDIF}
 
 initialization
 


### PR DESCRIPTION
in MacOs, add copy/cut/paste files perfectly, just like on windows:
1. true file format instead of text string
2. no matter inside dc or on external apps
3. MacOs 10.5 forward compatibility
4. tested on MacOs 12 and Windows 11