### PR TITLE
FIX: issues about Terminal

### DIFF
--- a/src/platform/unix/darwin/umydarwin.pas
+++ b/src/platform/unix/darwin/umydarwin.pas
@@ -44,6 +44,8 @@ function StringToCFStringRef(const S: String): CFStringRef;
 function NSArrayToList(const theArray:NSArray): TStringList;
 function ListToNSArray(const list:TStrings): NSArray;
 
+function getMacOSDefaultTerminal(): String;
+
 procedure cocoaInvalidControlCursor( const control:TWinControl );
 
 function NSGetTempPath: String;
@@ -294,6 +296,11 @@ end;
 function NSGetTempPath: String;
 begin
   Result:= IncludeTrailingBackslash(NSTemporaryDirectory.UTF8String);
+end;
+
+function getMacOSDefaultTerminal(): String;
+begin
+  Result:= NSStringToString( NSWorkspace.sharedWorkspace.fullPathForApplication( NSStr('terminal') ) );
 end;
 
 function StringToNSString(const S: String): NSString;

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -761,6 +761,9 @@ uses
    {$IF DEFINED(MSWINDOWS)}
     , ShlObj
    {$ENDIF}
+   {$IF DEFINED(DARWIN)}
+    , uMyDarwin
+   {$ENDIF}
    {$if lcl_fullversion >= 2010000}
    , SynEditMiscClasses
    {$endif}
@@ -2623,14 +2626,21 @@ begin
 
       // Let's try to be backward comptible and re-load possible old values for terminal launch command
       gRunTermCmd := GetValue(Node, 'JustRunTerminal', '');
-      if gRunTermCmd = '' then
-      begin
-        gRunTermCmd := GetValue(Node, 'RunTerminal', RunTermCmd);
-        SplitCmdLineToCmdParams(gRunTermCmd, gRunTermCmd,gRunTermParams);
-      end
-      else
-      begin
+      if gRunTermCmd <> '' then begin
         gRunTermParams := GetValue(Node, 'JustRunTermParams', RunTermParams);
+      end else begin
+        gRunTermCmd := GetValue(Node, 'RunTerminal', '' );
+        if gRunTermCmd <> '' then begin
+          SplitCmdLineToCmdParams(gRunTermCmd, gRunTermCmd, gRunTermParams);
+        end else begin
+          {$IF DEFINED(DARWIN)}
+          gRunTermCmd:= getMacOSDefaultTerminal;
+          if gRunTermCmd = '' then gRunTermCmd := RunTermCmd;
+          {$ELSE}
+          gRunTermCmd := RunTermCmd;
+          {$ENDIF}
+          gRunTermParams := RunTermParams;
+        end;
       end;
 
       gOnlyOneAppInstance := GetValue(Node, 'OnlyOneAppInstance', gOnlyOneAppInstance);


### PR DESCRIPTION
two issues about Termianl fixed:
1. fixed Terminal.app default location by `NSWorkspace.sharedWorkspace.fullPathForApplication` on MacOS
2. fixed the bug about RunTermParams when `JustRunTerminal` and `RunTerminal` are both missing. 

PS. #377 should be closed.