### PR TITLE
ADD: Button Help for Options

### DIFF
--- a/src/fattributesedit.lfm
+++ b/src/fattributesedit.lfm
@@ -540,6 +540,7 @@ object frmAttributesEdit: TfrmAttributesEdit
       Width = 94
       Caption = '&OK'
       Constraints.MinHeight = 30
+      Default = True
       Kind = bkOK
       ModalResult = 1
       OnClick = btnOkClick
@@ -550,6 +551,7 @@ object frmAttributesEdit: TfrmAttributesEdit
       Height = 32
       Top = 0
       Width = 118
+      Cancel = True
       Caption = '&Cancel'
       Constraints.MinHeight = 30
       Kind = bkCancel

--- a/src/foptions.lfm
+++ b/src/foptions.lfm
@@ -107,15 +107,16 @@ object frmOptions: TfrmOptions
     FullRepaint = False
     TabOrder = 2
     object btnHelp: TBitBtn
-      AnchorSideLeft.Control = btnOK
       AnchorSideLeft.Side = asrCenter
-      AnchorSideRight.Control = btnOK
-      Left = 307
+      AnchorSideLeft.Control = TreeFilterEdit
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = btnOK
+      Left = 201
       Height = 30
       Top = 5
       Width = 75
-      Anchors = [akTop, akRight]
       AutoSize = True
+      BorderSpacing.Left = 8
       BorderSpacing.Right = 16
       BorderSpacing.InnerBorder = 2
       Caption = '&Help'

--- a/src/foptions.lfm
+++ b/src/foptions.lfm
@@ -25,10 +25,11 @@ object frmOptions: TfrmOptions
     AutoExpand = True
     Images = OptionsEditorsImageList
     ReadOnly = True
+    RowSelect = True
     ScrollBars = ssAutoBoth
     TabOrder = 0
     OnChange = tvTreeViewChange
-    Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoKeepCollapsedNodes, tvoReadOnly, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips]
+    Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips]
   end
   object Panel3: TPanel
     Left = 196
@@ -105,6 +106,23 @@ object frmOptions: TfrmOptions
     ClientWidth = 640
     FullRepaint = False
     TabOrder = 2
+    object btnHelp: TBitBtn
+      AnchorSideLeft.Control = btnOK
+      AnchorSideLeft.Side = asrCenter
+      AnchorSideRight.Control = btnOK
+      Left = 307
+      Height = 30
+      Top = 5
+      Width = 75
+      Anchors = [akTop, akRight]
+      AutoSize = True
+      BorderSpacing.Right = 16
+      BorderSpacing.InnerBorder = 2
+      Caption = '&Help'
+      Kind = bkHelp
+      OnClick = btnHelpClick
+      TabOrder = 4
+    end
     object btnOK: TBitBtn
       AnchorSideRight.Control = btnCancel
       Left = 321

--- a/src/foptions.pas
+++ b/src/foptions.pas
@@ -50,6 +50,7 @@ type
   { TfrmOptions }
 
   TfrmOptions = class(TForm, IOptionsDialog)
+    btnHelp: TBitBtn;
     lblEmptyEditor: TLabel;
     OptionsEditorsImageList: TImageList;
     pnlButtons: TKASButtonPanel;
@@ -65,6 +66,7 @@ type
     alOptionsActionList: TActionList;
     actCloseWithEscape: TAction;
     procedure btnCancelClick(Sender: TObject);
