### PR TITLE
FIX: DARWIN: unmount driver compatible with MacOS 13

### DIFF
--- a/src/platform/unix/umyunix.pas
+++ b/src/platform/unix/umyunix.pas
@@ -539,7 +539,7 @@ begin
       Result := fpSystemStatus('pumount ' + Drive^.DeviceId) = 0;
     if not Result then
 {$ELSEIF DEFINED(DARWIN)}
-    Result := fpSystemStatus('diskutil unmount ' + Drive^.DeviceId) = 0;
+    Result := fpSystemStatus('diskutil unmount ' + Drive^.Path) = 0;
     if not Result then
 {$ENDIF}
     Result := fpSystemStatus('umount ' + Drive^.Path) = 0;


### PR DESCRIPTION
unmount driver by TDrive.path to compatible with MacOS 13 (TDrive.DeviceId changed)
