### PR TITLE
FIX: Drive list popup for Linux

### DIFF
--- a/src/platform/udrivewatcher.pas
+++ b/src/platform/udrivewatcher.pas
@@ -968,6 +968,7 @@ begin
             if (Drive = nil) then
             begin
               New(Drive);
+              FillChar(Drive^, SizeOf(TDrive), 0);
               UpdateDrive := False;
             end
             else begin

--- a/src/platform/udrivewatcher.pas
+++ b/src/platform/udrivewatcher.pas
@@ -509,7 +509,13 @@ begin
     Drive^.IsMediaRemovable := DeviceIsRemovable;
     Drive^.IsMounted := DeviceIsMounted;
     Drive^.AutoMount := (DeviceAutomountHint = EmptyStr) or (DeviceAutomountHint = 'always');
+
   end;
+
+  // DriveSize is not correct when Optical drive isn't mounted (at least in Linux)
+  with Drive^ do
+    if (DriveType = dtOptical) and not IsMounted then
+      DriveSize := 0;
 end;
 {$ENDIF}
 

--- a/src/platform/unix/linux/uudev.pas
+++ b/src/platform/unix/linux/uudev.pas
@@ -409,6 +409,8 @@ begin
     DeviceIsDrive:= (Value = UDEV_DEVICE_TYPE_DISK);
     DeviceIsPartition:= (Value = UDEV_DEVICE_TYPE_PARTITION);
 
+    DeviceIsRemovable := False;
+
     if DeviceIsDrive then
     begin
       DeviceIsPartitionTable:= (udev_device_get_property_value(Device, 'ID_PART_TABLE_TYPE' ) <> nil);

--- a/src/udriveslist.pas
+++ b/src/udriveslist.pas
@@ -591,8 +591,7 @@ begin
           Format('%s/%s', [cnvFormatFileSize(FreeSize, uoscHeader),
                            cnvFormatFileSize(TotalSize, uoscHeader)])
       end
-      else if IsAvailable(Drive, False) and
-         (Drive^.DriveSize > 0) then
+      else if (Drive^.DriveSize > 0) then
       begin
         Cells[4, RowNr] := cnvFormatFileSize(Drive^.DriveSize, uoscHeader);
       end

--- a/src/udriveslist.pas
+++ b/src/udriveslist.pas
@@ -591,7 +591,8 @@ begin
           Format('%s/%s', [cnvFormatFileSize(FreeSize, uoscHeader),
                            cnvFormatFileSize(TotalSize, uoscHeader)])
       end
-      else if (Drive^.DriveSize > 0) then
+      else if IsAvailable(Drive, False) and
+         (Drive^.DriveSize > 0) then
       begin
         Cells[4, RowNr] := cnvFormatFileSize(Drive^.DriveSize, uoscHeader);
       end


### PR DESCRIPTION
Correct total size for mounted network devices and non mounted [optical] drives.

P.S. Changes in uudev.pas is not necessary but I think it'll bring to error in the future.

May be there is better possibility to fix unmounted optical drive size but I think Linux returns not correct disk size.