### PR TITLE
UPD: Auto shortcuts in the tree view

### DIFF
--- a/src/ftreeviewmenu.lfm
+++ b/src/ftreeviewmenu.lfm
@@ -74,7 +74,7 @@ object frmTreeViewMenu: TfrmTreeViewMenu
       OnMouseWheelDown = tvMainMenuMouseWheelDown
       OnMouseWheelUp = tvMainMenuMouseWheelUp
       OnSelectionChanged = tvMainMenuSelectionChanged
-      Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoHotTrack, tvoKeepCollapsedNodes, tvoReadOnly, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips, tvoThemedDraw]
+      Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoHotTrack, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips, tvoThemedDraw]
     end
     object edSearchingEntry: TEdit
       AnchorSideLeft.Control = pnlAll


### PR DESCRIPTION
When opening a tree view menu (e.g. Directory Hotlist), automatic shortcuts are not applied to the short text of the item name. This update fixes this behavior.

Before:
![002  2023 03 07 10-29](https://user-images.githubusercontent.com/5895768/223365491-cae2215f-1d11-4451-a72f-33cf4cf1df3b.png)

After:
![003  2023 03 07 10-30](https://user-images.githubusercontent.com/5895768/223365512-97d0c5a8-24c7-4ce5-83bd-3e1989bec8d0.png)
