### PR TITLE
FIX: DARWIN: load the icon file content by native method

### DIFF
--- a/src/platform/unix/ushellcontextmenu.pas
+++ b/src/platform/unix/ushellcontextmenu.pas
@@ -42,6 +42,7 @@ type
     FFiles: TFiles;
     FDrive: TDrive;
     FUserWishForContextMenu: TUserWishForContextMenu;
+    FMenuImageList: TImageList;
     procedure PackHereSelect(Sender: TObject);
     procedure ExtractHereSelect(Sender: TObject);
     procedure ContextMenuSelect(Sender: TObject);
@@ -352,7 +353,6 @@ var
   ApplicationUrlRef: CFURLRef = nil;
   ApplicationNameCFRef: CFStringRef = nil;
   ApplicationCString: array[0..MAX_PATH-1] of Char;
-  menuImageList: TImageList;
 begin
   Result:= False;
   if (FFiles.Count <> 1) then Exit;
@@ -365,8 +365,8 @@ begin
       Result:= True;
       miOpenWith := TMenuItem.Create(Self);
       miOpenWith.Caption := rsMnuOpenWith;
-      menuImageList := TImageList.Create(nil);
-      miOpenWith.SubMenuImages := menuImageList;
+      FMenuImageList := TImageList.Create(nil);
+      miOpenWith.SubMenuImages := FMenuImageList;
       Self.Items.Add(miOpenWith);
 
       for I:= 0 to CFArrayGetCount(ApplicationArrayRef) - 1 do
@@ -395,8 +395,8 @@ begin
               bmpTemp:= PixMapManager.GetBitmap(ImageIndex);
               if Assigned(bmpTemp) then
                 begin
-                  mi.ImageIndex:=menuImageList.Count;
-                  menuImageList.Add( bmpTemp , nil );
+                  mi.ImageIndex:=FMenuImageList.Count;
+                  FMenuImageList.Add( bmpTemp , nil );
                   FreeAndNil(bmpTemp);
                 end;
             end;
@@ -910,6 +910,7 @@ end;
 destructor TShellContextMenu.Destroy;
 begin
   FreeThenNil(FFiles);
+  FreeThenNil(FMenuImageList);
   inherited Destroy;
 end;
 

--- a/src/platform/unix/ushellcontextmenu.pas
+++ b/src/platform/unix/ushellcontextmenu.pas
@@ -352,6 +352,7 @@ var
   ApplicationUrlRef: CFURLRef = nil;
   ApplicationNameCFRef: CFStringRef = nil;
   ApplicationCString: array[0..MAX_PATH-1] of Char;
+  menuImageList: TImageList;
 begin
   Result:= False;
   if (FFiles.Count <> 1) then Exit;
@@ -364,6 +365,8 @@ begin
       Result:= True;
       miOpenWith := TMenuItem.Create(Self);
       miOpenWith.Caption := rsMnuOpenWith;
+      menuImageList := TImageList.Create(nil);
+      miOpenWith.SubMenuImages := menuImageList;
       Self.Items.Add(miOpenWith);
 
       for I:= 0 to CFArrayGetCount(ApplicationArrayRef) - 1 do
@@ -392,7 +395,8 @@ begin
               bmpTemp:= PixMapManager.GetBitmap(ImageIndex);
               if Assigned(bmpTemp) then
                 begin
-                  mi.Bitmap.Assign(bmpTemp);
+                  mi.ImageIndex:=menuImageList.Count;
+                  menuImageList.Add( bmpTemp , nil );
                   FreeAndNil(bmpTemp);
                 end;
             end;


### PR DESCRIPTION
FIX: DARWIN: load the icon file content by native method, support all MacOS ICNS formats (bitmap/png/jpeg), and avoid limited image formats support of Lazarus.

tested on MacOS and Windows.