### PR TITLE
FIX: file icon issue in FileProperties Form

### DIFF
--- a/src/ffileproperties.lfm
+++ b/src/ffileproperties.lfm
@@ -64,6 +64,7 @@ object frmFileProperties: TfrmFileProperties
             Height = 32
             Top = 0
             Width = 32
+            Stretch = True
           end
         end
         object lblFileName: TLabel

--- a/src/ffileproperties.pas
+++ b/src/ffileproperties.pas
@@ -174,6 +174,8 @@ begin
 end;
 
 constructor TfrmFileProperties.Create(AOwner: TComponent; aFileSource: IFileSource; theFiles: TFiles);
+var
+  size: Integer;
 begin
   FExif:= TExifReader.Create;
   FFileSource:= aFileSource;
@@ -183,8 +185,10 @@ begin
 
   inherited Create(AOwner);
 
-  imgFileIcon.Width:= gIconsSize;
-  imgFileIcon.Height:= gIconsSize;
+  size:= gIconsSize * round( Application.MainForm.GetCanvasScaleFactor );
+  if size > 48 then size:= 48;
+  imgFileIcon.Width:= size;
+  imgFileIcon.Height:= size;
 end;
 
 destructor TfrmFileProperties.Destroy;


### PR DESCRIPTION
FIX: file icon issue in FileProperties Form.

1. display file icon correctly

2. on Retina screen, display larger sized file icon (up to 48x48)

tested on MacOS 12 and Linux.