### PR TITLE
UPD: Format file sizes and counts in file dialogs (v.2)

### DIFF
--- a/src/fFileOpDlg.pas
+++ b/src/fFileOpDlg.pas
@@ -780,8 +780,8 @@ begin
   else begin
     if Operation.State = fsosRunning then ProgressBar.Style := pbstNormal;
     ProgressBar.SetProgress(CurrentFiles, TotalFiles,
-                            cnvFormatFileSize(CurrentFiles, uoscNoUnit) + '/' +
-                            cnvFormatFileSize(TotalFiles, uoscNoUnit)
+                            IntToStrTS(CurrentFiles) + '/' +
+                            IntToStrTS(TotalFiles)
                             );
   end;
 end;
@@ -1078,7 +1078,7 @@ begin
     SetLabelCaption(lblFileNameFrom, CurrentFile);
 
     SetProgressFiles(Operation, pbTotal, DoneFiles, TotalFiles);
-    SetSpeedAndTime(Operation, RemainingTime, cnvFormatFileSize(FilesPerSecond, uoscNoUnit));
+    SetSpeedAndTime(Operation, RemainingTime, IntToStrTS(FilesPerSecond));
   end;
 end;
 
@@ -1149,7 +1149,7 @@ begin
   with CalcStatisticsOperationStatistics do
   begin
     SetLabelCaption(lblFileNameFrom, CurrentFile);
-    SetSpeedAndTime(Operation, 0, cnvFormatFileSize(FilesPerSecond, uoscNoUnit));
+    SetSpeedAndTime(Operation, 0, IntToStrTS(FilesPerSecond));
   end;
 end;
 
@@ -1203,7 +1203,7 @@ begin
     SetLabelCaption(lblFileNameFrom, CurrentFile);
 
     SetProgressFiles(Operation, pbTotal, DoneFiles, TotalFiles);
-    SetSpeedAndTime(Operation, RemainingTime, cnvFormatFileSize(FilesPerSecond, uoscNoUnit));
+    SetSpeedAndTime(Operation, RemainingTime, IntToStrTS(FilesPerSecond));
   end;
 end;
 
@@ -1227,7 +1227,7 @@ begin
   if (DoneFiles < 0) or (TotalFiles = 0) then
     lblFileCount.Caption := EmptyStr
   else begin
-    lblFileCount.Caption := IntToStr(DoneFiles) + ' / ' + IntToStr(TotalFiles);
+    lblFileCount.Caption := IntToStrTS(DoneFiles) + ' / ' + IntToStrTS(TotalFiles);
   end;
 end;
 

--- a/src/ffileproperties.pas
+++ b/src/ffileproperties.pas
@@ -539,7 +539,7 @@ begin
   if Assigned(FFileSourceCalcStatisticsOperation) then
     with FFileSourceCalcStatisticsOperation.RetrieveStatistics do
     begin
-      lblSize.Caption := Format('%s (%s)', [cnvFormatFileSize(Size), Numb2USA(IntToStr(Size))]);
+      lblSize.Caption := Format('%s (%s)', [cnvFormatFileSize(Size), IntToStrTS(Size)]);
       lblContains.Caption := Format(rsPropsContains, [Files, Directories]);
     end;
 end;

--- a/src/filesources/filesystem/ufilesystemutil.pas
+++ b/src/filesources/filesystem/ufilesystemutil.pas
@@ -174,7 +174,7 @@ type
 implementation
 
 uses
-  uDebug, uOSUtils, DCStrUtils, FileUtil, uFindEx, DCClassesUtf8, uFileProcs, uLng,
+  uDebug, uDCUtils, uOSUtils, DCStrUtils, FileUtil, uFindEx, DCClassesUtf8, uFileProcs, uLng,
   DCBasicTypes, uFileSource, uFileSystemFileSource, uFileProperty, uAdministrator,
   StrUtils, DCDateTimeUtils, uShowMsg, Forms, LazUTF8, uHash, uFileCopyEx, SysConst
 {$IFDEF UNIX}
@@ -287,11 +287,11 @@ begin
   Result:= rsMsgFileExistsOverwrite + LineEnding + WrapTextSimple(TargetName, 100) + LineEnding;
   if FileGetAttrUAC(TargetName, TargetInfo) then
   begin
