### PR TITLE
FIX: COCOA: AutoComplete issue in IME input state in TCocoaWSCustomComboBoxEx

### DIFF
--- a/src/platform/unix/darwin/ucocoawidgetsetfix.pas
+++ b/src/platform/unix/darwin/ucocoawidgetsetfix.pas
@@ -1,3 +1,32 @@
+{
+   Double Commander
+   -------------------------------------------------------------------------
+   This unit contains specific DARWIN FSEvent functions.
+
+   Copyright (C) 2023 Alexander Koblov (alexx2000@mail.ru)
+   Copyright (C) 2023 Rich Chang (rich2014.git@outlook.com)
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+   Notes:
+   1. TCocoaWSCustomComboBoxEx disalbe AutoComplete currently.
+      it is a workaround for the bug of Lazarus related IME of Cocoa.
+      related codes can be removed after Lazarus merges related Patches.
+      see also:
+      https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/40008
+}
+
 unit uCocoaWidgetSetFix;
 
 {$mode delphi}
@@ -11,7 +40,7 @@ implementation
 
 uses
   Classes, SysUtils,
-  StdCtrls, WSLCLClasses, WSStdCtrls,
+  LCLType, Controls, StdCtrls, WSLCLClasses, WSStdCtrls,
   CocoaAll, CocoaWSStdCtrls;
 
 type
@@ -22,11 +51,21 @@ type
  private
    class function getNSText(const ACustomComboBox: TCustomComboBox): NSText;
  published
+   class function CreateHandle(const AWinControl: TWinControl;
+     const AParams: TCreateParams): TLCLIntfHandle; override;
    class function  GetSelStart(const ACustomComboBox: TCustomComboBox): integer; override;
    class function  GetSelLength(const ACustomComboBox: TCustomComboBox): integer; override;
    class procedure SetSelStart(const ACustomComboBox: TCustomComboBox; NewStart: integer); override;
    class procedure SetSelLength(const ACustomComboBox: TCustomComboBox; NewLength: integer); override;
  end;
+
+
+class function TCocoaWSCustomComboBoxEx.CreateHandle(const AWinControl: TWinControl;
+  const AParams: TCreateParams): TLCLIntfHandle;
+begin
+  TCustomComboBox(AWinControl).AutoComplete:= false;
+  Result:= Inherited;
+end;
 
 class function TCocoaWSCustomComboBoxEx.getNSText(const ACustomComboBox: TCustomComboBox): NSText;
 var


### PR DESCRIPTION
FIX: COCOA: AutoComplete issue in IME input state in TCocoaWSCustomComboBoxEx.

disable AutoComplete until Cocoa IME Patch merged.

https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/40008