+    procedure btnHelpClick(Sender: TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
     procedure FormCloseQuery(Sender: TObject; var CanClose: boolean);
     procedure FormCreate(Sender: TObject);
@@ -106,7 +108,7 @@ implementation
 {$R *.lfm}
 
 uses
-  LCLProc, LCLVersion, LazUTF8, LResources, Menus, Translations, Graphics,
+  HelpIntfs, LCLProc, LCLVersion, LazUTF8, LResources, Menus, Translations, Graphics,
   DCStrUtils, uTranslator, uLng, uGlobsPaths, fMain;
 
 var
@@ -227,6 +229,11 @@ procedure TfrmOptions.btnCancelClick(Sender: TObject);
 begin
   // close window
   Close;
+end;
+
+procedure TfrmOptions.btnHelpClick(Sender: TObject);
+begin
+  ShowHelpOrErrorForKeyword('', HelpKeyword);
 end;
 
 procedure TfrmOptions.btnOKClick(Sender: TObject);
@@ -469,7 +476,10 @@ begin
     if Assigned(SelectedEditorView.Instance) then
     begin
       HelpKeyword:= SelectedEditorView.Instance.HelpKeyword;
-    end;
+      btnHelp.Visible := HelpKeyword <> '';
+    end
+    else
+      btnHelp.Visible:= False;
   end;
 end;
 

--- a/src/frames/foptionsdirectoryhotlist.lfm
+++ b/src/frames/foptionsdirectoryhotlist.lfm
@@ -171,7 +171,7 @@ inherited frmOptionsDirectoryHotlist: TfrmOptionsDirectoryHotlist
           Tag = 7
           AnchorSideTop.Control = btnSort
           AnchorSideTop.Side = asrBottom
-          AnchorSideRight.Control = btnHelp
+          AnchorSideRight.Control = btnBackup
           Left = 8
           Height = 25
           Top = 124
@@ -214,20 +214,6 @@ inherited frmOptionsDirectoryHotlist: TfrmOptionsDirectoryHotlist
           Caption = '&Sort...'
           OnClick = btnActionClick
           TabOrder = 3
-        end
-        object btnHelp: TBitBtn
-          AnchorSideTop.Control = btnMiscellaneous
-          AnchorSideTop.Side = asrCenter
-          AnchorSideRight.Control = pnlButtons
-          AnchorSideRight.Side = asrBottom
-          Left = 164
-          Height = 25
-          Top = 124
-          Width = 150
-          Anchors = [akTop, akRight]
-          Caption = '&Help'
-          OnClick = btnHelpClick
-          TabOrder = 8
         end
       end
       object rgWhereToAdd: TRadioGroup

--- a/src/frames/foptionsdirectoryhotlist.pas
+++ b/src/frames/foptionsdirectoryhotlist.pas
@@ -173,7 +173,6 @@ type
     btnExport: TBitBtn;
     btnImport: TBitBtn;
     btnBackup: TBitBtn;
-    btnHelp: TBitBtn;
     pnlBottom: TPanel;
     rgWhereToAdd: TRadioGroup;
     gbHotlistOtherOptions: TGroupBox;
@@ -216,7 +215,6 @@ type
     procedure miImportFromAnythingClick(Sender: TObject);
     procedure miGotoConfigureTCInfoClick(Sender: TObject);
     procedure btnActionClick(Sender: TObject);
-    procedure btnHelpClick(Sender: TObject);
     procedure cbFullExpandTreeChange(Sender: TObject);
     procedure lbleditHotDirNameChange(Sender: TObject);
     procedure anyRelativeAbsolutePathClick(Sender: TObject);
@@ -1324,12 +1322,6 @@ begin
     7: pmMiscellaneousDirectoryHotlist.PopUp(Mouse.CursorPos.X, Mouse.CursorPos.Y);
     8: pmSortDirectoryHotlist.PopUp(Mouse.CursorPos.X, Mouse.CursorPos.Y);
   end;
-end;
-
-{ TfrmOptionsDirectoryHotlist.btnHelpClick }
-procedure TfrmOptionsDirectoryHotlist.btnHelpClick(Sender: TObject);
-begin
-  ShowHelpOrErrorForKeyword('', '/directoryhotlist.html');
 end;
 
 { TfrmOptionsDirectoryHotlist.cbFullExpandTreeChange }

--- a/src/frames/foptionsfilesviewscomplement.lfm
+++ b/src/frames/foptionsfilesviewscomplement.lfm
@@ -171,6 +171,8 @@ inherited frmOptionsFilesViewsComplement: TfrmOptionsFilesViewsComplement
         Height = 27
         Top = 0
         Width = 304
+        HelpType = htKeyword
+        HelpKeyword = '/findfiles.html#attributes'
         Anchors = [akTop, akLeft, akRight]
         TabOrder = 0
       end

--- a/src/frames/foptionsfilesviewscomplement.pas
+++ b/src/frames/foptionsfilesviewscomplement.pas
@@ -129,7 +129,7 @@ procedure TfrmOptionsFilesViewsComplement.btnAddAttributeClick(Sender: TObject);
 var
   FFrmAttributesEdit: TfrmAttributesEdit;
 begin
-  FFrmAttributesEdit := TfrmAttributesEdit.Create(Self);
+  FFrmAttributesEdit := TfrmAttributesEdit.Create(Owner);
   try
   FFrmAttributesEdit.OnOk := @OnAddAttribute;
   FFrmAttributesEdit.Reset;

--- a/src/frames/foptionsquicksearchfilter.lfm
+++ b/src/frames/foptionsquicksearchfilter.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsQuickSearchFilter: TfrmOptionsQuickSearchFilter
   Height = 354
   Width = 702
+  HelpKeyword = '/configuration.html#ConfigQuick'
   ChildSizing.LeftRightSpacing = 6
   ChildSizing.TopBottomSpacing = 6
   ClientHeight = 354

--- a/src/frames/foptionstabs.lfm
+++ b/src/frames/foptionstabs.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsTabs: TfrmOptionsTabs
   Height = 492
   Width = 731
+  HelpKeyword = '/configuration.html#ConfigTabs'
   ClientHeight = 492
   ClientWidth = 731
   DesignLeft = 147

--- a/src/frames/foptionstabsextra.lfm
+++ b/src/frames/foptionstabsextra.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsTabsExtra: TfrmOptionsTabsExtra
   Height = 418
   Width = 720
+  HelpKeyword = '/configuration.html#ConfigTabsEx'
   AutoSize = True
   ClientHeight = 418
   ClientWidth = 720

--- a/src/frames/foptionsterminal.lfm
+++ b/src/frames/foptionsterminal.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsTerminal: TfrmOptionsTerminal
   Height = 324
   Width = 519
+  HelpKeyword = '/configuration.html#ConfigToolsTerminal'
   AutoSize = True
   ClientHeight = 324
   ClientWidth = 519

--- a/src/frames/foptionstoolbar.lfm
+++ b/src/frames/foptionstoolbar.lfm
@@ -1,2 +1,3 @@
 inherited frmOptionsToolbar: TfrmOptionsToolbar
+  HelpKeyword = '/configuration.html#ConfigToolbar'
 end

--- a/src/frames/foptionstoolbarextra.lfm
+++ b/src/frames/foptionstoolbarextra.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsToolbarExtra: TfrmOptionsToolbarExtra
   Height = 573
   Width = 850
+  HelpKeyword = '/configuration.html#ConfigToolbarEx'
   ChildSizing.LeftRightSpacing = 6
   ChildSizing.TopBottomSpacing = 6
   ClientHeight = 573

--- a/src/frames/foptionstoolbarmiddle.lfm
+++ b/src/frames/foptionstoolbarmiddle.lfm
@@ -1,2 +1,3 @@
 inherited frmOptionsToolbarMiddle: TfrmOptionsToolbarMiddle
+  HelpKeyword = '/configuration.html#ConfigToolbar'
 end

--- a/src/frames/foptionstools.lfm
+++ b/src/frames/foptionstools.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsViewer: TfrmOptionsViewer
   Height = 513
   Width = 586
+  HelpKeyword = '/configuration.html#ConfigToolsViewer'
   ClientHeight = 513
   ClientWidth = 586
   DesignLeft = 384

--- a/src/frames/foptionstoolsdiffer.lfm
+++ b/src/frames/foptionstoolsdiffer.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsDiffer: TfrmOptionsDiffer
   Height = 478
   Width = 586
+  HelpKeyword = '/configuration.html#ConfigToolsDiffer'
   ClientHeight = 478
   ClientWidth = 586
   DesignLeft = 377

--- a/src/frames/foptionstoolseditor.lfm
+++ b/src/frames/foptionstoolseditor.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsEditor: TfrmOptionsEditor
   Height = 513
   Width = 601
+  HelpKeyword = '/configuration.html#ConfigToolsEditor'
   ClientHeight = 513
   ClientWidth = 601
   ParentShowHint = False

--- a/src/frames/foptionstooltips.lfm
+++ b/src/frames/foptionstooltips.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsToolTips: TfrmOptionsToolTips
   Height = 480
   Width = 826
+  HelpKeyword = '/configuration.html#ConfigTooltips'
   AutoSize = True
   ClientHeight = 480
   ClientWidth = 826

--- a/src/frames/foptionstreeviewmenu.lfm
+++ b/src/frames/foptionstreeviewmenu.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsTreeViewMenu: TfrmOptionsTreeViewMenu
   Height = 415
   Width = 590
+  HelpKeyword = '/configuration.html#ConfigTreeMenu'
   AutoSize = True
   ChildSizing.LeftRightSpacing = 6
   ChildSizing.TopBottomSpacing = 6

--- a/src/frames/foptionstreeviewmenucolor.lfm
+++ b/src/frames/foptionstreeviewmenucolor.lfm
@@ -1,6 +1,7 @@
 inherited frmOptionsTreeViewMenuColor: TfrmOptionsTreeViewMenuColor
   Height = 478
   Width = 600
+  HelpKeyword = '/configuration.html#ConfigTreeMenuColor'
   AutoSize = True
   ChildSizing.LeftRightSpacing = 6
   ChildSizing.TopBottomSpacing = 6


### PR DESCRIPTION
1. Added HelpKeywords for remaining pages.
2. Added Help button to show that you open Help. Button will be invisible when no HelpKeyword.
3. Some small changes: Default and Cancel for TAttributesEdit and change owner for calling from Option page (because when Position=poOwnerFormCenter the owner have to be properly set to avoid showing not at the center as it was before).
4. Remove now duplicate button in Hotlistdir.

Should I commit .po files? It's very difficult to compare. If should than as is or by merging only new important changes?