### PR TITLE
FIX: TFileViewNotebook.DestroyAllPages: algorithm of tabs.clear()

### DIFF
--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -540,7 +540,7 @@ var
   i: Integer;
 begin
   for i:=PageCount-1 downto 0 do
-    if i<>ActivePageIndex then RemovePage( i );
+    if i<>ActivePageIndex then inherited RemovePage( i );
   RemovePage( 0 );
 end;
 

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -107,7 +107,6 @@ type
 
   TFileViewNotebook = class(TPageControl)
   private
-    FCanChangePageIndex: Boolean;
     FNotebookSide: TFilePanelSelect;
     FStartDrag: Boolean;
     FDraggedPageIndex: Integer;
@@ -141,7 +140,6 @@ type
     procedure WndProc(var Message: TLMessage); override;
 {$ENDIF}
     function AddPage: TFileViewPage;
-    function CanChangePageIndex: Boolean; override;
     function InsertPage(Index: Integer): TFileViewPage; reintroduce;
     function NewEmptyPage: TFileViewPage;
     function NewPage(CloneFromPage: TFileViewPage): TFileViewPage;
@@ -409,7 +407,6 @@ begin
   ShowHint := True;
 
   FHintPageIndex := -1;
-  FCanChangePageIndex := True;
   FNotebookSide := NotebookSide;
   FStartDrag := False;
 
@@ -458,11 +455,6 @@ end;
 function TFileViewNotebook.AddPage: TFileViewPage;
 begin
   Result := InsertPage(PageCount);
-end;
-
-function TFileViewNotebook.CanChangePageIndex: Boolean;
-begin
-  Result:= (inherited CanChangePageIndex) and FCanChangePageIndex;
 end;
 
 function TFileViewNotebook.InsertPage(Index: Integer): TFileViewPage;

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -544,10 +544,12 @@ begin
 end;
 
 procedure TFileViewNotebook.DestroyAllPages;
+var
+  i: Integer;
 begin
-  FCanChangePageIndex:= False;
-  Tabs.Clear;
-  FCanChangePageIndex:= True;
+  for i:=PageCount-1 downto 0 do
+    if i<>ActivePageIndex then RemovePage( i );
+  RemovePage( 0 );
 end;
 
 procedure TFileViewNotebook.ActivatePrevTab;

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -541,7 +541,7 @@ var
 begin
   for i:=PageCount-1 downto 0 do
     if i<>ActivePageIndex then inherited RemovePage( i );
-  RemovePage( 0 );
+  inherited RemovePage( 0 );
 end;
 
 procedure TFileViewNotebook.ActivatePrevTab;


### PR DESCRIPTION
FIX: TFileViewNotebook.DestroyAllPages: algorithm of clear tabs

when switching Favorites, a large number of Tabs that will be removed are activated unnecessarily.
this is because in `TFileViewNotebook.DestroyAllPages()` call `Tabs.Clear()`. the Clear() algorithm will cause the next Tab to be activated time by time after removing the currently active Tab. even FCanChangePageIndex:=False doesn't work.

In some cases, it will cause LCL control exception. for example, in `Thumbnails View` mode, in the Destroy process, because the Tab is reactivated, MakeFileSourceFileList() is restarted, and then TFunctionThread is restarted to update data in the background. at this time, the LCL control has been destroyed, thus exception thrown.

it exists at least in Cocoa, because NSTabView cannot be in the state of missing active tab, otherwise an exception will be thrown.

it was fixed by fine-tuning the algorithm in DestroyAllPages(). remove the Tab in the same reverse order, but skip the active tab, and remove the active tab at the end, to avoid activating other tabs in DestroyAllPages().

after the patch, the exception has been fixed. and the speed of switching Favorites has been visibly improved because it avoids activating the Tabs to be removed. 

tested on MacOS 12 and Windows 11.