### PR TITLE
UPD: PathLabel: add highlight calling in MouseEnter

### DIFF
--- a/src/upathlabel.pas
+++ b/src/upathlabel.pas
@@ -249,6 +249,8 @@ begin
   if FAllowHighlight then
   begin
     Cursor := crDefault;
+    FMousePos := ScreenToClient(Mouse.CursorPos).X;
+    Highlight;
     Invalidate;
   end;
 end;


### PR DESCRIPTION
1. in PathLabel, the current version only highlights the path selected in the MouseOver Event.
2. when the mouse first enters the PathLabel, it may only trigger the MouseEnter Event, resulting in missing highlighting.
3. fix the problem by adding highlight related codes in MouseEnter Event.
4. tested on MacOS and Windows.