### PR TITLE
FIX: COCOA: F2-Rename EditButton: VK_RETURN handler in IME state

### DIFF
--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -185,6 +185,7 @@ type
     procedure WorkerStarting(const Worker: TFileViewWorker); override;
     procedure WorkerFinished(const Worker: TFileViewWorker); override;
 
+    procedure ShowRenameFileEditInitSelect(Data: PtrInt);
     procedure ShowRenameFileEdit(var AFile: TFile); virtual;
     procedure UpdateRenameFileEditPosition; virtual;
     procedure RenameSelectPart(AActionType:TRenameFileActionType); virtual;
@@ -1549,6 +1550,14 @@ begin
   if not (csDestroying in ComponentState) then UpdateInfoPanel;
 end;
 
+procedure TFileViewWithMainCtrl.ShowRenameFileEditInitSelect(Data: PtrInt);
+begin
+  if gRenameSelOnlyName and not (FRenameFile.IsDirectory or FRenameFile.IsLinkToDirectory) then
+     RenameSelectPart(rfatName)
+  else
+     RenameSelectPart(rfatFull);
+end;
+
 procedure TFileViewWithMainCtrl.ShowRenameFileEdit(var AFile: TFile);
 var
   S: String;
@@ -1610,11 +1619,8 @@ begin
     FRenFile.CylceFinished:= False; // cycle of selection Name-FullName-Ext of FullName-Name-Ext, after finish this cycle will be part selection mechanism
     if FRenFile.LenExt = 0 then FRenFile.CylceFinished:= True;  // don't need cycle if no extension
 
-    if gRenameSelOnlyName and not (AFile.IsDirectory or AFile.IsLinkToDirectory) then
-       RenameSelectPart(rfatName)
-    else begin
-       RenameSelectPart(rfatFull);
-    end;
+    Application.QueueAsyncCall(@ShowRenameFileEditInitSelect, 0);
+
     aFile:= nil;
   end;
 end;


### PR DESCRIPTION
1. when using F2-Rename in MacOS, RETURN KEY is incorrectly handled in IME input state. the intermediate typing text is returned as the result, then returns directly and incorrectly changes the filename.
2. the correct way is to receive IME text, and still in the Rename EditButton, just like other apps on MacOS and DC on Windows.
3. tested on MacOS and Windows.