### PR TITLE
FIX: AutoRefresh: update directory correctly in FlatView mode on MacOS

### DIFF
--- a/src/platform/ufilesystemwatcher.pas
+++ b/src/platform/ufilesystemwatcher.pas
@@ -999,7 +999,14 @@ begin
                   // FCurrentEventData.Path contains WatchPath
                   // so in FlatView Mode, Path need to be adjusted to the Real Path
                   if TFileView(UserData).FlatView then begin
-                    FCurrentEventData.Path := ExcludeTrailingPathDelimiter(ExtractFilePath(FCurrentEventData.OriginalEvent.fullPath));
+                    if ecDir in FCurrentEventData.OriginalEvent.categories then begin
+                      // in FlatView Mode, when receiving events about subdirectories,
+                      // WatchPath reload should be used instead of partial update
+                      FCurrentEventData.EventType:= fswUnknownChange;
+                      FCurrentEventData.Path := AWatchPath;
+                    end else begin
+                      FCurrentEventData.Path := ExcludeTrailingPathDelimiter(ExtractFilePath(FCurrentEventData.OriginalEvent.fullPath));
+                    end;
                   end else begin
                     if TDarwinFSWatchEventCategory.ecChildChanged in FCurrentEventData.OriginalEvent.categories then
                       // not watching SubDir, then SubDir event should be discarded

--- a/src/platform/unix/darwin/udarwinfswatch.pas
+++ b/src/platform/unix/darwin/udarwinfswatch.pas
@@ -48,6 +48,7 @@ type TDarwinFSWatchEventCategory = (
   ecAttribChanged, ecCoreAttribChanged, ecXattrChanged,
   ecStructChanged, ecCreated, ecRemoved, ecRenamed,
   ecRootChanged, ecChildChanged,
+  ecFile, ecDir,
   ecDropabled );
 
 type TDarwinFSWatchEventCategories = set of TDarwinFSWatchEventCategory;
@@ -207,6 +208,12 @@ begin
         _categories:= _categories + [ecChildChanged];
     end;
   end;
+
+  if (_rawEventFlags and kFSEventStreamEventFlagItemIsFile)<>0 then
+    _categories:= _categories + [ecFile];
+
+  if (_rawEventFlags and kFSEventStreamEventFlagItemIsDir)<>0 then
+    _categories:= _categories + [ecDir];
 
   if _categories * [ecAttribChanged,ecStructChanged,ecRootChanged] = [] then
     _categories:= [ecDropabled];


### PR DESCRIPTION
FIX: AutoRefresh: update directory correctly in FlatView mode on MacOS.

1.  in FlatView mode, AutoRefresh works incorrectly when the subdirectory added or renamed (on all OS)

2. the PR fix the issue on MacOS. when the subdirectory changed, Reload() the WatchPath