### PR TITLE
FIX: Key Return handled in TKASPathEdit.handleSpecialKeys()

### DIFF
--- a/components/KASToolBar/kaspathedit.pas
+++ b/components/KASToolBar/kaspathedit.pas
@@ -456,6 +456,7 @@ begin
       if Assigned(onKeyESCAPE) then onKeyESCAPE( self );
     end else begin
       if Assigned(onKeyRETURN) then onKeyRETURN( self );
+      Key:= 0;
     end;
   end;
 end;


### PR DESCRIPTION
after the Key `Return` handled in TKASPathEdit.handleSpecialKeys(), `Key` should be eaten.

otherwise `Return` may be handled again by the `Default` Button of the Form (eg. Form `TfrmOptionsFilePanelsColors`,`TfrmOptionsCustomColumns`)

tested on Windows 11, MacOS 12 and Linux.