### PR TITLE
UPD: Use TFileViewNotebook.Clear() instead of DestroyAllPages()

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -5137,7 +5137,7 @@ begin
       begin
         if (DestinationToKeep<>tclLeft) AND (DestinationToKeep<>tclBoth) AND (not(tfadLeft in TabsAlreadyDestroyedFlags)) then
         begin
-          frmMain.LeftTabs.DestroyAllPages;
+          frmMain.LeftTabs.Clear;
           TabsAlreadyDestroyedFlags := TabsAlreadyDestroyedFlags + [tfadLeft]; // To don't delete it twice in case both target are left.
         end;
       end;
@@ -5151,7 +5151,7 @@ begin
       begin
         if (DestinationToKeep<>tclRight) AND (DestinationToKeep<>tclBoth) AND (not(tfadRight in TabsAlreadyDestroyedFlags)) then
           begin
-            frmMain.RightTabs.DestroyAllPages;
+            frmMain.RightTabs.Clear;
             TabsAlreadyDestroyedFlags := TabsAlreadyDestroyedFlags + [tfadRight]; // To don't delete it twice in case both target are right.
           end;
         LoadTabsXml(Config, ABranch + sSourceSectionName, RightTabs);
@@ -6748,7 +6748,7 @@ var
 begin
   for I := 0 to ANotebook.PageCount - 1 do
     ANotebook.View[I].Clear;
-  ANotebook.DestroyAllPages;
+  ANotebook.Clear;
 end;
 
 procedure TfrmMain.DriveListDriveSelected(Sender: TObject; ADriveIndex: Integer;

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -146,7 +146,6 @@ type
     function NewPage(CloneFromView: TFileView): TFileViewPage;
     procedure RemovePage(Index: Integer); reintroduce;
     procedure RemovePage(var aPage: TFileViewPage);
-    procedure DestroyAllPages;
     procedure ActivatePrevTab;
     procedure ActivateNextTab;
     procedure ActivateTabByIndex(Index: Integer);
@@ -533,15 +532,6 @@ begin
   // because later background will be again be erased but with TControl.Brush.
   // This is not actually needed on non-Windows because WMEraseBkgnd is not used there.
   Message.Result := 1;
-end;
-
-procedure TFileViewNotebook.DestroyAllPages;
-var
-  i: Integer;
-begin
-  for i:=PageCount-1 downto 0 do
-    if i<>ActivePageIndex then inherited RemovePage( i );
-  inherited RemovePage( 0 );
 end;
 
 procedure TFileViewNotebook.ActivatePrevTab;


### PR DESCRIPTION
the MR about TPageControl.Clear() had been merged in Lazarus Main branch.
https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/40019

we can remove TFileViewNotebook.DestroyAllPages() and use Clear() in LCL instead.
