### PR TITLE
FIX #699: COCOA: cursor in MainControl(Grid) may be always in waiting state

### DIFF
--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -36,7 +36,11 @@ uses
   uFileView,
   uDragDropEx,
   uFileViewNotebook,
-  uDebug;
+  uDebug
+{$IFDEF LCLCOCOA}
+  ,uMyDarwin
+{$ENDIF}
+  ;
 
 type
 
@@ -1630,6 +1634,9 @@ procedure TFileViewWithMainCtrl.WorkerFinished(const Worker: TFileViewWorker);
 begin
   inherited WorkerFinished(Worker);
   MainControl.Cursor := crDefault;
+  {$IFDEF LCLCOCOA}
+  cocoaInvalidControlCursor( MainControl );
+  {$ENDIF}
   // Update status line only
   if not (csDestroying in ComponentState) then UpdateInfoPanel;
 end;
@@ -1798,6 +1805,9 @@ procedure TFileViewWithMainCtrl.WorkerStarting(const Worker: TFileViewWorker);
 begin
   inherited WorkerStarting(Worker);
   MainControl.Cursor := crHourGlass;
+  {$IFDEF LCLCOCOA}
+  cocoaInvalidControlCursor( MainControl );
+  {$ENDIF}
   UpdateInfoPanel; // Update status line only
 end;
 

--- a/src/platform/unix/darwin/umydarwin.pas
+++ b/src/platform/unix/darwin/umydarwin.pas
@@ -28,13 +28,18 @@ unit uMyDarwin;
 interface
 
 uses
-  Classes, SysUtils, UnixType, MacOSAll, CocoaAll, CocoaUtils, CocoaInt, Cocoa_Extra, InterfaceBase, Menus, CocoaWSMenus;
+  Classes, SysUtils, UnixType,
+  InterfaceBase, Controls, Menus,
+  MacOSAll, CocoaAll, CocoaPrivate, CocoaInt,
+  Cocoa_Extra, CocoaWSMenus, CocoaUtils;
 
 // Darwin Util Function
 function StringToNSString(const S: String): NSString;
 function StringToCFStringRef(const S: String): CFStringRef;
 function NSArrayToList(const theArray:NSArray): TStringList;
 function ListToNSArray(const list:TStrings): NSArray;
+
+procedure cocoaInvalidControlCursor( const control:TWinControl );
 
 function NSGetTempPath: String;
 
@@ -325,6 +330,19 @@ begin
   end;
   CFRelease(FileNameRef);
 end;
+
+
+procedure cocoaInvalidControlCursor( const control:TWinControl );
+var
+  view: NSView;
+begin
+  if control.HandleAllocated then
+  begin
+    view:= NSObject(control.Handle).lclContentView;
+    view.window.invalidateCursorRectsForView( view );
+  end;
+end;
+
 
 var
   NetFS: TLibHandle = NilHandle;


### PR DESCRIPTION
FIX #699: cursor in MainControl(Grid) may be always in waiting state
1. Cocoa Interface doesn't fully support Cursors, especially for Control-level Cursor.
2. the patch can basically meet DC's needs for Cursor, and will submit patches to Lazarus to fully support more complex needs.
