### PR TITLE
FIX: TFileViewNotebook.DestroyAllPages: remove page by Tabs.Delete()

### DIFF
--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -548,8 +548,8 @@ var
   i: Integer;
 begin
   for i:=PageCount-1 downto 0 do
-    if i<>ActivePageIndex then inherited RemovePage( i );
-  inherited RemovePage( 0 );
+    if i<>ActivePageIndex then Tabs.Delete( i );
+  Tabs.Delete( 0 );
 end;
 
 procedure TFileViewNotebook.ActivatePrevTab;


### PR DESCRIPTION
FIX: TFileViewNotebook.DestroyAllPages: 
1. there is a bug in `TFileViewNotebook.DestroyAllPages`, the ViewPage is not properly destroyed.
2. `Tabs.Delete()` should be called when removing page, not `inherited RemovePage()`.
3. `Tabs.Delete()` consistent with `TNBPages.Clear`, it will call `TNBPages.Delete` at the end. the ViewPage will be properly destroyed.
4. `inherited RemovePage()` will call `TNBPages.DeletePage` at the end. it just remove the ViewPage from the list, the ViewPage will not be destroyed.

```pascal
procedure TNBPages.Clear;
var
  i: Integer;
begin
  // remove the pages in reverse order but skip the Active Page,
  // and remove the Active Page at the end,
  // to avoid activating other Pages.
  for i:=FNoteBook.PageCount-1 downto 0 do
    if i<>FNoteBook.PageIndex then Delete(i);
  if FNoteBook.PageCount>0 then Delete(0);
end;

procedure TNBPages.DeletePage(Index: Integer);
begin
  FPageList.Delete(Index);
end;

procedure TNBPages.Delete(Index: Integer);
var
  APage: TCustomPage;
begin
  // Make sure Index is in the range of valid pages to delete
  {$IFDEF NOTEBOOK_DEBUG}
  //DebugLn('TNBPages.Delete A Index=',Index);
  DebugLn(['TNBPages.Delete B ',FNotebook.Name,' Index=',Index,' FPageList.Count=',FPageList.Count,' FNotebook.PageIndex=',FNotebook.PageIndex]);
  {$ENDIF}
  if (Index >= 0) and
     (Index < FPageList.Count) then
  begin
    APage := TCustomPage(FPageList[Index]);
    // delete handle
    APage.Parent := nil;
    // free the page
    Application.ReleaseComponent(APage);
  end;
  {$IFDEF NOTEBOOK_DEBUG}
  DebugLn(['TNBPages.Delete END ',FNotebook.Name,' Index=',Index,' FPageList.Count=',FPageList.Count,' FNotebook.PageIndex=',FNotebook.PageIndex]);
  {$ENDIF}
end;
```