-    Result:= Result + Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(TargetInfo.Size)),
+    Result:= Result + Format(rsMsgFileExistsFileInfo, [cnvFormatFileSize(TargetInfo.Size, uoscOperation),
                              DateTimeToStr(FileTimeToDateTime(TargetInfo.LastWriteTime))]) + LineEnding;
   end;
   Result:= Result + LineEnding + rsMsgFileExistsWithFile + LineEnding + WrapTextSimple(SourceName, 100) + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(SourceSize)), DateTimeToStr(SourceTime)]);
+           Format(rsMsgFileExistsFileInfo, [cnvFormatFileSize(SourceSize, uoscOperation), DateTimeToStr(SourceTime)]);
 end;
 
 function FileCopyProgress(TotalBytes, DoneBytes: Int64; UserData: Pointer): LongBool;

--- a/src/filesources/gio/ugiofilesourceutil.pas
+++ b/src/filesources/gio/ugiofilesourceutil.pas
@@ -111,7 +111,7 @@ procedure FillAndCount(Files: TFiles; CountDirs: Boolean; out NewFiles: TFiles;
 implementation
 
 uses
-  Forms, StrUtils, DCDateTimeUtils, uFileProperty,
+  Forms, StrUtils, DCDateTimeUtils, uDCUtils, uFileProperty,
   uShowMsg, uLng, uGObject2, uGio, DCFileAttributes;
 
 procedure ShowError(AError: PGError);
@@ -205,10 +205,10 @@ end;
 function FileExistsMessage(SourceFile: TFile; TargetInfo: PGFileInfo; const TargetName: String): String;
 begin
   Result:= rsMsgFileExistsOverwrite + LineEnding + TargetName + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(g_file_info_get_size(TargetInfo))),
+           Format(rsMsgFileExistsFileInfo, [IntToStrTS(g_file_info_get_size(TargetInfo)),
                   DateTimeToStr(UnixFileTimeToDateTime(g_file_info_get_attribute_uint64(TargetInfo, FILE_ATTRIBUTE_TIME_MODIFIED)))]) + LineEnding;
   Result:= Result + LineEnding + rsMsgFileExistsWithFile + LineEnding + SourceFile.FullPath + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(SourceFile.Size)), DateTimeToStr(SourceFile.ModificationTime)]);
+           Format(rsMsgFileExistsFileInfo, [IntToStrTS(SourceFile.Size), DateTimeToStr(SourceFile.ModificationTime)]);
 end;
 
 procedure FreeAndNil(var AError: PGError);

--- a/src/filesources/wcxarchive/uwcxarchivecopyinoperation.pas
+++ b/src/filesources/wcxarchive/uwcxarchivecopyinoperation.pas
@@ -71,9 +71,10 @@ type
 implementation
 
 uses
-  LazUTF8, FileUtil, StrUtils, DCStrUtils, uLng, uShowMsg, fWcxArchiveCopyOperationOptions,
-  uFileSystemFileSource, DCOSUtils, uTarWriter, uClassesEx,
-  DCConvertEncoding, DCDateTimeUtils, uArchiveFileSourceUtil;
+  LazUTF8, FileUtil, StrUtils, DCStrUtils, uDCUtils, uLng, uShowMsg,
+  fWcxArchiveCopyOperationOptions, uFileSystemFileSource, DCOSUtils,
+  uTarWriter, uClassesEx, DCConvertEncoding, DCDateTimeUtils,
+  uArchiveFileSourceUtil;
 
 // ----------------------------------------------------------------------------
 // WCX callbacks
@@ -436,11 +437,11 @@ function TWcxArchiveCopyInOperation.FileExistsMessage(aSourceFile: TFile; aTarge
 begin
   Result:= rsMsgFileExistsOverwrite + LineEnding + aTargetHeader.FileName + LineEnding;
 
-  Result:= Result + Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(aTargetHeader.UnpSize)),
+  Result:= Result + Format(rsMsgFileExistsFileInfo, [IntToStrTS(aTargetHeader.UnpSize),
                            DateTimeToStr(WcxFileTimeToDateTime(aTargetHeader.FileTime))]) + LineEnding;
 
   Result:= Result + LineEnding + rsMsgFileExistsWithFile + LineEnding + aSourceFile.FullPath + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(aSourceFile.Size)), DateTimeToStr(aSourceFile.ModificationTime)]);
