### PR TITLE
FIX #832: MultiRename: FileName & Extension fields not updated on MacOS

### DIFF
--- a/src/doublecmd.lpr
+++ b/src/doublecmd.lpr
@@ -48,6 +48,9 @@ uses
   uWin32WidgetSetFix,
   {$ENDIF}
   {$ENDIF}
+  {$IFDEF LCLCOCOA}
+  uCocoaWidgetSetFix,
+  {$ENDIF}
   LCLProc,
   Classes,
   SysUtils,
@@ -181,6 +184,10 @@ begin
 
   Application.ShowMainForm:= False;
   Application.CreateForm(TfrmHackForm, frmHackForm);
+
+  {$IFDEF LCLCOCOA}
+  uCocoaWidgetSetFix.Initialize;
+  {$ENDIF}
 
   ProcessCommandLineParams; // before load paths
 

--- a/src/platform/unix/darwin/ucocoawidgetsetfix.pas
+++ b/src/platform/unix/darwin/ucocoawidgetsetfix.pas
@@ -1,0 +1,99 @@
+unit uCocoaWidgetSetFix;
+
+{$mode delphi}
+{$modeswitch objectivec1}
+
+interface
+
+procedure Initialize;
+
+implementation
+
+uses
+  Classes, SysUtils,
+  StdCtrls, WSLCLClasses, WSStdCtrls,
+  CocoaAll, CocoaWSStdCtrls;
+
+type
+
+ { TCocoaWSCustomComboBoxEx }
+
+ TCocoaWSCustomComboBoxEx = class(TCocoaWSCustomComboBox)
+ private
+   class function getNSText(const ACustomComboBox: TCustomComboBox): NSText;
+ published
+   class function  GetSelStart(const ACustomComboBox: TCustomComboBox): integer; override;
+   class function  GetSelLength(const ACustomComboBox: TCustomComboBox): integer; override;
+   class procedure SetSelStart(const ACustomComboBox: TCustomComboBox; NewStart: integer); override;
+   class procedure SetSelLength(const ACustomComboBox: TCustomComboBox; NewLength: integer); override;
+ end;
+
+class function TCocoaWSCustomComboBoxEx.getNSText(const ACustomComboBox: TCustomComboBox): NSText;
+var
+  control: NSControl;
+begin
+  Result:= nil;
+  if not Assigned(ACustomComboBox) or (not ACustomComboBox.HandleAllocated) or (ACustomComboBox.Handle=0) then
+    exit;
+  control:= NSControl( ACustomComboBox.Handle );
+  Result:= NSText( control.currentEditor );
+end;
+
+class function TCocoaWSCustomComboBoxEx.GetSelStart(
+  const ACustomComboBox: TCustomComboBox): integer;
+var
+  txt: NSText;
+begin
+  Result:= 0;
+  txt:= getNSText( ACustomComboBox );
+  if Assigned(txt) then
+    Result:= txt.selectedRange.location;
+end;
+
+class function TCocoaWSCustomComboBoxEx.GetSelLength(
+  const ACustomComboBox: TCustomComboBox): integer;
+var
+  txt: NSText;
+begin
+  Result:= 0;
+  txt:= getNSText( ACustomComboBox );
+  if Assigned(txt) then
+    Result:= txt.selectedRange.length;
+end;
+
+class procedure TCocoaWSCustomComboBoxEx.SetSelStart(
+  const ACustomComboBox: TCustomComboBox; NewStart: integer);
+var
+  txt: NSText;
+  range: NSRange;
+begin
+  txt:= getNSText( ACustomComboBox );
+  if not Assigned(txt) then
+    exit;
+  range:= txt.selectedRange;
+  range.location:= NewStart;
+  txt.setSelectedRange( range );
+end;
+
+class procedure TCocoaWSCustomComboBoxEx.SetSelLength(
+ const ACustomComboBox: TCustomComboBox; NewLength: integer);
+var
+  txt: NSText;
+  range: NSRange;
+begin
+  txt:= getNSText( ACustomComboBox );
+  if not Assigned(txt) then
+    exit;
+  range:= txt.selectedRange;
+  range.length:= NewLength;
+  txt.setSelectedRange( range );
+end;
+
+procedure Initialize;
+begin
+ // Replace TCustomComboBox widgetset class
+  WSStdCtrls.RegisterCustomComboBox;
+  RegisterWSComponent(TCustomComboBox, TCocoaWSCustomComboBoxEx);
+end;
+
+end.


### PR DESCRIPTION
FIX #832: MultiRename: FileName & Extension fields not updated on MacOS.

such as `GetSelStart()` is missing in TCocoaWSCustomComboBox.