### PR TITLE
FIX: COCOA: F2-Rename EditButton: VK_ESCAPE handler in IME state

### DIFF
--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -1473,7 +1473,10 @@ end;
 procedure TFileViewWithMainCtrl.edtRenameKeyDown(Sender: TObject;
   var Key: Word; Shift: TShiftState);
 begin
-  if key=VK_RETURN then keyDownText:= originalText;
+  if key=VK_RETURN then
+    keyDownText:= originalText
+  else if key=VK_ESCAPE then
+    keyDownText:= edtRename.Text;
 end;
 
 procedure TFileViewWithMainCtrl.edtRenameOnChange(Sender: TObject);
@@ -1487,7 +1490,7 @@ var
   currentText: String;
 begin
   currentText:= edtRename.Text;
-  if Key=VK_RETURN then
+  if (Key=VK_RETURN) or (key=VK_ESCAPE) then
   begin
       if currentText<>keyDownText then
       begin


### PR DESCRIPTION
1. when using F2-Rename in MacOS, ESCAPE KEY is incorrectly handled in IME input state, EditBuuton will be completely canceled.
2. the correct way is to ignore IME intermediate typing text only, and still in the Rename EditButton, just like other apps on MacOS and DC on Windows.
3. tested on MacOS and Windows.