### PR TITLE
ADD: show link targets in status bar

### DIFF
--- a/src/fileviews/ucolumnsfileview.pas
+++ b/src/fileviews/ucolumnsfileview.pas
@@ -745,10 +745,13 @@ begin
     if Assigned(AFile) then
       try
         if AFile.IsNameValid then begin
-          if gDirBrackets and (AFile.IsDirectory or AFile.IsLinkToDirectory) then 
-            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix
-          else 
-            lblInfo.Caption := AFile.Name;
+          lblInfo.Caption := AFile.Name;  
+          if gDirBrackets and AFile.IsDirectory then 
+            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix;
+          if AFile.IsLink then 
+            lblInfo.Caption := AFile.Name + ' -> ' + AFile.LinkProperty.LinkTo;
+          if gDirBrackets and AFile.IsLinkToDirectory then 
+            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix + ' -> ' + gFolderPrefix + AFile.LinkProperty.LinkTo + gFolderPostfix;
         end                       
         else 
          if not AInfo then begin

--- a/src/fileviews/ucolumnsfileview.pas
+++ b/src/fileviews/ucolumnsfileview.pas
@@ -738,6 +738,7 @@ end;
 procedure TColumnsFileView.UpdateFooterDetails(AInfo: Boolean);
 var
   AFile: TFile;
+  AText: String;
 begin
   if gColumnsLongInStatus and (FSelectedCount = 0) and (not FlatView) then
   begin
@@ -746,14 +747,25 @@ begin
       try
         if AFile.IsNameValid then begin
           if gDirBrackets and AFile.IsLinkToDirectory then
-            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix + ' -> ' + gFolderPrefix + AFile.LinkProperty.LinkTo + gFolderPostfix
-          else if AFile.IsLink then
-            lblInfo.Caption := AFile.Name + ' -> ' + AFile.LinkProperty.LinkTo
-          else if gDirBrackets and AFile.IsDirectory then
-            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix
-          else begin
-            lblInfo.Caption := AFile.Name;
-          end;
+            begin
+              AText := gFolderPrefix + AFile.Name + gFolderPostfix;
+              if Assigned(AFile.LinkProperty) then begin
+                AText += ' -> ' + gFolderPrefix + AFile.LinkProperty.LinkTo + gFolderPostfix;
+              end;
+            end
+            else if AFile.IsLink then
+            begin
+              AText := AFile.Name;
+              if Assigned(AFile.LinkProperty) then begin
+                AText += ' -> ' + AFile.LinkProperty.LinkTo;
+              end;
+            end
+            else if gDirBrackets and AFile.IsDirectory then
+              AText := gFolderPrefix + AFile.Name + gFolderPostfix
+            else begin
+              AText := AFile.Name;
+            end;
+            lblInfo.Caption := AText;
         end                       
         else 
          if not AInfo then begin

--- a/src/fileviews/ucolumnsfileview.pas
+++ b/src/fileviews/ucolumnsfileview.pas
@@ -745,13 +745,15 @@ begin
     if Assigned(AFile) then
       try
         if AFile.IsNameValid then begin
-          lblInfo.Caption := AFile.Name;  
-          if gDirBrackets and AFile.IsDirectory then 
-            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix;
-          if AFile.IsLink then 
-            lblInfo.Caption := AFile.Name + ' -> ' + AFile.LinkProperty.LinkTo;
-          if gDirBrackets and AFile.IsLinkToDirectory then 
-            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix + ' -> ' + gFolderPrefix + AFile.LinkProperty.LinkTo + gFolderPostfix;
+          if gDirBrackets and AFile.IsLinkToDirectory then
+            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix + ' -> ' + gFolderPrefix + AFile.LinkProperty.LinkTo + gFolderPostfix
+          else if AFile.IsLink then
+            lblInfo.Caption := AFile.Name + ' -> ' + AFile.LinkProperty.LinkTo
+          else if gDirBrackets and AFile.IsDirectory then
+            lblInfo.Caption := gFolderPrefix + AFile.Name + gFolderPostfix
+          else begin
+            lblInfo.Caption := AFile.Name;
+          end;
         end                       
         else 
          if not AInfo then begin


### PR DESCRIPTION
Useful at times. Without it, the only way I found to see where symlink is pointing is to go open its properties. 