### PR TITLE
UPD: Improve directories display in QuickView

### DIFF
--- a/src/uquickviewpanel.pas
+++ b/src/uquickviewpanel.pas
@@ -42,11 +42,14 @@ type
     FViewer: TfrmViewer;
     FFileName: String;
   private
-    procedure RaiseExit;
     procedure LoadFile(const aFileName: String);
     procedure OnChangeFileView(Sender: TObject);
     procedure CreateViewer(aFileView: TFileView);
     procedure FileViewChangeActiveFile(Sender: TFileView; const aFile : TFile);
+
+    function handleLinksToLocal( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
+    function handleNotDirect( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
+    function handleDirect( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
   protected
      procedure DoOnShowHint(HintInfo: PHintInfo) override;
   public
@@ -134,11 +137,6 @@ begin
   TFileViewPage(FFileView.NotebookPage).OnChangeFileView:= @OnChangeFileView;
 end;
 
-procedure TQuickViewPanel.RaiseExit;
-begin
-  raise EAbort.Create(rsSimpleWordFailedExcla);
-end;
-
 procedure TQuickViewPanel.LoadFile(const aFileName: String);
 begin
   if (not FFirstFile) then
@@ -163,78 +161,129 @@ end;
 
 procedure TQuickViewPanel.FileViewChangeActiveFile(Sender: TFileView; const aFile: TFile);
 var
+  fullPath: String;
+  showMsg: String;
+begin
+  fullPath:= EmptyStr;
+  showMsg:= EmptyStr;
+  try
+    if not Assigned(aFile) then
+      raise EAbort.Create(rsMsgErrNotSupported);
+
+    if not handleLinksToLocal(Sender, aFile, fullPath, showMsg) then
+      if not handleNotDirect(Sender, aFile, fullPath, showMsg) then
+        handleDirect(Sender, aFile, fullPath, showMsg);
+
+    if fullPath.IsEmpty() and ShowMsg.IsEmpty() then
+      showMsg:= rsMsgErrNotSupported;
+  except
+    on E: EAbort do
+    begin
+      showMsg:= E.Message;
+    end;
+  end;
+
+  if not fullPath.IsEmpty() then begin
+    LoadFile( fullPath );
+  end else begin
+    FViewer.Hide;
+    FFirstFile:= True;
+    Caption:= showMsg;
+    FViewer.LoadFile(EmptyStr);
+  end;
+end;
+
+// return true if it should handle it, otherwise return false
+// If files are links to local files
+// for example: results from searching
+function TQuickViewPanel.handleLinksToLocal( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
+var
+  ActiveFile: TFile = nil;
+begin
+  if not (fspLinksToLocalFiles in Sender.FileSource.Properties) then exit(false);
+  Result:= true;
+  if not aFile.IsNameValid then exit;
+
+  FFileSource := Sender.FileSource;
+  ActiveFile:= aFile.Clone;
+
+  try
+    if not FFileSource.GetLocalName(ActiveFile) then exit;
+    fullPath:= ActiveFile.FullPath;
+  finally
+    FreeAndNil(ActiveFile);
+  end;
+end;
+
+// return true if it should handle it, otherwise return false
+// If files not directly accessible copy them to temp file source.
+// for examples: ftp
+function TQuickViewPanel.handleNotDirect( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
+var
   ActiveFile: TFile = nil;
   TempFiles: TFiles = nil;
   Operation: TFileSourceOperation = nil;
   TempFileSource: ITempFileSystemFileSource = nil;
 begin
+  if (fspDirectAccess in Sender.FileSource.Properties) then exit(false);
+  Result:= true;
+  if SameText(FFileName, aFile.Name) then exit;
+  FFileName:= aFile.Name;
+
+  if aFile.IsDirectory or aFile.IsLinkToDirectory then exit;
+  if not (fsoCopyOut in Sender.FileSource.GetOperationsTypes) then exit;
+
+  ActiveFile:= aFile.Clone;
+  TempFiles:= TFiles.Create(ActiveFile.Path);
+  TempFiles.Add(aFile.Clone);
+
   try
-    if not (Assigned(aFile) and aFile.IsNameValid) then
-      raise EAbort.Create(rsMsgErrNotSupported);
+    if FFileSource.IsClass(TTempFileSystemFileSource) then
+      TempFileSource := (FFileSource as ITempFileSystemFileSource)
+    else
+      TempFileSource := TTempFileSystemFileSource.GetFileSource;
 
+    Operation := Sender.FileSource.CreateCopyOutOperation(
+                     TempFileSource,
+                     TempFiles,
+                     TempFileSource.FileSystemRoot);
+
+    if not Assigned(Operation) then exit;
+
+    Sender.Enabled:= False;
     try
-      // If files are links to local files
-      if (fspLinksToLocalFiles in Sender.FileSource.Properties) then
-      begin
-        if aFile.IsDirectory or aFile.IsLinkToDirectory then RaiseExit;
-        FFileSource := Sender.FileSource;
-        ActiveFile:= aFile.Clone;
-        if not FFileSource.GetLocalName(ActiveFile) then RaiseExit;
-      end
-      // If files not directly accessible copy them to temp file source.
-      else if not (fspDirectAccess in Sender.FileSource.Properties) then
-      begin
-        if aFile.IsDirectory or SameText(FFileName, aFile.Name) then RaiseExit;
-        if not (fsoCopyOut in Sender.FileSource.GetOperationsTypes) then RaiseExit;
-
-        ActiveFile:= aFile.Clone;
-        TempFiles:= TFiles.Create(ActiveFile.Path);
-        TempFiles.Add(aFile.Clone);
-
-        if FFileSource.IsClass(TTempFileSystemFileSource) then
-          TempFileSource := (FFileSource as ITempFileSystemFileSource)
-        else
-          TempFileSource := TTempFileSystemFileSource.GetFileSource;
-
-        Operation := Sender.FileSource.CreateCopyOutOperation(
-                         TempFileSource,
-                         TempFiles,
-                         TempFileSource.FileSystemRoot);
-
-        if not Assigned(Operation) then RaiseExit;
-
-        Sender.Enabled:= False;
-        try
-          Operation.Execute;
-        finally
-          FreeAndNil(Operation);
-          Sender.Enabled:= True;
-        end;
-
-        FFileName:= ActiveFile.Name;
-        FFileSource := TempFileSource;
-        ActiveFile.Path:= TempFileSource.FileSystemRoot;
-      end
-      else begin
-        // We can use the file source directly.
-        FFileSource := Sender.FileSource;
-        ActiveFile:= aFile.Clone;
-      end;
-
-      LoadFile(ActiveFile.FullPath);
-
+      Operation.Execute;
     finally
-      FreeAndNil(TempFiles);
-      FreeAndNil(ActiveFile);
+      FreeAndNil(Operation);
+      Sender.Enabled:= True;
     end;
-  except
-    on E: EAbort do
-    begin
-      FViewer.Hide;
-      FFirstFile:= True;
-      Caption:= E.Message;
-      FViewer.LoadFile(EmptyStr);
-    end;
+
+    FFileSource := TempFileSource;
+    ActiveFile.Path:= TempFileSource.FileSystemRoot;
+    fullPath:= ActiveFile.FullPath;
+  finally
+    FreeAndNil(TempFiles);
+    FreeAndNil(ActiveFile);
+  end;
+end;
+
+// return true if it should handle it, otherwise return false
+// for examples: file system
+function TQuickViewPanel.handleDirect( const Sender:TFileView; const aFile:TFile; var fullPath:String; var showMsg:String ): Boolean;
+var
+  parentDir: String;
+begin
+  Result:= true;
+  FFileSource:= Sender.FileSource;
+
+  if aFile.IsNameValid then begin
+    fullPath:= aFile.FullPath;
+  end else begin
+    parentDir:= FFileSource.GetParentDir( aFile.Path );
+    if FFileSource.IsPathAtRoot(parentDir) then
+      showMsg:= rsPropsFolder + ': ' + parentDir
+    else
+      fullPath:= parentDir;
   end;
 end;
 


### PR DESCRIPTION
improve directories display in QuickView:
1. refactoring `TQuickViewPanel.FileViewChangeActiveFile` to use normal flow control statements, use exceptions only when error occurs. while keeping the original function unchanged with FileSystem, Ftp, and Search Results.
2. Improvement: '..' and root can be displayed correctly in FileSystem
3. Improvement: directories can be displayed correctly in Search Results
4. Improvement: avoid wrongly displaying directory link symbols in Ftp

tests performed：
1. tested with FileSystem, Ftp, and Search Results
2. tested with normal directories, '..', and root
3. tested on MacOS 12 and Windows 11
