### PR TITLE
DEL: remove senseless text for separator and nothing

### DIFF
--- a/language/doublecmd.be.po
+++ b/language/doublecmd.be.po
@@ -11477,11 +11477,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Назва:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(падзяляльнік)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.bg.po
+++ b/language/doublecmd.bg.po
@@ -11962,11 +11962,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Име"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.ca.po
+++ b/language/doublecmd.ca.po
@@ -12482,11 +12482,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Nom:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.cs.po
+++ b/language/doublecmd.cs.po
@@ -11500,11 +11500,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Název:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(oddělovač)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.da.po
+++ b/language/doublecmd.da.po
@@ -12570,11 +12570,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Navn"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(separator)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.de.po
+++ b/language/doublecmd.de.po
@@ -11667,11 +11667,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Name:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(Trennzeichen)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"
@@ -14203,3 +14198,4 @@ msgstr "Eine Ersetzung hat nicht stattgefunden."
 #, object-pascal-format
 msgid "No setup named \"%s\""
 msgstr "Keine Einstellung namens »%s«"
+

--- a/language/doublecmd.el.po
+++ b/language/doublecmd.el.po
@@ -11704,11 +11704,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Ονομασία:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(διαχωριστικό)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.es.po
+++ b/language/doublecmd.es.po
@@ -11607,11 +11607,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Nombre:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(separador)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.fr.po
+++ b/language/doublecmd.fr.po
@@ -11771,11 +11771,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Nom :"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(séparateur)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.hr.po
+++ b/language/doublecmd.hr.po
@@ -12183,11 +12183,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Ime:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(razdvajač)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.hu.po
+++ b/language/doublecmd.hu.po
@@ -11754,11 +11754,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Név:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(elválasztó)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.it.po
+++ b/language/doublecmd.it.po
@@ -11953,11 +11953,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Nome:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.ja.po
+++ b/language/doublecmd.ja.po
@@ -11725,11 +11725,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "名前："
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "（区切り）"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.ko.po
+++ b/language/doublecmd.ko.po
@@ -11710,11 +11710,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "이름(&N):"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(구분자)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.nb.po
+++ b/language/doublecmd.nb.po
@@ -12017,11 +12017,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Navn:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(delestrek)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.nl.po
+++ b/language/doublecmd.nl.po
@@ -11496,11 +11496,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Naam:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(scheidingsteken)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.nn.po
+++ b/language/doublecmd.nn.po
@@ -12017,11 +12017,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Namn:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(delestrek)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.pl.po
+++ b/language/doublecmd.pl.po
@@ -11438,11 +11438,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Nazwa:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(separator)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.pot
+++ b/language/doublecmd.pot
@@ -11448,11 +11448,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr ""
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.pt.po
+++ b/language/doublecmd.pt.po
@@ -11811,11 +11811,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Nome:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(separador)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.pt_BR.po
+++ b/language/doublecmd.pt_BR.po
@@ -11929,11 +11929,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Nome:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(separador)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.ro.po
+++ b/language/doublecmd.ro.po
@@ -11781,11 +11781,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Nume:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.ru.po
+++ b/language/doublecmd.ru.po
@@ -11740,11 +11740,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "И&мя:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(разделитель)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.sk.po
+++ b/language/doublecmd.sk.po
@@ -11741,11 +11741,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Meno:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(oddelovač)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.sl.po
+++ b/language/doublecmd.sl.po
@@ -11590,11 +11590,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "&Ime:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(ločilnik)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.sr.po
+++ b/language/doublecmd.sr.po
@@ -12015,11 +12015,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Име:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(раздвајач)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.sr@latin.po
+++ b/language/doublecmd.sr@latin.po
@@ -12016,11 +12016,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Ime:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(razdvajač)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.tr.po
+++ b/language/doublecmd.tr.po
@@ -12167,11 +12167,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Adı:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.uk.po
+++ b/language/doublecmd.uk.po
@@ -11834,11 +11834,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "Назва:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "(роздільник)"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.zh_CN.po
+++ b/language/doublecmd.zh_CN.po
@@ -11549,11 +11549,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "名称(&N)："
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr "（分隔器）"
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/language/doublecmd.zh_TW.po
+++ b/language/doublecmd.zh_TW.po
@@ -12493,11 +12493,6 @@ msgctxt "ulng.rsmsghotdirsimplename"
 msgid "&Name:"
 msgstr "名稱:"
 
