### PR TITLE
FIX: QuickView: Not exiting PluginMode when receiving empty string in TfrmViewer.LoadFile()

### DIFF
--- a/src/fviewer.pas
+++ b/src/fviewer.pas
@@ -696,6 +696,7 @@ begin
   if dwFileAttributes = faInvalidAttributes then
   begin
     ActivatePanel(pnlFolder);
+    ExitPluginMode;
     memFolder.Font.Color:= clRed;
     memFolder.Lines.Text:= rsMsgErrNoFiles;
     Exit;


### PR DESCRIPTION
Not exiting PluginMode when receiving empty string in TfrmViewer.LoadFile().
will cause multiple Plugins content to be overlaped.

```pascal
procedure TfrmViewer.LoadFile(const aFileName: String);
......
  if dwFileAttributes = faInvalidAttributes then
  begin
    ActivatePanel(pnlFolder);
    ExitPluginMode;  // missed before
    ----------------
    memFolder.Font.Color:= clRed;
    memFolder.Lines.Text:= rsMsgErrNoFiles;
    Exit;
  end;


procedure TQuickViewPanel.FileViewChangeActiveFile(Sender: TFileView; const aFile: TFile);
......
  except
    on E: EAbort do
    begin
      FViewer.Hide;
      FFirstFile:= True;
      Caption:= E.Message;
      FViewer.LoadFile(EmptyStr);
      ---------------------------
    end;
  end;
```