### PR TITLE
FIX: COCOA: garbled when editing in FileViewHeader

### DIFF
--- a/src/fileviews/ufileviewheader.pas
+++ b/src/fileviews/ufileviewheader.pas
@@ -274,6 +274,7 @@ begin
   FPathEdit.Parent:= Self;
   FPathEdit.Visible:= False;
   FPathEdit.TabStop:= False;
+  FPathEdit.BorderStyle:= bsNone;
   FPathEdit.ObjectTypes:= [otFolders, otHidden];
 
   OnResize:= @HeaderResize;


### PR DESCRIPTION
FIX: garbled when editing in FileViewHeader:
1. this problem only occurs on MacOS and dark mode
2. in dark mode, the TEdit with border becomes transparent, and the PathEdit fails to cover the PathLabel
3. set PathEdit to opaque by BorderStyle:=bsNone
4. tested on MacOS 12 and Windows 11