### PR TITLE
FIX: FindDlg: the buttons are not shown

### DIFF
--- a/src/fFindDlg.lfm
+++ b/src/fFindDlg.lfm
@@ -3,6 +3,7 @@ object frmFindDlg: TfrmFindDlg
   Height = 469
   Top = 176
   Width = 875
+  AutoSize = True
   Caption = 'Find files'
   ClientHeight = 449
   ClientWidth = 875


### PR DESCRIPTION
FIX: FindDlg: the buttons are not shown because the height of the FindDlg Form is insufficient after upgrading to LCL2.2.4
1. after many tests, it was found that the problem was caused by the upgrade of this LCL commit (at 2022.5.17): https://gitlab.com/freepascal.org/lazarus/lazarus/-/commit/64bc8e992e3be1acc1104d406a4f0633516490fa
2. once we have found the cause, simply set the FindDlg's `AutoSize:=true` to fix the issue
3. works well in every situation, including resizing the FindDlg Form
3. tested on MacOS 12 and Windows 11