### PR TITLE
ADD: Elevation delete to trash

### DIFF
--- a/language/doublecmd.be.po
+++ b/language/doublecmd.be.po
@@ -9798,6 +9798,10 @@ msgstr "для стварэння гэтага аб’екта:"
 msgid "to delete this object:"
 msgstr "для выдалення гэтага аб’екта:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "для атрымання атрыбутаў гэтага аб’екта:"

--- a/language/doublecmd.bg.po
+++ b/language/doublecmd.bg.po
@@ -10285,6 +10285,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.ca.po
+++ b/language/doublecmd.ca.po
@@ -10798,6 +10798,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.cs.po
+++ b/language/doublecmd.cs.po
@@ -9820,6 +9820,10 @@ msgstr "vytvoření objektu:"
 msgid "to delete this object:"
 msgstr "výmaz objektu:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "atributy objektu:"

--- a/language/doublecmd.da.po
+++ b/language/doublecmd.da.po
@@ -10842,6 +10842,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.de.po
+++ b/language/doublecmd.de.po
@@ -9984,6 +9984,10 @@ msgstr "um dieses Objekt zu erstellen:"
 msgid "to delete this object:"
 msgstr "um dieses Objekt zu löschen:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "um die Attribute zu erfragen von:"
@@ -14203,3 +14207,4 @@ msgstr "Eine Ersetzung hat nicht stattgefunden."
 #, object-pascal-format
 msgid "No setup named \"%s\""
 msgstr "Keine Einstellung namens »%s«"
+

--- a/language/doublecmd.el.po
+++ b/language/doublecmd.el.po
@@ -10019,6 +10019,10 @@ msgstr "για τη δημιουργία αυτού του αντικειμέν�
 msgid "to delete this object:"
 msgstr "για τη διαγραφή αυτού του αντικειμένου:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "για λήψη ιδιοτήτων αυτού του αντικειμένου:"

--- a/language/doublecmd.es.po
+++ b/language/doublecmd.es.po
@@ -9914,6 +9914,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.fr.po
+++ b/language/doublecmd.fr.po
@@ -10087,6 +10087,10 @@ msgstr "pour créer cet objet:"
 msgid "to delete this object:"
 msgstr "pour effacer cet objet:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "pour obtenir les attributs de cet objet:"

--- a/language/doublecmd.hr.po
+++ b/language/doublecmd.hr.po
@@ -10489,6 +10489,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.hu.po
+++ b/language/doublecmd.hu.po
@@ -10068,6 +10068,10 @@ msgstr "ennek az objektumnak a létrehozásához:"
 msgid "to delete this object:"
 msgstr "ennek az objektumnak a törléséhez:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "ezen objektum attribútumainak lekéréséhez:"

--- a/language/doublecmd.it.po
+++ b/language/doublecmd.it.po
@@ -10269,6 +10269,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.ja.po
+++ b/language/doublecmd.ja.po
@@ -10028,6 +10028,10 @@ msgstr "このオブジェクトを作成する:"
 msgid "to delete this object:"
 msgstr "このオブジェクトを削除する:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "このオブジェクトの属性を取得する:"

--- a/language/doublecmd.ko.po
+++ b/language/doublecmd.ko.po
@@ -10033,6 +10033,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.nb.po
+++ b/language/doublecmd.nb.po
@@ -10333,6 +10333,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.nl.po
+++ b/language/doublecmd.nl.po
@@ -9821,6 +9821,10 @@ msgstr "om dit object te maken:"
 msgid "to delete this object:"
 msgstr "om dit object te verwijderen:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "om attributen van dit object te krijgen:"

--- a/language/doublecmd.nn.po
+++ b/language/doublecmd.nn.po
@@ -10333,6 +10333,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.pl.po
+++ b/language/doublecmd.pl.po
@@ -9759,6 +9759,10 @@ msgstr "aby utworzyć ten obiekt:"
 msgid "to delete this object:"
 msgstr "aby usunąć ten obiekt:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "aby uzyskać atrybuty tego obiektu:"

--- a/language/doublecmd.pot
+++ b/language/doublecmd.pot
@@ -9790,6 +9790,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.pt.po
+++ b/language/doublecmd.pt.po
@@ -10126,6 +10126,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.pt_BR.po
+++ b/language/doublecmd.pt_BR.po
@@ -10241,6 +10241,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.ro.po
+++ b/language/doublecmd.ro.po
@@ -10113,6 +10113,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.ru.po
+++ b/language/doublecmd.ru.po
@@ -10055,6 +10055,10 @@ msgstr "для создания этого объекта:"
 msgid "to delete this object:"
 msgstr "для удаления этого объекта:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr "для удаления в корзину этого объекта:"
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "для получения атрибутов этого объекта:"

--- a/language/doublecmd.sk.po
+++ b/language/doublecmd.sk.po
@@ -10058,6 +10058,10 @@ msgstr "na vytvorenie tohto objektu:"
 msgid "to delete this object:"
 msgstr "na vymazanie tohto objektu:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "na získanie atribútov tohto objektu:"

