### PR TITLE
FIX: DARWIN: aarch64: Mounted Driver <no label>

### DIFF
--- a/src/platform/udrivewatcher.pas
+++ b/src/platform/udrivewatcher.pas
@@ -58,6 +58,9 @@ uses
    {$IFDEF LINUX}
    , uUDisks, uUDev, uMountWatcher, DCStrUtils, uOSUtils, FileUtil, uGVolume, DCOSUtils
    {$ENDIF}
+   {$IFDEF DARWIN}
+   , uMyDarwin    // Workarounds for FPC RTL Bug
+   {$ENDIF}
   {$ENDIF}
   {$IFDEF MSWINDOWS}
   uMyWindows, Windows, JwaDbt, LazUTF8, JwaWinNetWk, ShlObj, DCOSUtils, uDebug,
@@ -79,6 +82,13 @@ type
 {$ENDIF}
 
 {$IFDEF BSD}
+// Workarounds for FPC RTL Bug
+{$IFDEF DARWIN}
+type TFixedStatfs = TDarwinStatfs;
+{$ELSE}
+type TFixedStatfs = TStatFs;
+{$ENDIF}
+
 const
   {$warning Remove this two constants when they are added to FreePascal}
   NOTE_MOUNTED = $0008;
@@ -1163,8 +1173,8 @@ const
 var
   drive: PDrive;
   fstab: PFSTab;
-  fs: TStatFS;
-  fsList: array[0..MAX_FS] of TStatFS;
+  fs: TFixedStatfs;
+  fsList: array[0..MAX_FS] of TFixedStatfs;
   iMounted, iAdded, count: Integer;
   found: boolean;
   dtype: TDriveType;

--- a/src/platform/unix/darwin/umydarwin.pas
+++ b/src/platform/unix/darwin/umydarwin.pas
@@ -28,7 +28,7 @@ unit uMyDarwin;
 interface
 
 uses
-  Classes, SysUtils, MacOSAll, CocoaAll, CocoaUtils, CocoaInt, InterfaceBase, Menus, CocoaWSMenus;
+  Classes, SysUtils, UnixType, MacOSAll, CocoaAll, CocoaUtils, CocoaInt, InterfaceBase, Menus, CocoaWSMenus;
 
 // Darwin Util Function
 function StringToNSString(const S: String): NSString;
@@ -42,6 +42,40 @@ function NSGetFolderPath(Folder: NSSearchPathDirectory): String;
 
 function GetFileDescription(const FileName: String): String;
 function MountNetworkDrive(const serverAddress: String): Boolean;
+
+// Workarounds for FPC RTL Bug
+// copied from ptypes.inc and modified fstypename only
+{$if defined(cpuarm) or defined(cpuaarch64) or defined(iphonesim)}
+     { structure used on iPhoneOS and available on Mac OS X 10.6 and later }
+
+const MFSTYPENAMELEN = 16;
+
+type TDarwinAarch64Statfs = record
+          bsize : cuint32;
+          iosize : cint32;
+          blocks : cuint64;
+          bfree : cuint64;
+          bavail : cuint64;
+          files : cuint64;
+          ffree : cuint64;
+          fsid : fsid_t;
+          owner : uid_t;
+          ftype : cuint32;
+          fflags : cuint32;
+          fssubtype : cuint32;
+          fstypename : array[0..(MFSTYPENAMELEN)-1] of char;
+          mountpoint : array[0..(PATH_MAX)-1] of char;
+          mntfromname : array[0..(PATH_MAX)-1] of char;
+          reserved: array[0..7] of cuint32;
+     end;
+
+type TDarwinStatfs = TDarwinAarch64Statfs;
+
+{$else}
+
+type TDarwinStatfs = TStatFs;
+
+{$endif}
 
 // MacOS Service Integration
 type TNSServiceProviderCallBack = Procedure( filenames:TStringList ) of object;


### PR DESCRIPTION
FIX: DARWIN: aarch64: get mounted driver infomation error.

cause by TStatFS bug of FPC RTL ([issue #39873](https://gitlab.com/freepascal.org/fpc/source/-/issues/39873))