### PR TITLE
FIX: ufileview in FlatView mode: issues when there are files with the same name in different subdirectories

### DIFF
--- a/src/fileviews/ufileview.pas
+++ b/src/fileviews/ufileview.pas
@@ -156,6 +156,12 @@ type
     FOnFileListChanged : TOnFileListChanged;
     FLoadingFileListLongTimer: TTimer;
 
+    // when not in FlatView Mode, FileName only used as Key for FHashedNames
+    // to save resource;
+    // otherwise, subPath+FileName should be used as Key
+    // to identify files with the same name in different subdirectories
+    function calcFileHashKey(const FileName, APath: String): String;
+
     procedure AddFile(const FileName, APath: String; NewFilesPosition: TNewFilesPosition; UpdatedFilesPosition: TUpdatedFilesPosition);
     procedure AddEventToPendingFilesChanges(const EventData: TFSWatcherEventData);
     function ApplyFilter(ADisplayFile: TDisplayFile; NewFilesPosition: TNewFilesPosition): TFileViewApplyFilterResult;
@@ -188,7 +194,7 @@ type
     procedure HashFileList;
     procedure InsertFile(ADisplayFile: TDisplayFile; AFileList: TDisplayFiles; NewFilesPosition: TNewFilesPosition);
     procedure RemoveFile(ADisplayFile: TDisplayFile);
-    procedure RemoveFile(const FileName: String);
+    procedure RemoveFile(const FileName, APath: String);
     procedure RenameFile(const NewFileName, OldFileName, APath: String; NewFilesPosition: TNewFilesPosition; UpdatedFilesPosition: TUpdatedFilesPosition);
     procedure ResortFile(ADisplayFile: TDisplayFile; AFileList: TDisplayFiles);
     procedure SetActive(bActive: Boolean); inline; overload;
@@ -1048,13 +1054,28 @@ begin
     Result := nil;
 end;
 
+function TFileView.calcFileHashKey(const FileName, APath: String): String;
+var
+  subPath: String;
+begin
+  if not FFlatView then begin
+    Result := FileName;
+  end else begin
+    subPath := APath.Substring( currentPath.Length );
+    if subPath<>EmptyStr then subPath := IncludeTrailingPathDelimiter(subPath);
+    Result := subPath + FileName;
+  end;
+end;
+
 procedure TFileView.AddFile(const FileName, APath: String; NewFilesPosition: TNewFilesPosition; UpdatedFilesPosition: TUpdatedFilesPosition);
 var
   ADisplayFile: TDisplayFile;
   AFile: TFile;
   I: Integer;
+  AFileKey: String;
 begin
-  I := FHashedNames.Find(FileName);
+  AFileKey := calcFileHashKey(FileName, APath);
+  I := FHashedNames.Find(AFileKey);
   if I < 0 then
   begin
     AFile := TFile.Create(APath);
@@ -1071,7 +1092,7 @@ begin
     end;
     ADisplayFile := TDisplayFile.Create(AFile);
     FHashedFiles.Add(ADisplayFile, nil);
-    FHashedNames.Add(FileName, ADisplayFile);
+    FHashedNames.Add(AFileKey, ADisplayFile);
     InsertFile(ADisplayFile, FAllDisplayFiles, NewFilesPosition);
     if not TFileListBuilder.MatchesFilter(ADisplayFile.FSFile, FileFilter, FFilterOptions) then
     begin
@@ -1086,18 +1107,18 @@ begin
     UpdateFile(FileName, APath, NewFilesPosition, UpdatedFilesPosition);
 end;
 
-procedure TFileView.RemoveFile(const FileName: String);
+procedure TFileView.RemoveFile(const FileName, APath: String);
 var
   I: Integer;
 begin
-  I := FHashedNames.Find(FileName);
+  I := FHashedNames.Find( calcFileHashKey(FileName,APath) );
   if I >= 0 then
     RemoveFile(TDisplayFile(FHashedNames.List[I]^.Data));
 end;
 
 procedure TFileView.RemoveFile(ADisplayFile: TDisplayFile);
 begin
