### PR TITLE
FIX: DARWIN: Cursor not reset in Reactive Application on MacOS 13 again (#733)

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -6985,8 +6985,7 @@ end;
 procedure TfrmMain.AppActivate(Sender: TObject);
 begin
   {$IFDEF DARWIN}
-  if self.Active then
-    resetScreenCursor;
+  resetScreenCursor;
   {$ENDIF}
 
   if Assigned(FrameLeft) then


### PR DESCRIPTION
FIX #733 again: DARWIN: Cursor not reset in Reactive Application on MacOS 13