### PR TITLE
FIX: F7-mkdir: VK_ESCAPE VK_RETURN in IME state

### DIFF
--- a/src/fmkdir.lfm
+++ b/src/fmkdir.lfm
@@ -13,7 +13,6 @@ object frmMkDir: TfrmMkDir
   Constraints.MinHeight = 50
   Constraints.MinWidth = 350
   KeyPreview = True
-  OnKeyPress = FormKeyPress
   Position = poOwnerFormCenter
   LCLVersion = '2.2.0.4'
   object lblMakeDir: TLabel

--- a/src/fmkdir.pas
+++ b/src/fmkdir.pas
@@ -20,7 +20,6 @@ type
     procedure cbExtendedChange(Sender: TObject);
     procedure cbMkDirChange(Sender: TObject);
     procedure cbMkDirKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
-    procedure FormKeyPress(Sender: TObject; var Key: Char);
     procedure RefreshExample;
   public
 
@@ -59,20 +58,6 @@ begin
       Break;
   end;
   Result := Result + sMask;
-end;
-
-procedure TfrmMkDir.FormKeyPress(Sender: TObject; var Key: Char);
-begin
-  if Key = #27 then
-  begin
-    ModalResult:= mrCancel;
-    Key := #0;
-  end
-  else if Key = #13 then
-  begin
-    ModalResult:= mrOK;
-    Key:= #0;
-  end;
 end;
 
 procedure TfrmMkDir.RefreshExample;


### PR DESCRIPTION
1. In Lazarus 2.2, it is no longer necessary to handle the Enter key in TForm.OnKeyPress
2. After removing the OnKeyPress code, the IME state can be handled correctly