+           Format(rsMsgFileExistsFileInfo, [IntToStrTS(aSourceFile.Size), DateTimeToStr(aSourceFile.ModificationTime)]);
 end;
 
 function TWcxArchiveCopyInOperation.FileExists(aSourceFile: TFile;

--- a/src/filesources/wfxplugin/uwfxpluginutil.pas
+++ b/src/filesources/wfxplugin/uwfxpluginutil.pas
@@ -117,7 +117,7 @@ type
 implementation
 
 uses
-  uFileProcs, StrUtils, DCStrUtils, uLng, uFileSystemUtil, uFileProperty,
+  uDCUtils, uFileProcs, StrUtils, DCStrUtils, uLng, uFileSystemUtil, uFileProperty,
   DCDateTimeUtils, DCBasicTypes, DCFileAttributes;
 
 function WfxRenameFile(aFileSource: IWfxPluginFileSource; const aFile: TFile; const NewFileName: String): Boolean;
@@ -433,9 +433,9 @@ end;
 function FileExistsMessage(TargetFile: TFile; SourceFile: TFile): String;
 begin
   Result:= rsMsgFileExistsOverwrite + LineEnding + TargetFile.FullPath + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(TargetFile.Size)), DateTimeToStr(TargetFile.ModificationTime)]) + LineEnding;
+           Format(rsMsgFileExistsFileInfo, [IntToStrTS(TargetFile.Size), DateTimeToStr(TargetFile.ModificationTime)]) + LineEnding;
   Result:= Result + LineEnding + rsMsgFileExistsWithFile + LineEnding + SourceFile.FullPath + LineEnding +
