### PR TITLE
FIX: FileProperties would be incorrectly closed by Button "Skip this File"

### DIFF
--- a/src/ffileproperties.lfm
+++ b/src/ffileproperties.lfm
@@ -788,7 +788,6 @@ object frmFileProperties: TfrmFileProperties
     BorderSpacing.Bottom = 4
     Caption = 'Ski&p this file'
     Kind = bkIgnore
-    ModalResult = 5
     OnClick = btnSkipFileClick
     TabOrder = 4
   end


### PR DESCRIPTION
Form `FileProperties` would be incorrectly closed by Button `Skip this File`.

it' caused by the property `ModalResult` of the button, which was incorrectly set to mrIgnore before.