### PR TITLE
FIX: MacOS: color not updated in FileView after theme changed

### DIFF
--- a/src/fileviews/ufileview.pas
+++ b/src/fileviews/ufileview.pas
@@ -440,6 +440,8 @@ type
 
     procedure UpdateView;
 
+    procedure UpdateColor; virtual; abstract;
+
     {en
        Moves the selection focus to the file specified by aFilePath.
        @param(aFilePath may be an absolute path to the file or just a file name.)

--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -221,6 +221,8 @@ type
     procedure SetFocus; override;
     procedure SetDragCursor(Shift: TShiftState); override;
 
+    procedure UpdateColor; override;
+
   published
     procedure cm_RenameOnly(const Params: array of string);
     procedure cm_ContextMenu(const Params: array of string);
@@ -494,7 +496,7 @@ end;
 procedure TFileViewWithMainCtrl.DoActiveChanged;
 begin
   inherited DoActiveChanged;
-  MainControl.Color := DimColor(gBackColor);
+  UpdateColor;
   // Needed for rename on mouse
   FMouseRename := False;
 end;
@@ -577,13 +579,18 @@ end;
 
 procedure TFileViewWithMainCtrl.DoLoadingFileListLongTime;
 begin
-  MainControl.Color := DimColor(gBackColor);
+  UpdateColor;
   inherited DoLoadingFileListLongTime;
 end;
 
 procedure TFileViewWithMainCtrl.DoUpdateView;
 begin
   inherited DoUpdateView;
+  UpdateColor;
+end;
+
+procedure TFileViewWithMainCtrl.UpdateColor;
+begin
   MainControl.Color := DimColor(gBackColor);
 end;
 

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -874,6 +874,7 @@ type
     procedure OnNSServiceOpenWithNewTab( filenames:TStringList );
     function NSServiceMenuIsReady(): boolean;
     function NSServiceMenuGetFilenames(): TStringList;
+    procedure NSThemeChangedHandler();
     {$ENDIF}
     procedure LoadWindowState;
     procedure SaveWindowState;
@@ -1216,6 +1217,7 @@ begin
 
 {$IF DEFINED(DARWIN)}
   InitNSServiceProvider( @OnNSServiceOpenWithNewTab, @NSServiceMenuIsReady, @NSServiceMenuGetFilenames );
+  InitNSThemeChangedObserver( @NSThemeChangedHandler );
 {$ENDIF}
 end;
 
@@ -6124,6 +6126,12 @@ begin
   end;
 
   if filenames.Count>0 then Result:= filenames;
+end;
+
+procedure TfrmMain.NSThemeChangedHandler;
+begin
+  FrameLeft.UpdateColor;
+  FrameRight.UpdateColor;
 end;
 {$ENDIF}
 


### PR DESCRIPTION
on MacOS, background color not updated in FileView after theme changed.
fixed by monitoring Theme is changed and updating MainControl.Color.
tested on MacOS 12 and Windows 11.

<img width="940" alt="image" src="https://user-images.githubusercontent.com/102933068/205942576-74ad2d84-69be-4441-9e06-ca83df19cd0c.png">

<img width="922" alt="image" src="https://user-images.githubusercontent.com/102933068/205942926-da1f2889-c8e4-4d7e-94d3-7a7e7aa55bd8.png">
 