### PR TITLE
FIX: key ESC/RETURN handled in Options Dialog & KasPathEdit

### DIFF
--- a/components/KASToolBar/kaspathedit.pas
+++ b/components/KASToolBar/kaspathedit.pas
@@ -453,10 +453,15 @@ begin
     Key:= 0;
   end else begin
     if Key=VK_ESCAPE then begin
-      if Assigned(onKeyESCAPE) then onKeyESCAPE( self );
+      if Assigned(onKeyESCAPE) then begin
+        onKeyESCAPE( self );
+        Key:= 0;
+      end;
     end else begin
-      if Assigned(onKeyRETURN) then onKeyRETURN( self );
-      Key:= 0;
+      if Assigned(onKeyRETURN) then begin
+        onKeyRETURN( self );
+        Key:= 0;
+      end;
     end;
   end;
 end;

--- a/src/foptions.lfm
+++ b/src/foptions.lfm
@@ -151,6 +151,7 @@ object frmOptions: TfrmOptions
       AutoSize = True
       BorderSpacing.Right = 8
       BorderSpacing.InnerBorder = 2
+      Cancel = True
       Caption = '&Cancel'
       Kind = bkCancel
       ModalResult = 2
@@ -778,13 +779,5 @@ object frmOptions: TfrmOptions
       D73DE4F08A7C2E3B4F73707845BE85C5CDFB5C86B81C38129CE8B72873DD607D
       1D14CA2287977319F2E70F4F81E18A95C2FF03529B5370
     }
-  end
-  object alOptionsActionList: TActionList
-    Left = 72
-    Top = 80
-    object actCloseWithEscape: TAction
-      OnExecute = actCloseWithEscapeExecute
-      ShortCut = 27
-    end
   end
 end

--- a/src/foptions.lfm
+++ b/src/foptions.lfm
@@ -154,8 +154,8 @@ object frmOptions: TfrmOptions
       Cancel = True
       Caption = '&Cancel'
       Kind = bkCancel
-      ModalResult = 2
       OnClick = btnCancelClick
+      OnMouseDown = btnCancelMouseDown
       TabOrder = 1
     end
     object btnApply: TBitBtn

--- a/src/foptions.pas
+++ b/src/foptions.pas
@@ -63,8 +63,6 @@ type
     TreeFilterEdit: TTreeFilterEdit;
     tvTreeView: TTreeView;
     splOptionsSplitter: TSplitter;
-    alOptionsActionList: TActionList;
-    actCloseWithEscape: TAction;
     procedure btnCancelClick(Sender: TObject);
     procedure btnHelpClick(Sender: TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
@@ -77,7 +75,6 @@ type
     function TreeFilterEditFilterItem(ItemData: Pointer;
                                       out Done: Boolean): Boolean;
     procedure tvTreeViewChange(Sender: TObject; Node: TTreeNode);
-    procedure actCloseWithEscapeExecute(Sender: TObject);
   private
     FOptionsEditorList: TOptionsEditorViews;
     FOldEditor: TOptionsEditorView;
@@ -222,7 +219,7 @@ end;
 
 procedure TfrmOptions.FormCloseQuery(Sender: TObject; var CanClose: boolean);
 begin
-  CanClose := (ModalResult in [mrOK, mrCancel]) or CycleThroughOptionEditors(False);
+  CanClose := (ModalResult in [mrOK]) or CycleThroughOptionEditors(False);
 end;
 
 procedure TfrmOptions.btnCancelClick(Sender: TObject);
@@ -572,13 +569,6 @@ var
 begin
   TreeNode.MakeVisible;
   TreeFilterEdit.StoreSelection;
-end;
-
-{ TfrmOptions.actCloseWithEscapeExecute }
-procedure TfrmOptions.actCloseWithEscapeExecute(Sender: TObject);
-begin
-  // Closing with the "Escape" key this way won't set the modalresult to mrCancel so this way, if an unsaved modification has been made, we'll be able to prompt confirmation from user who attempt to quit by hitting "Escape".
-  close;
 end;
 
 finalization

--- a/src/foptions.pas
+++ b/src/foptions.pas
@@ -64,6 +64,8 @@ type
     tvTreeView: TTreeView;
     splOptionsSplitter: TSplitter;
     procedure btnCancelClick(Sender: TObject);
+    procedure btnCancelMouseDown(Sender: TObject; Button: TMouseButton;
+      Shift: TShiftState; X, Y: Integer);
     procedure btnHelpClick(Sender: TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
     procedure FormCloseQuery(Sender: TObject; var CanClose: boolean);
@@ -219,7 +221,14 @@ end;
 
 procedure TfrmOptions.FormCloseQuery(Sender: TObject; var CanClose: boolean);
 begin
-  CanClose := (ModalResult in [mrOK]) or CycleThroughOptionEditors(False);
+  CanClose := (ModalResult in [mrOK, mrCancel]) or CycleThroughOptionEditors(False);
+end;
+
+procedure TfrmOptions.btnCancelMouseDown(Sender: TObject; Button: TMouseButton;
+  Shift: TShiftState; X, Y: Integer);
+begin
+  // set ModalResult when mouse click, to pass FormCloseQuery
+  ModalResult:= mrCancel;
 end;
 
 procedure TfrmOptions.btnCancelClick(Sender: TObject);


### PR DESCRIPTION
fix key ESC/RETURN handled in KasPathEdit & Options Dialog:

1. after the Key ESC/RETURN handled in TKASPathEdit.handleSpecialKeys(), Key should be eaten (there is a bug in #876)

2. in fOptions, set `btnCancel.Cancel`=`true` , and remove `alOptionsActionList`, handle `ESCAPE` correctly on all platforms

3. tested on Windows 11, MacOS12 and Linux