### PR TITLE
FIX: FileView: missing call to TOrderedFileView.OnChangeActiveFille()

### DIFF
--- a/src/fileviews/uorderedfileview.pas
+++ b/src/fileviews/uorderedfileview.pas
@@ -885,6 +885,8 @@ begin
       if Result then
       begin
           SetUpdate(Index);
+          if Assigned(OnChangeActiveFile) then
+            OnChangeActiveFile(Self, FFiles[Index].FSFile);
           Exit(True);
       end;
     end;


### PR DESCRIPTION
there is a problem when `F2 Rename` in the `Quick View` state, the Viewer is set to "..".
it's because in TOrderedFileView.SetActiveFileNow(), TOrderedFileView.OnChangeActiveFille() is missed, when F2 Rename and the Index value of the file is not changed.