### PR TITLE
UPD: DARWIN: unmount driver

### DIFF
--- a/src/platform/unix/darwin/umydarwin.pas
+++ b/src/platform/unix/darwin/umydarwin.pas
@@ -3,7 +3,7 @@
    -------------------------------------------------------------------------
    This unit contains specific DARWIN functions.
 
-   Copyright (C) 2016-2021 Alexander Koblov (alexx2000@mail.ru)
+   Copyright (C) 2016-2023 Alexander Koblov (alexx2000@mail.ru)
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -54,6 +54,8 @@ function NSGetFolderPath(Folder: NSSearchPathDirectory): String;
 
 function GetFileDescription(const FileName: String): String;
 function MountNetworkDrive(const serverAddress: String): Boolean;
+
+function unmountAndEject(const path: String): Boolean;
 
 // Workarounds for FPC RTL Bug
 // copied from ptypes.inc and modified fstypename only
@@ -343,6 +345,10 @@ begin
   CFRelease(FileNameRef);
 end;
 
+function unmountAndEject(const path: String): Boolean;
+begin
+  Result:= NSWorkspace.sharedWorkspace.unmountAndEjectDeviceAtPath( StringToNSString(path) );
+end;
 
 procedure cocoaInvalidControlCursor( const control:TWinControl );
 var

--- a/src/platform/unix/umyunix.pas
+++ b/src/platform/unix/umyunix.pas
@@ -3,7 +3,7 @@
     -------------------------------------------------------------------------
     This unit contains specific UNIX functions.
 
-    Copyright (C) 2008-2022 Alexander Koblov (alexx2000@mail.ru)
+    Copyright (C) 2008-2023 Alexander Koblov (alexx2000@mail.ru)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -174,6 +174,9 @@ uses
 {$ENDIF}
 {$IF NOT (DEFINED(DARWIN) OR DEFINED(HAIKU))}
   , uMimeActions, uMimeType, uGVolume
+{$ENDIF}
+{$IFDEF DARWIN}
+  , uMyDarwin
 {$ENDIF}
 {$IFDEF LINUX}
   , uUDisks2
@@ -539,7 +542,7 @@ begin
       Result := fpSystemStatus('pumount ' + Drive^.DeviceId) = 0;
     if not Result then
 {$ELSEIF DEFINED(DARWIN)}
-    Result := fpSystemStatus('diskutil unmount ' + Drive^.Path) = 0;
+    Result := unmountAndEject( Drive^.Path );
     if not Result then
 {$ENDIF}
     Result := fpSystemStatus('umount ' + Drive^.Path) = 0;
@@ -561,7 +564,7 @@ begin
     Result := uUDisks2.Eject(Drive^.DeviceId);
   if not Result then
 {$ELSEIF DEFINED(DARWIN)}
-  Result := fpSystemStatus('diskutil eject ' + Drive^.DeviceId) = 0;
+  Result := unmountAndEject( Drive^.Path );
   if not Result then
 {$ENDIF}
   Result := fpSystemStatus('eject ' + Drive^.DeviceId) = 0;

--- a/src/platform/unix/ushellcontextmenu.pas
+++ b/src/platform/unix/ushellcontextmenu.pas
@@ -525,11 +525,17 @@ begin
     end
   else
     begin
+      {$IF not DEFINED(DARWIN)}
       mi.Caption := rsMnuUmount;
       mi.OnClick := Self.DriveUnmountSelect;
+      {$ELSE}
+      mi.Caption := rsMnuUmount + ' / ' + rsMnuEject;
+      mi.OnClick := Self.DriveEjectSelect;
+      {$ENDIF}
     end;
   Self.Items.Add(mi);
 
+  {$IF not DEFINED(DARWIN)}
   if ADrive^.IsMediaEjectable then
     begin
       mi :=TMenuItem.Create(Self);
@@ -537,6 +543,7 @@ begin
       mi.OnClick := Self.DriveEjectSelect;
       Self.Items.Add(mi);
     end;
+  {$ENDIF}
 end;
 
 { TShellContextMenu.CreateActionSubMenu }


### PR DESCRIPTION
use `NSWorkspace.sharedWorkspace.unmountAndEjectDeviceAtPath()` instead of `diskutil unmount`.

`diskutil unmount` has a high probability of not successfully unmounting.