### PR TITLE
FIX: DARWIN: set MACOSX_DEPLOYMENT_TARGET to 11.0 on aarch64 CPU_TARGET

### DIFF
--- a/install/create_packages.mac
+++ b/install/create_packages.mac
@@ -25,13 +25,21 @@ if [ -z $CPU_TARGET ]; then
   export CPU_TARGET=$(fpc -iTP)
 fi
 
+export CPU_TARGET=`echo $CPU_TARGET|tr '[:upper:]' '[:lower:]'`
+
 # Set widgetset
 if [ -z $lcl ]; then
   export lcl=cocoa
 fi
 
 # Set minimal Mac OS X target version
-export MACOSX_DEPLOYMENT_TARGET=10.5
+if [ -z $MACOSX_DEPLOYMENT_TARGET ]; then
+  if [ $CPU_TARGET = "aarch64" ]; then
+    export MACOSX_DEPLOYMENT_TARGET=11.0
+  else
+    export MACOSX_DEPLOYMENT_TARGET=10.5
+  fi
+fi
 
 # Copy libraries
 cp -a darwin/lib/$CPU_TARGET/*.dylib         $BUILD_DC_TMP_DIR/


### PR DESCRIPTION
the earliest version of MacOS that supports aarch64 (M1) is 11.0
set MACOSX_DEPLOYMENT_TARGET to 11.0 when create aarch64 package.
and keep 10.5 when create x86_64 package.