--- a/language/doublecmd.sl.po
+++ b/language/doublecmd.sl.po
@@ -9911,6 +9911,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.sr.po
+++ b/language/doublecmd.sr.po
@@ -10306,6 +10306,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.sr@latin.po
+++ b/language/doublecmd.sr@latin.po
@@ -10308,6 +10308,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.tr.po
+++ b/language/doublecmd.tr.po
@@ -10483,6 +10483,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.uk.po
+++ b/language/doublecmd.uk.po
@@ -10140,6 +10140,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/language/doublecmd.zh_CN.po
+++ b/language/doublecmd.zh_CN.po
@@ -9868,6 +9868,10 @@ msgstr "创建这个对象:"
 msgid "to delete this object:"
 msgstr "删除这个对象:"
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr "获取此对象的属性:"

--- a/language/doublecmd.zh_TW.po
+++ b/language/doublecmd.zh_TW.po
@@ -10810,6 +10810,10 @@ msgstr ""
 msgid "to delete this object:"
 msgstr ""
 
+#: uadministrator.rselevationrequireddeletetotrash
+msgid "to delete to trash this object:"
+msgstr ""
+
 #: uadministrator.rselevationrequiredgetattributes
 msgid "to get attributes of this object:"
 msgstr ""

--- a/src/doublecmd.lpi
+++ b/src/doublecmd.lpi
@@ -307,7 +307,7 @@ end;"/>
         <PackageName Value="Image32"/>
       </Item13>
     </RequiredPackages>
-    <Units Count="269">
+    <Units Count="270">
       <Unit0>
         <Filename Value="doublecmd.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -1972,6 +1972,11 @@ end;"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="uDarwinFSWatch"/>
       </Unit268>
+      <Unit269>
+        <Filename Value="platform\uurihandling.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="uURIHandling"/>
+      </Unit269>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/doublecmd.lpi
+++ b/src/doublecmd.lpi
@@ -1208,6 +1208,7 @@ end;"/>
       <Unit138>
         <Filename Value="filesources\filesystem\ufilesystemcalcstatisticsoperation.pas"/>
         <IsPartOfProject Value="True"/>
+        <UnitName Value="uFileSystemCalcStatisticsOperation"/>
       </Unit138>
       <Unit139>
         <Filename Value="filesources\filesystem\ufilesystemcombineoperation.pas"/>

--- a/src/filesources/filesystem/ufilesystemdeleteoperation.pas
+++ b/src/filesources/filesystem/ufilesystemdeleteoperation.pas
@@ -59,7 +59,7 @@ type
 implementation
 
 uses
-  DCOSUtils, DCStrUtils, uLng, uFileSystemUtil, uTrash, uAdministrator
+  DCOSUtils, DCStrUtils, uLng, uFileSystemUtil, uAdministrator
 {$IF DEFINED(MSWINDOWS)}
   , Windows,  uFileUnlock, fFileUnlock, uSuperUser
 {$ENDIF}

--- a/src/platform/uClipboard.pas
+++ b/src/platform/uClipboard.pas
@@ -22,17 +22,6 @@ uses
   function PasteFromClipboard(out ClipboardOp: TClipboardOperation;
                               out filenames:TStringList):Boolean;
 
-  function URIDecode(encodedUri: String): String;
-  function URIEncode(path: String): String;
-
-{$IF DEFINED(UNIX_not_DARWIN)}
-  function ExtractFilenames(uriList: String): TStringList;
-  function FileNameToURI(const FileName: String): String;
-
-  function FormatUriList(FileNames: TStringList): String;
-  function FormatTextPlain(FileNames: TStringList): String;
-{$ENDIF}
-
   procedure ClearClipboard;
   procedure ClipboardSetText(AText: String);
 
@@ -110,7 +99,7 @@ uses
 {$IF DEFINED(MSWINDOWS)}
   Clipbrd, Windows, ActiveX, uOleDragDrop, fMain, uShellContextMenu, uOSForms
 {$ELSEIF DEFINED(UNIX_not_DARWIN)}
-  Clipbrd, LCLIntf
+  Clipbrd, LCLIntf, uURIHandling
 {$ELSEIF DEFINED(DARWIN)}
   DCStrUtils, CocoaAll, CocoaUtils, uMyDarwin
 {$ENDIF}
@@ -143,83 +132,6 @@ begin
 {$ENDIF}
 
 end;