-  FHashedNames.Remove(ADisplayFile.FSFile.Name);
+  FHashedNames.Remove( calcFileHashKey(ADisplayFile.FSFile.Name, ADisplayFile.FSFile.Path) );
   FHashedFiles.Remove(ADisplayFile);
   FFiles.Remove(ADisplayFile);
   FAllDisplayFiles.Remove(ADisplayFile);
@@ -1111,17 +1132,20 @@ var
   ADisplayFile: TDisplayFile;
   OldIndex, NewIndex: Integer;
   ANotifications: TFileViewNotifications;
+  OldFileKey, NewFileKey : String;
 begin
-  OldIndex := FHashedNames.Find(OldFileName);
-  NewIndex := FHashedNames.Find(NewFileName);
+  OldFileKey := calcFileHashKey(OldFileName,APath);
+  NewFileKey := calcFileHashKey(NewFileName,APath);
+  OldIndex := FHashedNames.Find( OldFileKey );
+  NewIndex := FHashedNames.Find( NewFileKey );
   if OldIndex >= 0 then
   begin
     ADisplayFile := TDisplayFile(FHashedNames.List[OldIndex]^.Data);
     if NewIndex < 0 then
     begin
       ADisplayFile.FSFile.Name := NewFileName;
-      FHashedNames.Remove(OldFileName);
-      FHashedNames.Add(NewFileName, ADisplayFile);
+      FHashedNames.Remove(OldFileKey);
+      FHashedNames.Add(NewFileKey, ADisplayFile);
       ADisplayFile.Busy:= False;
       ADisplayFile.IconID := -1;
       ADisplayFile.Selected := False;
@@ -1240,7 +1264,7 @@ var
   end;
 
 begin
-  I := FHashedNames.Find(FileName);
+  I := FHashedNames.Find( calcFileHashKey(FileName,APath) );
   if I >= 0 then
   begin
     ADisplayFile := TDisplayFile(FHashedNames.List[I]^.Data);
@@ -2269,6 +2293,7 @@ end;
 procedure TFileView.HashFileList;
 var
   i: Integer;
+  AFile: TFile;
 begin
   // Cannot use FHashedFiles.Clear because it also destroys the buckets.
   FHashedFiles.Free;
@@ -2279,8 +2304,9 @@ begin
   begin
     for i := 0 to FAllDisplayFiles.Count - 1 do
     begin
+      AFile := FAllDisplayFiles[i].FSFile;
       FHashedFiles.Add(FAllDisplayFiles[i], nil);
-      FHashedNames.Add(FAllDisplayFiles[i].FSFile.Name, FAllDisplayFiles[i]);
+      FHashedNames.Add( calcFileHashKey(AFile.Name,AFile.Path) , FAllDisplayFiles[i] );
     end;
   end;
 end;
@@ -3313,13 +3339,13 @@ begin
     fswFileChanged:
       Self.UpdateFile(EventData.FileName, EventData.Path, NewFilesPosition, UpdatedFilesPosition);
     fswFileDeleted:
-      Self.RemoveFile(EventData.FileName);
+      Self.RemoveFile(EventData.FileName, EventData.Path);
     fswFileRenamed:
       Self.RenameFile(EventData.NewFileName, EventData.FileName, EventData.Path, NewFilesPosition, UpdatedFilesPosition);
     fswSelfDeleted:
       CurrentPath:= GetDeepestExistingPath(CurrentPath);
     else
-      Reload(EventData.Path);
+      Reload();
   end;
 end;
 
@@ -3367,7 +3393,7 @@ begin
       if EventData.EventType <> fswUnknownChange then
         AddEventToPendingFilesChanges(EventData)
       else
-        Reload(EventData.Path);
+        Reload();
     end
     else
     begin


### PR DESCRIPTION
FIX: ufileview in FlatView mode: issues when there are files with the same name in different subdirectories:

1. currently only filename is used as HashKey, without path
2. when in normal mode, it works well
3. when in FlatView mode, filename only is not enough to identify a file
4. in the patch, when in FlatView mode, include the path to identify a file

example of related issue:
1. DC in FlatView mode, currently at `currentPath`
2. there is a file in subPath: `currentPath\subPath\file.txt`
3. create file.txt in `currentPath` with another file manager: `currentPath\file.txt`
4. but `currentPath\file.txt` is not shown in DC, and refresh `currentPath\subPath\file.txt` wrongly