-#: ulng.rsmsghotdirsimpleseparator
-msgctxt "ulng.rsmsghotdirsimpleseparator"
-msgid "(separator)"
-msgstr ""
-
 #: ulng.rsmsghotdirsubmenuname
 msgctxt "ulng.rsmsghotdirsubmenuname"
 msgid "Submenu name"

--- a/src/frames/foptionsdirectoryhotlist.pas
+++ b/src/frames/foptionsdirectoryhotlist.pas
@@ -1071,7 +1071,7 @@ var
   OriginalNode: TTreeNode;
 begin
   OriginalNode := tvDirectoryHotlist.Selected;
-  lbleditHotDirName.Text := '';
+
   lbleditHotDirName.Enabled := False;
   lbleditHotDirPath.Visible := False;
   cbSortHotDirPath.Visible := False;
@@ -1079,6 +1079,7 @@ begin
   lbleditHotDirTarget.Visible := False;
   btnRelativePath.Visible := False;
   btnRelativeTarget.Visible := False;
+
   Application.ProcessMessages;
   try
     RefreshExistingProperty(TComponent(Sender).tag);
@@ -1533,6 +1534,7 @@ begin
         lbleditHotDirName.EditLabel.Caption := rsMsgHotDirSimpleName;
         lbleditHotDirName.Text := THotDir(WorkingPointer).HotDirName;
         lbleditHotDirName.ReadOnly := False;
+        lbleditHotDirName.Visible := True;
 
         lbleditHotDirPath.EditLabel.Caption := rsMsgHotDirJustPath;
         lbleditHotDirPath.Text := THotDir(WorkingPointer).HotDirPath; //DirectoryHotlistTemp.HotDir[IndexInHotlist].HotDirPath;
@@ -1563,10 +1565,7 @@ begin
 
       hd_SEPARATOR:
       begin
-        lbleditHotDirName.EditLabel.Caption := '';
-        lbleditHotDirName.Text := rsMsgHotDirSimpleSeparator;
-        lbleditHotDirName.ReadOnly := True;
-
+        lbleditHotDirName.Visible := False;
         lbleditHotDirPath.Visible := False;
         lbleditHotDirTarget.Visible := False;
       end;
@@ -1576,6 +1575,7 @@ begin
         lbleditHotDirName.EditLabel.Caption := rsMsgHotDirSimpleMenu;
         lbleditHotDirName.Text := THotDir(WorkingPointer).HotDirName;
         lbleditHotDirName.ReadOnly := False;
+        lbleditHotDirName.Visible := True;
 
         lbleditHotDirPath.Visible := False;
         lbleditHotDirTarget.Visible := False;
@@ -1586,6 +1586,7 @@ begin
         lbleditHotDirName.EditLabel.Caption := '';
         lbleditHotDirName.Text := rsMsgHotDirSimpleEndOfMenu;
         lbleditHotDirName.ReadOnly := True;
+        lbleditHotDirName.Visible:= True;
 
         lbleditHotDirPath.Visible := False;
         lbleditHotDirTarget.Visible := False;
@@ -1607,11 +1608,7 @@ begin
     btnInsert.Enabled := btnAdd.Enabled;
     btnMiscellaneous.Enabled := btnAdd.Enabled;
 
-    lbleditHotDirName.EditLabel.Caption := '';
-    lbleditHotDirName.Text := '';
-    lbleditHotDirName.ReadOnly := True;
-    lbleditHotDirName.Text := 'Nothing...';
-
+    lbleditHotDirName.Visible := False;
     lbleditHotDirPath.Visible := False;
     lbleditHotDirTarget.Visible := False;
   end;

--- a/src/ulng.pas
+++ b/src/ulng.pas
@@ -262,7 +262,6 @@ resourcestring
   rsMsgHotDirTarget = 'Hotdir target';
   rsMsgHotDirSubMenuName = 'Submenu name';
   rsMsgHotDirSimpleName = '&Name:';
-  rsMsgHotDirSimpleSeparator = '(separator)';
   rsMsgHotDirSimpleMenu = 'Menu &name:';
   rsMsgHotDirSimpleEndOfMenu = '(end of sub menu)';
   rsMsgHotDirSimpleCommand = 'Command:';


### PR DESCRIPTION
Also "Nothing..." was not translated and text for separator and "nothing" was without a label so it looked strange.

Because of this I removed translated string because there is no place where it can be used.

Well, I would be do some cleaning with this module too. Do you mind if I:
1) replace "case of" with one condition to if;
2) remove all concerning hd_COMMAND. I think before it was like a simple for adding command but now this code is unused, Or may be you have a plan for adding command to hotdir list?