-           Format(rsMsgFileExistsFileInfo, [Numb2USA(IntToStr(SourceFile.Size)), DateTimeToStr(SourceFile.ModificationTime)]);
+           Format(rsMsgFileExistsFileInfo, [IntToStrTS(SourceFile.Size), DateTimeToStr(SourceFile.ModificationTime)]);
 end;
 
 function TWfxPluginOperationHelper.FileExists(aFile: TFile;

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -628,9 +628,9 @@ begin
     chkDeleteLeft.Caption := Format(rsDeleteLeft, [DeleteLeftCount]);
     chkDeleteRight.Caption := Format(rsDeleteRight, [DeleteRightCount]);
     chkLeftToRight.Caption :=
-      Format(rsLeftToRightCopy, [CopyRightCount, cnvFormatFileSize(CopyRightSize, fsfFloat, gFileSizeDigits), Numb2USA(IntToStr(CopyRightSize))]);
+      Format(rsLeftToRightCopy, [CopyRightCount, cnvFormatFileSize(CopyRightSize, fsfFloat, gFileSizeDigits), IntToStrTS(CopyRightSize)]);
     chkRightToLeft.Caption :=
-      Format(rsRightToLeftCopy, [CopyLeftCount, cnvFormatFileSize(CopyLeftSize, fsfFloat, gFileSizeDigits), Numb2USA(IntToStr(CopyLeftSize))]);
+      Format(rsRightToLeftCopy, [CopyLeftCount, cnvFormatFileSize(CopyLeftSize, fsfFloat, gFileSizeDigits), IntToStrTS(CopyLeftSize)]);
     if ShowModal = mrOk then
     begin
       EnableControls(False);
@@ -1840,7 +1840,7 @@ var
   BarText : String;
   CaptionText : String;
 begin
-  BarText := cnvFormatFileSize(CurrentFiles, uoscNoUnit) + '/' + cnvFormatFileSize(TotalFiles, uoscNoUnit);
+  BarText := IntToStrTS(CurrentFiles) + '/' + IntToStrTS(TotalFiles);
   AProgressBar.SetProgress(CurrentFiles, TotalFiles, BarText );
 
   {$IFDEF LCLCOCOA}

--- a/src/udcutils.pas
+++ b/src/udcutils.pas
@@ -58,7 +58,7 @@ const
   EnvVarTodaysDate    = VARDELIMITER + 'DC_TODAYSDATE' + VARDELIMITER_END;
 
 type
-  TUsageOfSizeConversion = (uoscFile, uoscHeader, uoscFooter, uoscOperation, uoscNoUnit);
+  TUsageOfSizeConversion = (uoscFile, uoscHeader, uoscFooter, uoscOperation);
 
 function GetCmdDirFromEnvVar(const sPath : String) : String;
 function SetCmdDirAsEnvVar(const sPath : String) : String;
@@ -82,6 +82,12 @@ function ReplaceTilde(const Path: String): String;
 }
 function mbExpandFileName(const sFileName: String): String;
 {en
+  Convert Int64 to string with Thousand separators. We can't use FloatToStrF with ffNumber because of integer rounding to thousands
+  @param(AValue Integer value)
+  @returns(String represenation)
+}
+function IntToStrTS(const APositiveValue: Int64): String;
+{en
    Convert file size to string representation in floating format (Kb, Mb, Gb)
    @param(iSize File size)
    @param(ShortFormat If @true than short format is used,
@@ -89,9 +95,9 @@ function mbExpandFileName(const sFileName: String): String;
    @param(Number Number of digits after decimal)
    @returns(File size in string representation)
 }
-function cnvFormatFileSize(iSize: Int64; FSF: TFileSizeFormat; Number: Integer): String;
-function cnvFormatFileSize(iSize: Int64; UsageOfSizeConversion: TUsageOfSizeConversion): String;
-function cnvFormatFileSize(iSize: Int64): String; inline;
+function cnvFormatFileSize(const iSize: Int64; FSF: TFileSizeFormat; const Number: Integer): String;
+function cnvFormatFileSize(const iSize: Int64; const UsageOfSizeConversion: TUsageOfSizeConversion): String;
+function cnvFormatFileSize(const iSize: Int64): String; inline;
 {en
    Minimize file path
    @param(PathToMince File path)
@@ -360,7 +366,37 @@ begin
   end;
 end;
 
-function cnvFormatFileSize(iSize: int64; FSF: TFileSizeFormat; Number: integer): string;
+function IntToStrTS(const APositiveValue: Int64): String;
+var i, vSrcLen, vSrcI, vSrcNumberNo, vResLen: byte;
+begin
+  if APositiveValue < 0 then
+    Exit(IntToStr(APositiveValue));
+  Str(APositiveValue, Result);
+  vSrcLen := Result.Length;
+
+  vResLen := vSrcLen + ((vSrcLen - 1) div 3);
+  if vSrcLen = vResLen then
+    Exit;
+
+  SetLength(Result, vResLen);
+
+  vSrcI := vResLen;
+  vSrcNumberNo := 1;
+
+  for i:= vSrcLen downto 1 do
+    begin
+      Result[vSrcI] := Result[i];
+      Dec(vSrcI);
+      if(vSrcNumberNo <> vSrcLen) and (vSrcNumberNo mod 3 = 0) then
+        begin
+          Result[vSrcI] := FormatSettings.ThousandSeparator;
+          Dec(vSrcI);
+        end;
+      Inc(vSrcNumberNo);
+    end;
+end;
+
+function cnvFormatFileSize(const iSize: int64; FSF: TFileSizeFormat; const Number: integer): string;
 const
   DIVISORS: array[LOW(TFileSizeFormat) .. HIGH(TFileSizeFormat)] of uint64 = (1, 1, 1024, (1024*1024), (1024*1024*1024), (1024*1024*1024*1024), 1, 1, 1024, (1024*1024), (1024*1024*1024), (1024*1024*1024*1024));
 var
@@ -391,7 +427,7 @@ begin
   end;
 end;
 
-function cnvFormatFileSize(iSize: Int64; UsageOfSizeConversion: TUsageOfSizeConversion): String;
+function cnvFormatFileSize(const iSize: Int64; const UsageOfSizeConversion: TUsageOfSizeConversion): String;
 begin
   case UsageOfSizeConversion of
     uoscOperation: //By legacy, it was simply adding a "B" to single size letter so we will do the samefor legacy mode.
@@ -406,11 +442,10 @@ begin
     uoscFile: Result := cnvFormatFileSize(iSize, gFileSizeFormat, gFileSizeDigits);
     uoscHeader: Result := cnvFormatFileSize(iSize, gHeaderSizeFormat, gHeaderDigits);
     uoscFooter: Result := cnvFormatFileSize(iSize, gFooterSizeFormat, gFooterDigits);
-    uoscNoUnit: Result := IntToStr(iSize);
   end;
 end;
 
-function cnvFormatFileSize(iSize: Int64): String;
+function cnvFormatFileSize(const iSize: Int64): String;
 begin
   Result := cnvFormatFileSize(iSize, gFileSizeFormat, gFileSizeDigits);
 end;

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -556,7 +556,7 @@ begin
     CalcStatisticsOperationStatistics := CalcStatisticsOperation.RetrieveStatistics;
     with CalcStatisticsOperationStatistics do
     begin
-      msgOK(Format(rsSpaceMsg, [Files, Directories, cnvFormatFileSize(Size), Numb2USA(IntToStr(Size))]));
+      msgOK(Format(rsSpaceMsg, [Files, Directories, cnvFormatFileSize(Size), IntToStrTS(Size)]));
     end;
   end;
 end;


### PR DESCRIPTION
Now DC uses options for file size when file replacing and also format number of files according to regional settings of OS. Tested only on Windows