### PR TITLE
FIX: the order of closing FileView and closing QuickView

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -2580,9 +2580,7 @@ begin
     end;
   end;
 
-  if Assigned(QuickViewPanel) then
-    Commands.cm_QuickView(['Close']);
-
+  QuickViewClose;
   UpdatePrompt;
   UpdateTreeViewPath;
   UpdateMainTitleBar;
@@ -4974,7 +4972,7 @@ begin
        else
          Exit(1);
     end;
-    if Assigned(QuickViewPanel) then QuickViewClose;
+    QuickViewClose;
     ANoteBook.RemovePage(iPageIndex);
 
     if UserAnswer=mmrAll then Result:=3 else Result:= 0;
@@ -5128,6 +5126,8 @@ var
 begin
   if Destination<>tclNone then
   begin
+    QuickViewClose;
+
     // 1. Normalize our destination side and destination to keep in case params specified active/inactive
     if ((Destination=tclActive) and (ActiveFrame=FrameLeft)) OR ((Destination=tclInactive) and (NotActiveFrame=FrameLeft)) then Destination:=tclLeft;
     if ((Destination=tclActive) and (ActiveFrame=FrameRight)) OR ((Destination=tclInactive) and (NotActiveFrame=FrameRight)) then Destination:=tclRight;

--- a/src/uquickviewpanel.pas
+++ b/src/uquickviewpanel.pas
@@ -83,8 +83,11 @@ end;
 
 procedure QuickViewClose;
 begin
-  FreeAndNil(QuickViewPanel);
-  frmMain.actQuickView.Checked:= False;
+  if Assigned(QuickViewPanel) then
+  begin
+    FreeAndNil(QuickViewPanel);
+    frmMain.actQuickView.Checked:= False;
+  end;
 end;
 
 { TQuickViewPanel }


### PR DESCRIPTION
in the QuickView state, switching Favorites Tabs causes an exception.

it's because the FileView has been released before `TfrmMain.nbPageChanged()`.

this problem exists in all OS/Interface.

```
| DC v1.1.0 alpha Rev. 10529 -- aarch64-Darwin-cocoa
| Mac OS X 12.6.2 | PID 2598
Unhandled exception: EAccessViolation: Access violation
  Stack trace:
  $0000000101530174 line 1384, column 6 of fileviews/ufileviewwithmainctrl.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100EC1BF8 in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100F43A54 in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001015F12E4 line 86, column 3 of uquickviewpanel.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001015138D8 line 2065, column 9 of umaincommands.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100F881B4 line 2584, column 28 of fmain.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100F91680 line 5084, column 9 of fmain.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100F91BD4 line 5155, column 55 of fmain.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000101351464 line 601, column 13 of ufavoritetabs.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $000000010151EFF8 line 4935, column 9 of umaincommands.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001010F739C line 83, column 5 of include/menuitem.inc in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001010F7D34 line 296, column 5 of include/menuitem.inc in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $0000000100EC252C in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $000000010126EE00 line 114, column 35 of lclmessageglue.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001011F0138 line 292, column 48 of cocoa/cocoawsmenus.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001011F07FC line 405, column 3 of cocoa/cocoawsmenus.pas in /Applications/（10529）Double Commander.app/Contents/MacOS/doublecmd
  $00000001AB28E5C8 in /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
```