-
-{ Changes all '%XX' to bytes (XX is a hex number). }
-function URIDecode(encodedUri: String): String;
-var
-  i, oldIndex: Integer;
-  len: Integer;
-begin
-  len := Length(encodedUri);
-  Result := '';
-
-  oldIndex := 1;
-  i := 1;
-  while i <= len-2 do // must be at least 2 more characters after '%'
-  begin
-    if encodedUri[i] = '%' then
-    begin
-      Result := Result + Copy(encodedUri, oldIndex, i-oldIndex)
-                       + Chr(StrToInt('$' + Copy(encodedUri, i+1, 2)));
-      i := i + 3;
-      oldIndex := i;
-    end
-    else
-      Inc(i);
-  end;
-
-  Result := Result + Copy(encodedUri, oldIndex, len - oldIndex + 1 );
-end;
-
-{ Escapes forbidden characters to '%XX' (XX is a hex number). }
-function URIEncode(path: String): String;
-const
-{
-  Per RFC-3986, what's allowed in uri-encoded path.
-
-  path-absolute = "/" [ segment-nz *( "/" segment ) ]
-  segment       = *pchar
-  segment-nz    = 1*pchar
-  pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"      <--
-  pct-encoded   = "%" HEXDIG HEXDIG
-  unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
-  reserved      = gen-delims / sub-delims
-  gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
-  sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
-                / "*" / "+" / "," / ";" / "="
-
-  We'll also allow "/" in pchar, because it happens to also be the OS path delimiter.
-}
-  allowed : set of char
-          = [ '-', '.', '_', '~', // 'A'..'Z', 'a'..'z', '0'..'9',
-              '!', '$', '&', #39 {'}, '(', ')', '*', '+', ',', ';', '=',
-              ':', '@', '/' ];
-var
-  i, oldIndex: Integer;
-  len: Integer;
-begin
-  len := Length(path);
-  Result := '';
-
-  oldIndex := 1;
-  i := 1;
-  for i := 1 to len do
-  begin
-    if not ((path[i] >= 'a') and (path[i] <= 'z')) and
-       not ((path[i] >= 'A') and (path[i] <= 'Z')) and
-       not ((path[i] >= '0') and (path[i] <= '9')) and
-       not (path[i] in allowed) then
-    begin
-      Result := Result + Copy(path, oldIndex, i-oldIndex)
-                       + '%' + Format('%2x', [Ord(path[i])]);
-
-      oldIndex := i + 1;
-    end;
-  end;
-
-  Result := Result + Copy(path, oldIndex, len - oldIndex + 1 );
-end;
-
 
 {$IFDEF UNIX_not_DARWIN}
 { Extracts a path from URI }
@@ -257,88 +169,6 @@ begin
   end
   else
     Result := '';
