### PR TITLE
FIX #621: FindDlg: buttons not shown

### DIFF
--- a/src/fFindDlg.lfm
+++ b/src/fFindDlg.lfm
@@ -3,7 +3,6 @@ object frmFindDlg: TfrmFindDlg
   Height = 469
   Top = 176
   Width = 875
-  AutoSize = True
   Caption = 'Find files'
   ClientHeight = 449
   ClientWidth = 875
@@ -1399,7 +1398,6 @@ object frmFindDlg: TfrmFindDlg
       Width = 103
       Align = alRight
       Anchors = [akTop, akRight]
-      AutoSize = True
       BorderSpacing.Left = 6
       BorderSpacing.Top = 40
       BevelOuter = bvNone

--- a/src/fFindDlg.lfm
+++ b/src/fFindDlg.lfm
@@ -1398,6 +1398,7 @@ object frmFindDlg: TfrmFindDlg
       Width = 103
       Align = alRight
       Anchors = [akTop, akRight]
+      AutoSize = True
       BorderSpacing.Left = 6
       BorderSpacing.Top = 40
       BevelOuter = bvNone

--- a/src/fFindDlg.pas
+++ b/src/fFindDlg.pas
@@ -2206,6 +2206,10 @@ end;
 { TfrmFindDlg.FormShow }
 procedure TfrmFindDlg.frmFindDlgShow(Sender: TObject);
 begin
+  {$IFDEF LCLCOCOA}
+  pgcSearch.DoAdjustClientRectChange();
+  {$ENDIF}
+
   pgcSearch.PageIndex := 0;
 
   if cmbFindFileMask.Visible then

--- a/src/fFindDlg.pas
+++ b/src/fFindDlg.pas
@@ -2206,7 +2206,6 @@ end;
 { TfrmFindDlg.FormShow }
 procedure TfrmFindDlg.frmFindDlgShow(Sender: TObject);
 begin
-  AutoSize:=false;
   pgcSearch.PageIndex := 0;
 
   if cmbFindFileMask.Visible then


### PR DESCRIPTION
FIX #621 : FindDlg: buttons not shown:
1. the Caption of the buttons in `pnlButtons` are too long to accurately calculate the height of `pnlButtons`
2. the height of TabSheets affected by pnlButtons, and are increased by 30 points incorrectly
3. therefore the buttons in TabSheets align to bottom are not visible
4. fix the issue by canceling `autosize` of pnlButtons

tested on MacOS 12 and Windows 11