### PR TITLE
FIX: LINUX: run in terminal option default value

### DIFF
--- a/src/platform/uOSUtils.pas
+++ b/src/platform/uOSUtils.pas
@@ -70,7 +70,7 @@ const
   RunInTermStayOpenCmd: String = 'xterm'; // default run in terminal command AND Stay open after command
   RunInTermStayOpenParams: String = '-e sh -c ''{command}; echo -n Press ENTER to exit... ; read a''';
   RunInTermCloseCmd: String = 'xterm'; // default run in terminal command AND Close after command
-  RunInTermCloseParams: String = '-e sh -c {command}';
+  RunInTermCloseParams: String = '-e sh -c ''{command}''';
   MonoSpaceFont = 'Monospace';
   {$ENDIF}
   fmtCommandPath = '[%s]$:';


### PR DESCRIPTION
Add quotes to default value of "run in terminal and close" parameters option. This at least fixes unobvious behavior of external tools (like external editor) that are missing filename parameter passed from DC.