### PR TITLE
FIX: use ad-hoc signing, fixes "Double Commander is damaged" on ARM-based Macs

### DIFF
--- a/install/create_packages.mac
+++ b/install/create_packages.mac
@@ -55,6 +55,7 @@ if [ "$lcl" = "qt" ]; then
   macdeployqt doublecmd.app
 fi
 mv doublecmd.app 'Double Commander.app'
+codesign --deep --force --verify --verbose --sign '-' 'Double Commander.app'
 hdiutil create -anyowners -volname "Double Commander" -imagekey zlib-level=9 -format UDZO -srcfolder 'Double Commander.app' $PACK_DIR/doublecmd-$DC_VER-$DC_REVISION.$lcl.$CPU_TARGET.dmg
 
 # Clean DC build dir


### PR DESCRIPTION
trying to launch nightly aarch64 build faced this error:
<img width="372" alt="Screenshot 2022-07-30 at 12 54 54" src="https://user-images.githubusercontent.com/947647/181908141-11944080-a526-4fc1-919f-a5cdbe6858ff.png">
launch from the terminal was successful, and everything looks fine, the app is at least usable.

just doing ad-hoc signing before dropping the application into the Applications directory fixes this issue. so, let's do a signing in the build script (this still will be considered as an "untrusted" application in any case).

very strange that everything is fine on Intel-based MacBook running the same macOS version. very likely macOS on ARM-based Mac is much more "phone-like"...