### PR TITLE
ADD: DARWIN: new FileSystemType 'lifs' supported in MacOS 13 (FIX:#651)

### DIFF
--- a/src/platform/udrivewatcher.pas
+++ b/src/platform/udrivewatcher.pas
@@ -1108,6 +1108,8 @@ end;
       Result := dtHardDisk
     else if FSType = 'exfat' then
       Result := dtHardDisk
+    else if FSType = 'lifs' then
+      Result := dtHardDisk
     else if FSType = 'ufsd_NTFS' then
       Result := dtHardDisk
     else if FSType = 'tuxera_ntfs' then


### PR DESCRIPTION
ADD: DARWIN: new FileSystemType 'lifs' supported in MacOS 13

FIX:#651 External USB flash drive not shown in drives list