-end;
-
-{ Retrieves file names delimited by line ending characters. }
-function ExtractFilenames(uriList: String): TStringList;
-var
-  i, oldIndex: Integer;
-  len: Integer;
-  path: String;
-begin
-  // Format should be:      file://hostname/path/to/file
-  // Hostname may be empty.
-
-  len := Length(uriList);
-  Result := TStringList.Create;
-
-  // For compatibility with apps that end the string with zero.
-  while (len > 0) and (uriList[len] = #0) do Dec(len);
-  if len = 0 then Exit;
-
-  oldIndex := 1;
-  for i := 1 to len do
-  begin
-    // Search for the end of line.
-    if uriList[i] in [ #10, #13 ] then
-    begin
-      if i > oldIndex then
-      begin
-        path := ExtractPath(Copy(uriList, oldIndex, i - oldIndex));
-        if Length(path) > 0 then
-          Result.Add(path);
-      end;
-
-      oldIndex := i + 1;
-    end
-  end;
-
-  if i >= oldIndex then
-  begin
-    // copy including 'i'th character
-    path := ExtractPath(Copy(uriList, oldIndex, i - oldIndex + 1));
-    if Length(path) > 0 then
-      Result.Add(path);
-  end;
-end;
-
-function FileNameToURI(const FileName: String): String;
-begin
-  Result := fileScheme + '//' + URIEncode(FileName);
-end;
-
-function FormatUriList(FileNames: TStringList): String;
-var
-  i : integer;
-begin
-  Result := '';
-  for i := 0 to filenames.Count-1 do
-  begin
-    // Separate previous uris with line endings,
-    // but do not end the whole string with it.
-    if i > 0 then
-      Result := Result + LineEnding;
-
-    Result := Result
-            + fileScheme + '//'  { don't put hostname }
-            + URIEncode(filenames[i]);
-  end;
-end;
-
-function FormatTextPlain(FileNames: TStringList): String;
-var
-  i : integer;
-begin
-  Result := '';
-  for i := 0 to filenames.Count-1 do
-  begin
-    if i > 0 then
-      Result := Result + LineEnding;
-
-    Result := Result
-            + fileScheme + '//'  { don't put hostname }
-            + filenames[i];
-  end;
 end;
 
 function GetClipboardFormatAsString(formatId: TClipboardFormat): String;

--- a/src/platform/uOSUtils.pas
+++ b/src/platform/uOSUtils.pas
@@ -30,7 +30,7 @@ unit uOSUtils;
 interface
 
 uses
-    SysUtils, Classes, LCLType, uDrive, DCBasicTypes, uFindEx
+    SysUtils, Classes, LCLType, uDrive, DCBasicTypes
     {$IF DEFINED(UNIX)}
     , DCFileAttributes
       {$IFDEF DARWIN}
@@ -88,11 +88,6 @@ const
   termClose=False;
 type
   tTerminalEndindMode = boolean;
-
-  EInvalidCommandLine = class(Exception);
-  EInvalidQuoting = class(EInvalidCommandLine)
-    constructor Create; reintroduce;
-  end;
 
 {$IF DEFINED(MSWINDOWS) and DEFINED(FPC_HAS_CPSTRING)}
   NativeString = UnicodeString;
@@ -192,7 +187,7 @@ implementation
 
 uses
   StrUtils, uFileProcs, FileUtil, uDCUtils, DCOSUtils, DCStrUtils, uGlobs, uLng,
-  fConfirmCommandLine, uLog, DCConvertEncoding, LazUTF8, uSysFolders
+  fConfirmCommandLine, uLog, DCConvertEncoding, LazUTF8
   {$IF DEFINED(MSWINDOWS)}
   , Windows, uMyWindows, JwaWinNetWk,
     uShlObjAdditional, DCWindows, uNetworkThread
@@ -202,7 +197,7 @@ uses
     {$IF DEFINED(DARWIN)}
   , CocoaAll, uMyDarwin
     {$ELSEIF NOT DEFINED(HAIKU)}
-  , uGio, uClipboard, uXdg, uKde
+  , uGio, uClipboard, uKde
     {$ENDIF}
     {$IF DEFINED(LINUX)}
   , DCUnix, uMyLinux
@@ -801,13 +796,6 @@ begin
   Result:= Param;
 end;
 {$ENDIF}
-
-{ EInvalidQuoting }
-
-constructor EInvalidQuoting.Create;
-begin
-  inherited Create(rsMsgInvalidQuoting);
-end;
 
 { GetCurrentUserName }
 function GetCurrentUserName : String;

--- a/src/platform/udragdropgtk.pas
+++ b/src/platform/udragdropgtk.pas
@@ -89,7 +89,7 @@ type
 implementation
 
 uses
-  uClipboard;     // URI handling
+  uURIHandling;     // URI handling
 
 
 type

--- a/src/platform/unix/umyunix.pas
+++ b/src/platform/unix/umyunix.pas
@@ -110,12 +110,6 @@ function FileIsLinkToFolder(const FileName: String; out LinkTarget: String): Boo
    @returns(The function returns @true if successful, @false otherwise)
 }
 function FileIsUnixExecutable(const Filename: String): Boolean;
-{en
-   Find mount point of file system where file is located
-   @param(FileName File name)
-   @returns(Mount point of file system)
-}
-function FindMountPointPath(const FileName: String): String;
 function FindExecutableInSystemPath(var FileName: String): Boolean;
 function ExecutableInSystemPath(const FileName: String): Boolean;
 function GetDefaultAppCmd(const FileName: String): String;
@@ -168,8 +162,8 @@ implementation
 
 uses
   URIParser, Unix, Process, LazUTF8, DCOSUtils, DCClassesUtf8, DCStrUtils,
-  DCUnix, uDCUtils, uOSUtils
-{$IF (NOT DEFINED(FPC_USE_LIBC)) or (DEFINED(BSD) AND NOT DEFINED(DARWIN))}
+  DCUnix, uDCUtils
+{$IF (NOT DEFINED(FPC_USE_LIBC) AND NOT DEFINED(LINUX)) or (DEFINED(BSD) AND NOT DEFINED(DARWIN))}
   , SysCall
 {$ENDIF}
 {$IF NOT (DEFINED(DARWIN) OR DEFINED(HAIKU))}
@@ -301,49 +295,6 @@ begin
     Result:= False;
   end;
 end;
-
-function FindMountPointPath(const FileName: String): String;
-var
-  I, J: LongInt;
-  sTemp: String;
-  recStat: Stat;
-  st_dev: QWord;
-begin
-  // Set root directory as mount point by default
-  Result:= PathDelim;
-  // Get stat info for original file
-  if (fpLStat(UTF8ToSys(FileName), recStat) < 0) then Exit;
-  // Save device ID of original file
-  st_dev:= recStat.st_dev;
-  J:= Length(FileName);
-  for I:= J downto 1 do
-  begin
-    if FileName[I] = PathDelim then
-    begin
-      if (I = 1) then
-        sTemp:= PathDelim
-      else
-        sTemp:= Copy(FileName, 1, I - 1);
-      // Stat for current directory
-      if (fpLStat(UTF8ToSys(sTemp), recStat) < 0) then Continue;
-      // If it is a link then checking link destination
-      if fpS_ISLNK(recStat.st_mode) then
-      begin
-        sTemp:= ReadSymLink(sTemp);
-        Result:= FindMountPointPath(sTemp);
-        Exit;
-      end;
-      // Check device ID
-      if (recStat.st_dev <> st_dev) then
-      begin
-        Result:= Copy(FileName, 1, J);
-        Exit;
-      end;
-      J:= I;
-    end;
-  end;
-end;
-
 function FindExecutableInSystemPath(var FileName: String): Boolean;
 var
   I: Integer;

--- a/src/platform/uurihandling.pas
+++ b/src/platform/uurihandling.pas
@@ -1,0 +1,229 @@
+unit uURIHandling;
+
+{$mode ObjFPC}{$H+}
+
+{$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
+  {$Define UNIX_not_DARWIN}
+{$ENDIF}
+
+interface
+
+uses
+  Classes, SysUtils;
+
+  function URIDecode(encodedUri: String): String;
+  function URIEncode(const path: String): String;
+
+  {$IF DEFINED(UNIX_not_DARWIN)}
+  function ExtractFilenames(uriList: String): TStringList;
+  function FileNameToURI(const FileName: String): String;
+
+  function FormatUriList(FileNames: TStringList): String;
+  function FormatTextPlain(FileNames: TStringList): String;
+  {$ENDIF}
+
+const
+  fileScheme      = 'file:';   // for URI
+  // General MIME
+  uriListMime     = 'text/uri-list';
+  textPlainMime   = 'text/plain';
+
+
+implementation
+
+{ Changes all '%XX' to bytes (XX is a hex number). }
+function URIDecode(encodedUri: String): String;
+var
+  i, oldIndex: Integer;
+  len: Integer;
+begin
+  len := Length(encodedUri);
+  Result := '';
+
+  oldIndex := 1;
+  i := 1;
+  while i <= len-2 do // must be at least 2 more characters after '%'
+  begin
+    if encodedUri[i] = '%' then
+    begin
+      Result := Result + Copy(encodedUri, oldIndex, i-oldIndex)
+                       + Chr(StrToInt('$' + Copy(encodedUri, i+1, 2)));
+      i := i + 3;
+      oldIndex := i;
+    end
+    else
+      Inc(i);
+  end;
+
+  Result := Result + Copy(encodedUri, oldIndex, len - oldIndex + 1 );
+end;
+
+{ Escapes forbidden characters to '%XX' (XX is a hex number). }
+function URIEncode(const path: String): String;
+const
+{
+  Per RFC-3986, what's allowed in uri-encoded path.
+
+  path-absolute = "/" [ segment-nz *( "/" segment ) ]
+  segment       = *pchar
+  segment-nz    = 1*pchar
+  pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"      <--
+  pct-encoded   = "%" HEXDIG HEXDIG
+  unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+  reserved      = gen-delims / sub-delims
+  gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+  sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+                / "*" / "+" / "," / ";" / "="
+
+  We'll also allow "/" in pchar, because it happens to also be the OS path delimiter.
+}
+  allowed : set of char
+          = [ 'A'..'Z', 'a'..'z', '0'..'9', '-', '.', '_', '~',
+              '!', '$', '&', '''' {'}, '(', ')', '*', '+', ',', ';', '=',
+              ':', '@', '/' ];
+var
+  i, oldIndex: Integer;
+  len: Integer;
+begin
+  len := Length(path);
+  Result := '';
+
+  oldIndex := 1;
+  for i := 1 to len do
+  begin
+    if not (path[i] in allowed) then
+    begin
+      Result := Result + Copy(path, oldIndex, i-oldIndex)
+                       + '%' + Format('%2x', [Ord(path[i])]);
+
+      oldIndex := i + 1;
+    end;
+  end;
+
+  Result := Result + Copy(path, oldIndex, len - oldIndex + 1 );
+end;
+
+
+{$IFDEF UNIX_not_DARWIN}
+{ Extracts a path from URI }
+function ExtractPath(uri: String): String;
+var
+  len: Integer;
+  i, j: Integer;
+begin
+  len := Length(uri);
+  if (len >= Length(fileScheme)) and
+     (CompareChar(uri[1], fileScheme, Length(fileScheme)) = 0) then
+  begin
+    i := 1 + Length(fileScheme);
+
+    // Omit case where we would have a root-less path - it is useless to us.
+    if (i <= len) and (uri[i] = '/') then
+    begin
+      // Check if we have a: - "//" authority - part.
+      if (i+1 <= len) and (uri[i+1] = '/') then
+      begin
+        // Authority (usually a hostname) may be empty.
+        for j := i + 2 to len do
+          if uri[j] = '/' then
+          begin
+            Result := Copy(uri, j, len - j + 1);
+            Break;
+          end;
+      end
+      else
+      begin
+        // We have only a path.
+        Result := Copy(uri, i, len - i + 1);
+      end;
+    end;
+  end
+  else
+    Result := '';
+end;
+
+{ Retrieves file names delimited by line ending characters. }
+function ExtractFilenames(uriList: String): TStringList;
+var
+  i, oldIndex: Integer;
+  len: Integer;
+  path: String;
+begin
+  // Format should be:      file://hostname/path/to/file
+  // Hostname may be empty.
+
+  len := Length(uriList);
+  Result := TStringList.Create;
+
+  // For compatibility with apps that end the string with zero.
+  while (len > 0) and (uriList[len] = #0) do Dec(len);
+  if len = 0 then Exit;
+
+  oldIndex := 1;
+  for i := 1 to len do
+  begin
+    // Search for the end of line.
+    if uriList[i] in [ #10, #13 ] then
+    begin
+      if i > oldIndex then
+      begin
+        path := ExtractPath(Copy(uriList, oldIndex, i - oldIndex));
+        if Length(path) > 0 then
+          Result.Add(path);
+      end;
+
+      oldIndex := i + 1;
+    end
+  end;
+
+  if i >= oldIndex then
+  begin
+    // copy including 'i'th character
+    path := ExtractPath(Copy(uriList, oldIndex, i - oldIndex + 1));
+    if Length(path) > 0 then
+      Result.Add(path);
+  end;
+end;
+
+function FileNameToURI(const FileName: String): String;
+begin
+  Result := fileScheme + '//' + URIEncode(FileName);
+end;
+
+function FormatUriList(FileNames: TStringList): String;
+var
+  i : integer;
+begin
+  Result := '';
+  for i := 0 to filenames.Count-1 do
+  begin
+    // Separate previous uris with line endings,
+    // but do not end the whole string with it.
+    if i > 0 then
+      Result := Result + LineEnding;
+
+    Result := Result
+            + fileScheme + '//'  { don't put hostname }
+            + URIEncode(filenames[i]);
+  end;
+end;
+
+function FormatTextPlain(FileNames: TStringList): String;
+var
+  i : integer;
+begin
+  Result := '';
+  for i := 0 to filenames.Count-1 do
+  begin
+    if i > 0 then
+      Result := Result + LineEnding;
+
+    Result := Result
+            + fileScheme + '//'  { don't put hostname }
+            + filenames[i];
+  end;
+end;
+{$ENDIF}
+
+end.
+

--- a/src/rpc/uadministrator.pas
+++ b/src/rpc/uadministrator.pas
@@ -301,7 +301,7 @@ var
   LastError: Integer;
 begin
   Result:= mbDeleteToTrash(FileName);
-  if not Result {and ElevationRequired }then
+  if not Result and ElevationRequired then
   begin
     LastError:= GetLastOSError;
     if RequestElevation(rsElevationRequiredDeleteToTrash, FileName) then

--- a/src/rpc/uadministrator.pas
+++ b/src/rpc/uadministrator.pas
@@ -28,6 +28,7 @@ function FileCopyUAC(const Source, Target: String; Options: UInt32;
                      UpdateProgress: TFileCopyProgress; UserData: Pointer): Boolean;
 
 function DeleteFileUAC(const FileName: String): LongBool;
+function DeleteToTrashFileUAC(const FileName: String): LongBool;
 function RenameFileUAC(const OldName, NewName: String): LongBool;
 
 function FindFirstUAC(const Path: String; Flags: UInt32; out SearchRec: TSearchRecEx): Integer;
@@ -65,12 +66,13 @@ threadvar
 implementation
 
 uses
-  RtlConsts, DCStrUtils, LCLType, uShowMsg, uElevation, uSuperUser,
+  RtlConsts, DCStrUtils, LCLType, uShowMsg, uElevation, uSuperUser, uTrash,
   fElevation;
 
 resourcestring
   rsElevationRequired = 'You need to provide administrator permission';
   rsElevationRequiredDelete = 'to delete this object:';
+  rsElevationRequiredDeleteToTrash = 'to delete to trash this object:';
   rsElevationRequiredOpen = 'to open this object:';
   rsElevationRequiredCopy = 'to copy this object:';
   rsElevationRequiredCreate = 'to create this object:';
@@ -289,6 +291,21 @@ begin
     LastError:= GetLastOSError;
     if RequestElevation(rsElevationRequiredDelete, FileName) then
       Result:= TWorkerProxy.Instance.DeleteFile(FileName)
+    else
+      SetLastOSError(LastError);
+  end;
+end;
+
+function DeleteToTrashFileUAC(const FileName: String): LongBool;
+var
+  LastError: Integer;
+begin
+  Result:= mbDeleteToTrash(FileName);
+  if not Result {and ElevationRequired }then
+  begin
+    LastError:= GetLastOSError;
+    if RequestElevation(rsElevationRequiredDeleteToTrash, FileName) then
+      Result:= TWorkerProxy.Instance.DeleteToTrashFile(FileName)
     else
       SetLastOSError(LastError);
   end;

--- a/src/rpc/uservice.pas
+++ b/src/rpc/uservice.pas
@@ -11,6 +11,7 @@ type
 
   TRPC_Commands = (
     RPC_Terminate,          //  = 0;
+    RPC_Execute,            // master = 1;
     RPC_FileOpen,           // = 1;
     RPC_FileCreate,         // = 2;
     RPC_DeleteFile,         // = 3;
@@ -30,7 +31,6 @@ type
     RPC_FindNext,           // = 17;
     RPC_FindClose,          // = 18;
     RPC_FileCopy,           // = 19;
-    RPC_Execute,            // master = 1;
     RPC_DeleteToTrashFile
     );
 

--- a/src/rpc/uservice.pas
+++ b/src/rpc/uservice.pas
@@ -9,6 +9,32 @@ uses
 
 type
 
+  TRPC_Commands = (
+    RPC_Terminate,          //  = 0;
+    RPC_FileOpen,           // = 1;
+    RPC_FileCreate,         // = 2;
+    RPC_DeleteFile,         // = 3;
+    RPC_RenameFile,         // = 4;
+    RPC_CreateDirectory,    // = 5;
+    RPC_RemoveDirectory,    // = 6;
+    RPC_CreateSymbolicLink, // = 7;
+    RPC_CreateHardLink,     // = 8;
+    RPC_FileExists,         // = 9;
+    RPC_FileGetAttr,        // = 10;
+    RPC_FileSetAttr,        // = 11;
+    RPC_FileSetTime,        // = 12;
+    RPC_DirectoryExists,    // = 13;
+    RPC_FileSetReadOnly,    // = 14;
+    RPC_FileCopyAttr,       // = 15;
+    RPC_FindFirst,          // = 16;
+    RPC_FindNext,           // = 17;
+    RPC_FindClose,          // = 18;
+    RPC_FileCopy,           // = 19;
+    RPC_Execute,            // master = 1;
+    RPC_DeleteToTrashFile
+    );
+
+
   { TBaseTransport }
 
   TBaseTransport = class
@@ -31,7 +57,7 @@ type
     FVerifyParent: Boolean;
     FServerThread: TThread;
   protected
-    procedure ProcessRequest(ATransport: TBaseTransport; ACommand: Int32; ARequest: TStream); virtual; abstract;
+    procedure ProcessRequest(ATransport: TBaseTransport; const ACommand: TRPC_Commands; ARequest: TStream); virtual; abstract;
   public
     constructor Create(const AName: String); virtual;
     destructor Destroy; override;
@@ -52,7 +78,7 @@ type
     FOwner : TBaseService;
     FTransport: TBaseTransport;
   protected
-    function ReadRequest(ARequest : TMemoryStream; var ACommand : LongInt): Integer;
+    function ReadRequest(ARequest : TMemoryStream; out ACommand : TRPC_Commands): Integer;
     procedure SendResponse(AResponse : TMemoryStream);
   public
     procedure Execute; override;
@@ -118,7 +144,7 @@ end;
 { TClientThread }
 
 function TClientThread.ReadRequest(ARequest: TMemoryStream;
-  var ACommand: LongInt): Integer;
+  out ACommand: TRPC_Commands): Integer;
 var
   R: Int64;
   ALength : Int32 = 0;
@@ -146,7 +172,7 @@ end;
 
 procedure TClientThread.Execute;
 var
-  ACommand : Int32 = 0;
+  ACommand : TRPC_Commands;// = 0;
   ARequest : TMemoryStream;
 begin
   InterLockedIncrement(FOwner.ClientCount);

--- a/src/rpc/uworker.pas
+++ b/src/rpc/uworker.pas
@@ -7,20 +7,32 @@ interface
 uses
   Classes, SysUtils, SyncObjs, uService;
 
-const
-  RPC_Execute     = 1;
+{const
+  RPC_Execute     = 1;}
 
 type
 
-  { TMasterService }
+{type
+  RPC_Commands = (RPC_Terminate, RPC_FileOpen, RPC_FileCreate,
+    RPC_DeleteFile, RPC_RenameFile, RPC_CreateDirectory,
+    RPC_RemoveDirectory, RPC_CreateSymbolicLink, RPC_CreateHardLink
+    RPC_FileExists, RPC_FileGetAttr, RPC_FileSetAttr,
+    RPC_FileSetTime, RPC_DirectoryExists
+  RPC_FileSetReadOnly = 14;
+  RPC_FileCopyAttr = 15;
 
-  TMasterService = class(TBaseService)
-  public
-    constructor Create(const AName: String); override;
-    procedure ProcessRequest(ATransport: TBaseTransport; ACommand: Int32; ARequest: TStream); override;
-  end;
+  RPC_FileCopy = 19;
 
-const
+  RPC_FindFirst = 16;
+  RPC_FindNext = 17;
+  RPC_FindClose = 18;
+
+   = 8;
+   = 7;
+
+  RPC_DirectoryExists = 13; }
+
+{const
   RPC_Terminate  = 0;
   RPC_FileOpen   = 1;
   RPC_FileCreate = 2;
@@ -44,16 +56,22 @@ const
 
   RPC_CreateDirectory = 5;
   RPC_RemoveDirectory = 6;
-  RPC_DirectoryExists = 13;
+  RPC_DirectoryExists = 13;}
 
-type
+  { TMasterService }
+
+  TMasterService = class(TBaseService)
+  public
+    constructor Create(const AName: String); override;
+    procedure ProcessRequest(ATransport: TBaseTransport; const ACommand: TRPC_Commands; ARequest: TStream); override;
+  end;
 
   { TWorkerService }
 
   TWorkerService = class(TBaseService)
   public
     constructor Create(const AName: String); override;
-    procedure ProcessRequest(ATransport: TBaseTransport; ACommand: Int32; ARequest: TStream); override;
+    procedure ProcessRequest(ATransport: TBaseTransport; const ACommand: TRPC_Commands; ARequest: TStream); override;
   end;
 
 var
@@ -62,7 +80,7 @@ var
 implementation
 
 uses
-  DCBasicTypes, DCOSUtils, uFindEx, uDebug, uFileCopyEx;
+  DCBasicTypes, DCOSUtils, uFindEx, uDebug, uFileCopyEx, uTrash;
 
 function FileCopyProgress(TotalBytes, DoneBytes: Int64; UserData: Pointer): LongBool;
 var
@@ -83,7 +101,7 @@ begin
   Self.FVerifyChild:= True;
 end;
 
-procedure TMasterService.ProcessRequest(ATransport: TBaseTransport; ACommand: Int32;
+procedure TMasterService.ProcessRequest(ATransport: TBaseTransport; const ACommand: TRPC_Commands;
   ARequest: TStream);
 var
   Result: LongBool = True;
@@ -106,7 +124,7 @@ begin
   Self.FVerifyParent:= True;
 end;
 
-procedure TWorkerService.ProcessRequest(ATransport: TBaseTransport; ACommand: Int32;
+procedure TWorkerService.ProcessRequest(ATransport: TBaseTransport; const ACommand: TRPC_Commands;
   ARequest: TStream);
 const
   FIND_MAX = 512;
@@ -144,6 +162,15 @@ begin
       FileName:= ARequest.ReadAnsiString;
       DCDebug('DeleteFile ', FileName);
       Result:= mbDeleteFile(FileName);
+      LastError:= GetLastOSError;
+      ATransport.WriteBuffer(Result, SizeOf(Result));
+      ATransport.WriteBuffer(LastError, SizeOf(LastError));
+    end;
+  RPC_DeleteToTrashFile:
+    begin
+      FileName:= ARequest.ReadAnsiString;
+      DCDebug('DeleteToTrashFile ', FileName);
+      Result:= mbDeleteToTrash(FileName);
       LastError:= GetLastOSError;
       ATransport.WriteBuffer(Result, SizeOf(Result));
       ATransport.WriteBuffer(LastError, SizeOf(LastError));

--- a/src/ucmdlineparams.pas
+++ b/src/ucmdlineparams.pas
@@ -26,7 +26,7 @@ implementation
 
 uses
   Forms, Dialogs, SysUtils, uOSUtils, uDCUtils, uGlobsPaths, getopts, uDebug,
-  uLng, uClipboard, DCStrUtils;
+  uLng, uURIHandling, DCStrUtils;
 
 function DecodePath(const Path: String): String;
 begin

--- a/src/udcutils.pas
+++ b/src/udcutils.pas
@@ -60,6 +60,15 @@ const
 type
   TUsageOfSizeConversion = (uoscFile, uoscHeader, uoscFooter, uoscOperation);
 
+  EInvalidCommandLine = class(Exception);
+
+  { EInvalidQuoting }
+
+  EInvalidQuoting = class(EInvalidCommandLine)
+    constructor Create; reintroduce;
+  end;
+
+
 function GetCmdDirFromEnvVar(const sPath : String) : String;
 function SetCmdDirAsEnvVar(const sPath : String) : String;
 {en
@@ -248,7 +257,7 @@ procedure DCPlaceCursorNearControlIfNecessary(AControl: TControl);
 implementation
 
 uses
-  uLng, LCLProc, LCLType, uMasks, FileUtil, StrUtils, uOSUtils, uGlobs, uGlobsPaths,
+  uLng, LCLProc, LCLType, uMasks, FileUtil, StrUtils, uGlobs, uGlobsPaths,
   DCStrUtils, DCOSUtils, DCConvertEncoding, LazUTF8
 {$IF DEFINED(MSWINDOWS)}
   , Windows
@@ -1356,6 +1365,13 @@ begin
   ptControlCenter := AControl.ClientToScreen(Classes.Point(AControl.Width div 2, AControl.Height div 2));
   if (abs(Mouse.CursorPos.x - ptControlCenter.x) > (AControl.Width div 2)) or  (abs(Mouse.CursorPos.y - ptControlCenter.y) > (AControl.Height div 2)) then
     Mouse.CursorPos := Classes.Point((ptControlCenter.x + (AControl.width div 2)) - 10, ptControlCenter.y);
+end;
+
+{ EInvalidQuoting }
+
+constructor EInvalidQuoting.Create;
+begin
+  inherited Create(rsMsgInvalidQuoting);
 end;
 
 end.

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -2517,8 +2517,8 @@ begin
     BoolValue := bRecycle;
 
     if bRecycle then
-      bRecycle := FileSource.IsClass(TFileSystemFileSource) and
-                  mbCheckTrash(CurrentPath);
+      bRecycle := FileSource.IsClass(TFileSystemFileSource){$IF DEFINED(MSWINDOWS)} and
+                  mbCheckTrash(CurrentPath){$ENDIF};
 
     if not HasConfirmationParam then
     begin


### PR DESCRIPTION
It tested in Windows 10 and Ubuntu 22.04. I had to separate some functions to uURIHandling and other changes for Linux.

Also I changed default behavior for Windows: it allow to trash only if a registry value equal some value and default not - it's right for network drives for example.

Also I want to add checking on Windows for size of removing files. Because DC could show information about impossibility to trash files more than max size for trash on this disk.