### PR TITLE
ADD: FileTime: at least millisecond precision supported on Linux and MacOS

### DIFF
--- a/components/doublecmd/dcbasictypes.pas
+++ b/components/doublecmd/dcbasictypes.pas
@@ -22,6 +22,9 @@
 
 unit DCBasicTypes;
 
+{$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
+
 interface
 
 type
@@ -35,6 +38,7 @@ type
 
 {$IFDEF MSWINDOWS}
   TFileTime = TWinFileTime;
+  TFileTimeEx = TFileTime;
 {$ELSE}
   // Unix time (UTC).
   // Unix defines time_t as signed integer,
@@ -44,6 +48,15 @@ type
   {$ELSE}
   TFileTime = DWord;
   {$ENDIF}
+
+  TFileTimeEx = record
+    public
+      sec: int64;
+      nanosec: int64;
+    public
+      constructor create( aSec:int64; aNanosec:int64=0 );
+      class operator =(l,r : TFileTimeEx): Boolean;
+  end;
 {$ENDIF}
 
   TUnixFileTime = TFileTime;
@@ -51,6 +64,22 @@ type
   PFileTime = ^TFileTime;
   PWinFileTime = ^TWinFileTime;
 
+const
+  TFileTimeExNull: TFileTimeEx = {$IFDEF MSWINDOWS} 0 {$ELSE} (sec:0; nanosec:-1) {$ENDIF};
+
 implementation
+
+{$IF not DEFINED(MSWINDOWS)}
+constructor TFileTimeEx.create( aSec:int64; aNanosec:int64 );
+begin
+  self.sec:= aSec;
+  self.nanosec:= aNanosec;
+end;
+
+class operator TFileTimeEx.=(l,r : TFileTimeEx): Boolean;
+begin
+  Result:= (l.sec=r.sec) and (l.nanosec=r.nanosec);
+end;
+{$ENDIF}
 
 end.

--- a/components/doublecmd/dcdarwin.pas
+++ b/components/doublecmd/dcdarwin.pas
@@ -6,10 +6,10 @@ unit DCDarwin;
 interface
 
 uses
-  Classes, SysUtils, BaseUnix, CocoaAll;
+  Classes, SysUtils, DCBasicTypes, CocoaAll;
 
 // MacOS File Utils
-function MacosFileSetCreationTime( const path:String; const birthtime:time_t ): Boolean;
+function MacosFileSetCreationTime( const path:String; const birthtime:TFileTimeEx ): Boolean;
 
 implementation
 
@@ -18,13 +18,17 @@ begin
   Result:= NSString(NSString.stringWithUTF8String(PAnsiChar(S)));
 end;
 
-function MacosFileSetCreationTime( const path:String; const birthtime:time_t ): Boolean;
+function MacosFileSetCreationTime( const path:String; const birthtime:TFileTimeEx ): Boolean;
 var
+  seconds: Double;
   attrs: NSMutableDictionary;
   nsPath: NSString;
 begin
+  Result:= true;
+  if birthtime = TFileTimeExNull then exit;
+  seconds:= birthtime.sec.ToDouble + birthtime.nanosec.ToDouble / (1000.0*1000.0*1000.0);
   attrs:= NSMutableDictionary.dictionaryWithCapacity( 1 );
-  attrs.setValue_forKey( NSDate.dateWithTimeIntervalSince1970(birthtime), NSFileCreationDate );
+  attrs.setValue_forKey( NSDate.dateWithTimeIntervalSince1970(seconds), NSFileCreationDate );
   nsPath:= StringToNSString( path );
   Result:= NSFileManager.defaultManager.setAttributes_ofItemAtPath_error( attrs, nsPath, nil );
 end;

--- a/components/doublecmd/dcosutils.pas
+++ b/components/doublecmd/dcosutils.pas
@@ -173,15 +173,21 @@ function mbFileCreate(const FileName: String; Mode: LongWord): System.THandle; o
 function mbFileCreate(const FileName: String; Mode, Rights: LongWord): System.THandle; overload;
 function mbFileAge(const FileName: String): DCBasicTypes.TFileTime;
 // On success returns True.
+// nanoseconds supported
 function mbFileGetTime(const FileName: String;
-                       var ModificationTime: DCBasicTypes.TFileTime;
-                       var CreationTime    : DCBasicTypes.TFileTime;
-                       var LastAccessTime  : DCBasicTypes.TFileTime): Boolean;
+                       var ModificationTime: DCBasicTypes.TFileTimeEx;
+                       var CreationTime    : DCBasicTypes.TFileTimeEx;
+                       var LastAccessTime  : DCBasicTypes.TFileTimeEx): Boolean;
 // On success returns True.
 function mbFileSetTime(const FileName: String;
                        ModificationTime: DCBasicTypes.TFileTime;
                        CreationTime    : DCBasicTypes.TFileTime = 0;
                        LastAccessTime  : DCBasicTypes.TFileTime = 0): Boolean;
+// nanoseconds supported
+function mbFileSetTimeEx(const FileName: String;
+                         ModificationTime: DCBasicTypes.TFileTimeEx;
+                         CreationTime    : DCBasicTypes.TFileTimeEx;
+                         LastAccessTime  : DCBasicTypes.TFileTimeEx): Boolean;
 {en
    Checks if a given file exists - it can be a real file or a link to a file,
    but it can be opened and read from.
@@ -543,6 +549,9 @@ end;
 var
   Option: TCopyAttributesOption;
   StatInfo : TDCStat;
+  modificationTime: TFileTimeEx;
+  creationTime: TFileTimeEx;
+  lastAccessTime: TFileTimeEx;
   mode : TMode;
 begin
   if DC_fpLStat(UTF8ToSys(sSrc), StatInfo) < 0 then
@@ -582,11 +591,10 @@ begin
     begin
       if caoCopyTime in Options then
       begin
-        if DC_FileSetTime(
-          sDst,
-          StatInfo.st_mtime,
-          {$IFDEF DARWIN} StatInfo.st_birthtime {$ELSE} 0 {$ENDIF},
-          StatInfo.st_atime) = false then
+        modificationTime:= StatInfo.mtime;
+        lastAccessTime:= StatInfo.atime;
+        creationTime:= StatInfo.birthtime;
+        if DC_FileSetTime(sDst, modificationTime, creationTime, lastAccessTime) = false then
         begin
           Include(Result, caoCopyTime);
           if Assigned(Errors) then Errors^[caoCopyTime]:= GetLastOSError;
@@ -872,9 +880,9 @@ end;
 {$ENDIF}
 
 function mbFileGetTime(const FileName: String;
-                       var ModificationTime: DCBasicTypes.TFileTime;
-                       var CreationTime    : DCBasicTypes.TFileTime;
-                       var LastAccessTime  : DCBasicTypes.TFileTime): Boolean;
+                       var ModificationTime: DCBasicTypes.TFileTimeEx;
+                       var CreationTime    : DCBasicTypes.TFileTimeEx;
+                       var LastAccessTime  : DCBasicTypes.TFileTimeEx): Boolean;
 {$IFDEF MSWINDOWS}
 var
   Handle: System.THandle;
@@ -905,12 +913,12 @@ begin
   Result := DC_fpLStat(UTF8ToSys(FileName), StatInfo) >= 0;
   if Result then
   begin
-    LastAccessTime   := StatInfo.st_atime;
-    ModificationTime := StatInfo.st_mtime;
+    ModificationTime:= StatInfo.mtime;
+    LastAccessTime:= StatInfo.atime;
     {$IF DEFINED(DARWIN)}
-    CreationTime     := StatInfo.st_birthtime;
+    CreationTime:= StatInfo.birthtime;
     {$ELSE}
-    CreationTime     := StatInfo.st_ctime;
+    CreationTime:= StatInfo.ctime;
     {$ENDIF}
   end;
 end;
@@ -920,6 +928,27 @@ function mbFileSetTime(const FileName: String;
                        ModificationTime: DCBasicTypes.TFileTime;
                        CreationTime    : DCBasicTypes.TFileTime = 0;
                        LastAccessTime  : DCBasicTypes.TFileTime = 0): Boolean;
+{$IFDEF MSWINDOWS}
+begin
+  Result:= mbFileSetTimeEx(FileName, ModificationTime, CreationTime, LastAccessTime);
+end;
+{$ELSE}
+var
+  NewModificationTime: DCBasicTypes.TFileTimeEx;
+  NewCreationTime    : DCBasicTypes.TFileTimeEx;
+  NewLastAccessTime  : DCBasicTypes.TFileTimeEx;
+begin
+  NewModificationTime:= specialize IfThen<TFileTimeEx>(ModificationTime<>0, TFileTimeEx.create(ModificationTime), TFileTimeExNull);
+  NewCreationTime:= specialize IfThen<TFileTimeEx>(CreationTime<>0, TFileTimeEx.create(CreationTime), TFileTimeExNull);
+  NewLastAccessTime:= specialize IfThen<TFileTimeEx>(LastAccessTime<>0, TFileTimeEx.create(LastAccessTime), TFileTimeExNull);
+  Result:= mbFileSetTimeEx(FileName, NewModificationTime, NewCreationTime, NewLastAccessTime);
+end;
+{$ENDIF}
+
+function mbFileSetTimeEx(const FileName: String;
+                         ModificationTime: DCBasicTypes.TFileTimeEx;
+                         CreationTime    : DCBasicTypes.TFileTimeEx;
+                         LastAccessTime  : DCBasicTypes.TFileTimeEx): Boolean;
 {$IFDEF MSWINDOWS}
 var
   Handle: System.THandle;
@@ -961,14 +990,14 @@ begin
 end;
 {$ELSE}
 var
-  CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime: DCBasicTypes.TFileTime;
+  CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime: DCBasicTypes.TFileTimeEx;
 begin
-  if mbFileGetTime(FileName,CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime) then
+  if mbFileGetTime(FileName, CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime) then
   begin
-    if ModificationTime<>0 then CurrentModificationTime:= ModificationTime;
-    if CreationTime<>0 then CurrentCreationTime:= CreationTime;
-    if LastAccessTime<>0 then CurrentLastAccessTime:= LastAccessTime;
-    Result := DC_FileSetTime(FileName,CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime);
+    if ModificationTime<>TFileTimeExNull then CurrentModificationTime:= ModificationTime;
+    if CreationTime<>TFileTimeExNull then CurrentCreationTime:= CreationTime;
+    if LastAccessTime<>TFileTimeExNull then CurrentLastAccessTime:= LastAccessTime;
+    Result := DC_FileSetTime(FileName, CurrentModificationTime, CurrentCreationTime, CurrentLastAccessTime);
   end
   else
   begin

--- a/components/doublecmd/dcunix.pas
+++ b/components/doublecmd/dcunix.pas
@@ -28,12 +28,13 @@
 unit DCUnix;
 
 {$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
 {$packrecords c}
 
 interface
 
 uses
-  InitC, BaseUnix, UnixType, SysUtils;
+  InitC, BaseUnix, UnixType, DCBasicTypes, SysUtils;
 
 const
 {$IF DEFINED(LINUX)}
@@ -155,11 +156,21 @@ type
   TDCStat = BaseUnix.Stat;
 {$ENDIF}
 
+  TDCStatHelper = record Helper for TDCStat
+  Public
+    function birthtime: TFileTimeEx; inline;
+    function mtime:     TFileTimeEx; inline;
+    function atime:     TFileTimeEx; inline;
+    function ctime:     TFileTimeEx; inline;
+  end;
+
 Function DC_fpLstat( const path:RawByteString; var Info:TDCStat ): cint; inline;
+
+// nanoseconds supported
 function DC_FileSetTime(const FileName: String;
-                        const mtime    : time_t;
-                        const birthtime: time_t;
-                        const atime    : time_t ): Boolean;
+                        const mtime    : TFileTimeEx;
+                        const birthtime: TFileTimeEx;
+                        const atime    : TFileTimeEx ): Boolean;
 
 
 {en
@@ -259,6 +270,55 @@ uses
 {$ENDIF}
   ;
 
+{$IF not DEFINED(LINUX)}
+function TDCStatHelper.birthtime: TFileTimeEx;
+begin
+  Result.sec:= st_birthtime;
+  Result.nanosec:= st_birthtimensec;
+end;
+
+function TDCStatHelper.mtime: TFileTimeEx;
+begin
+  Result.sec:= st_mtime;
+  Result.nanosec:= st_mtimensec;
+end;
+
+function TDCStatHelper.atime: TFileTimeEx;
+begin
+  Result.sec:= st_atime;
+  Result.nanosec:= st_atimensec;
+end;
+
+function TDCStatHelper.ctime: TFileTimeEx;
+begin
+  Result.sec:= st_ctime;
+  Result.nanosec:= st_ctimensec;
+end;
+{$ELSE}
+function TDCStatHelper.birthtime: TFileTimeEx;
+begin
+  Result:= TFileTimeExNull;
+end;
+
+function TDCStatHelper.mtime: TFileTimeEx;
+begin
+  Result.sec:= st_mtime;
+  Result.nanosec:= st_mtime_nsec;
+end;
+
+function TDCStatHelper.atime: TFileTimeEx;
+begin
+  Result.sec:= st_atime;
+  Result.nanosec:= st_atime_nsec;
+end;
+
+function TDCStatHelper.ctime: TFileTimeEx;
+begin
+  Result.sec:= st_ctime;
+  Result.nanosec:= st_ctime_nsec;
+end;
+{$ENDIF}
+
 
 {$IF DEFINED(DARWIN)}
 
@@ -281,18 +341,24 @@ end;
 
 {$ENDIF}
 
+function fputimes( path:pchar; times:Array of UnixType.timeval ): cint; cdecl; external clib name 'utimes';
+
 function DC_FileSetTime(const FileName: String;
-                        const mtime    : time_t;
-                        const birthtime: time_t;
-                        const atime    : time_t ): Boolean;
+                        const mtime    : TFileTimeEx;
+                        const birthtime: TFileTimeEx;
+                        const atime    : TFileTimeEx ): Boolean;
 var
-  utb: BaseUnix.TUTimBuf;
+  timevals: Array[0..1] of UnixType.timeval;
 begin
   Result:= false;
 
-  utb.actime:= atime;   // last access time
-  utb.modtime:= mtime;  // last modification time
-  if fputime(UTF8ToSys(FileName), @utb) <> 0 then exit;
+  // last access time
+  timevals[0].tv_sec:= atime.sec;
+  timevals[0].tv_usec:= round( Extended(atime.nanosec) / 1000.0 );
+  // last modification time
+  timevals[1].tv_sec:= mtime.sec;
+  timevals[1].tv_usec:= round( Extended(mtime.nanosec) / 1000.0 );
+  if fputimes(pchar(UTF8ToSys(FileName)), timevals) <> 0 then exit;
 
   {$IF not DEFINED(DARWIN)}
   Result:= true;

--- a/src/filesources/filesystem/ufilesystemfilesource.pas
+++ b/src/filesources/filesystem/ufilesystemfilesource.pas
@@ -333,7 +333,9 @@ begin
 {$IF DEFINED(UNIX)}
     ChangeTimeProperty := TFileChangeDateTimeProperty.Create(DCBasicTypes.TFileTime(pSearchRecord^.PlatformTime));
     {$IF DEFINED(DARWIN)}
-    CreationTimeProperty := TFileCreationDateTimeProperty.Create(DCBasicTypes.TFileTime(pSearchRecord^.FindData.st_birthtime));
+    CreationTimeProperty := TFileCreationDateTimeProperty.Create(
+      UnixFileTimeToDateTimeEx(
+        TFileTimeEx.create( pSearchRecord^.BirthdayTime, pSearchRecord^.BirthdayTimensec) ));
     {$ENDIF}
 {$ELSE}
     CreationTimeProperty := TFileCreationDateTimeProperty.Create(DCBasicTypes.TFileTime(pSearchRecord^.PlatformTime));

--- a/src/filesources/filesystem/ufilesystemsetfilepropertyoperation.pas
+++ b/src/filesources/filesystem/ufilesystemsetfilepropertyoperation.pas
@@ -199,11 +199,11 @@ begin
         if (aTemplateProperty as TFileModificationDateTimeProperty).Value <>
            (aFile.Properties[fpModificationTime] as TFileModificationDateTimeProperty).Value then
         begin
-          if not FileSetTimeUAC(
+          if not FileSetTimeExUAC(
             aFile.FullPath,
-            DateTimeToFileTime((aTemplateProperty as TFileModificationDateTimeProperty).Value),
-            0,
-            0) then
+            DateTimeToFileTimeEx((aTemplateProperty as TFileModificationDateTimeProperty).Value),
+            TFileTimeExNull,
+            TFileTimeExNull) then
           begin
             Result := sfprError;
           end;
@@ -215,11 +215,11 @@ begin
         if (aTemplateProperty as TFileCreationDateTimeProperty).Value <>
            (aFile.Properties[fpCreationTime] as TFileCreationDateTimeProperty).Value then
         begin
-          if not FileSetTimeUAC(
+          if not FileSetTimeExUAC(
             aFile.FullPath,
-            0,
-            DateTimeToFileTime((aTemplateProperty as TFileCreationDateTimeProperty).Value),
-            0) then
+            TFileTimeExNull,
+            DateTimeToFileTimeEx((aTemplateProperty as TFileCreationDateTimeProperty).Value),
+            TFileTimeExNull) then
           begin
             Result := sfprError;
           end;
@@ -231,11 +231,11 @@ begin
         if (aTemplateProperty as TFileLastAccessDateTimeProperty).Value <>
            (aFile.Properties[fpLastAccessTime] as TFileLastAccessDateTimeProperty).Value then
         begin
-          if not FileSetTimeUAC(
+          if not FileSetTimeExUAC(
             aFile.FullPath,
-            0,
-            0,
-            DateTimeToFileTime((aTemplateProperty as TFileLastAccessDateTimeProperty).Value)) then
+            TFileTimeExNull,
+            TFileTimeExNull,
+            DateTimeToFileTimeEx((aTemplateProperty as TFileLastAccessDateTimeProperty).Value)) then
           begin
             Result := sfprError;
           end;

--- a/src/platform/ufindex.pas
+++ b/src/platform/ufindex.pas
@@ -72,6 +72,10 @@ type
     FindData : TDCStat;
     property PlatformTime: TUnixTime read FindData.st_ctime;
     property LastAccessTime: TUnixTime read FindData.st_atime;
+    {$IF DEFINED(DARWIN)}
+    property BirthdayTime: TUnixTime read FindData.st_birthtime;
+    property BirthdayTimensec: clong read FindData.st_birthtimensec;
+    {$ENDIF}
 {$ENDIF}
   end;
 

--- a/src/rpc/uadministrator.pas
+++ b/src/rpc/uadministrator.pas
@@ -17,6 +17,10 @@ function FileSetTimeUAC(const FileName: String;
                         ModificationTime: DCBasicTypes.TFileTime;
                         CreationTime    : DCBasicTypes.TFileTime = 0;
                         LastAccessTime  : DCBasicTypes.TFileTime = 0): LongBool;
+function FileSetTimeExUAC(const FileName: String;
+                          ModificationTime: DCBasicTypes.TFileTimeEx;
+                          CreationTime    : DCBasicTypes.TFileTimeEx;
+                          LastAccessTime  : DCBasicTypes.TFileTimeEx): LongBool;
 function FileSetReadOnlyUAC(const FileName: String; ReadOnly: Boolean): Boolean;
 function FileCopyAttrUAC(const sSrc, sDst: String;
                          Options: TCopyAttributesOptions): TCopyAttributesOptions;
@@ -190,6 +194,28 @@ begin
     LastError:= GetLastOSError;
     if RequestElevation(rsElevationRequiredSetAttributes, FileName) then
       Result:= TWorkerProxy.Instance.FileSetTime(FileName, ModificationTime, CreationTime, LastAccessTime)
+    else
+      SetLastOSError(LastError);
+  end;
+end;
+
+function FileSetTimeExUAC(const FileName: String;
+                          ModificationTime: DCBasicTypes.TFileTimeEx;
+                          CreationTime    : DCBasicTypes.TFileTimeEx;
+                          LastAccessTime  : DCBasicTypes.TFileTimeEx): LongBool;
+var
+  LastError: Integer;
+begin
+  Result:= mbFileSetTimeEx(FileName, ModificationTime, CreationTime, LastAccessTime);
+  if (not Result) and ElevationRequired then
+  begin
+    LastError:= GetLastOSError;
+    if RequestElevation(rsElevationRequiredSetAttributes, FileName) then
+{$IFDEF MSWINDOWS}
+      Result:= TWorkerProxy.Instance.FileSetTime(FileName, ModificationTime, CreationTime, LastAccessTime)
+{$ELSE}
+      Result:= TWorkerProxy.Instance.FileSetTime(FileName, ModificationTime.sec, CreationTime.sec, LastAccessTime.sec)
+{$ENDIF}
     else
       SetLastOSError(LastError);
   end;

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -3940,9 +3940,9 @@ var
   ActiveFile: TFile = nil;
   SelectedFiles: TFiles = nil;
   aFileProperties: TFileProperties;
-  CreationTime: DCBasicTypes.TFileTime = 0;
-  LastAccessTime : DCBasicTypes.TFileTime = 0;
-  ModificationTime: DCBasicTypes.TFileTime = 0;
+  CreationTime: DCBasicTypes.TFileTimeEx;
+  LastAccessTime : DCBasicTypes.TFileTimeEx;
+  ModificationTime: DCBasicTypes.TFileTimeEx;
   Operation: TFileSourceSetFilePropertyOperation = nil;
 
 begin
@@ -3963,11 +3963,11 @@ begin
           if mbFileGetTime(ActiveFile.FullPath, ModificationTime, CreationTime, LastAccessTime) then
           begin
             if fpModificationTime in ActiveFile.SupportedProperties then
-              ActiveFile.ModificationTime:= FileTimeToDateTime(ModificationTime);
+              ActiveFile.ModificationTime:= FileTimeToDateTimeEx(ModificationTime);
             if fpCreationTime in ActiveFile.SupportedProperties then
-              ActiveFile.CreationTime:= FileTimeToDateTime(CreationTime);
+              ActiveFile.CreationTime:= FileTimeToDateTimeEx(CreationTime);
             if fpLastAccessTime in ActiveFile.SupportedProperties then
-              ActiveFile.LastAccessTime:= FileTimeToDateTime(LastAccessTime);
+              ActiveFile.LastAccessTime:= FileTimeToDateTimeEx(LastAccessTime);
           end;
         end;
         FillByte(aFileProperties, SizeOf(aFileProperties), 0);


### PR DESCRIPTION
### currently DC only supports FileTime with second precision on Linux and MacOS:

1. FileTime includes ModificationTime, CreationTime, AccessTime, ChangeTime

2. when copying files in DC, the fractional parts of FileTime are ignored

3. in SetFileProperties Dialog, the milliseconds are ignored

### this PR adds support for at least millisecond precision, which is usually required, as on Windows. the ideas are:

1. because it involves modifications in many places, the principle of this PR is to make as few changes as possible, so the original function and the `Ex` function version are retained at the same time. after this PR is merged, it should take one or two more PRs to replace them all with the new `Ex` version.

2. record `TFileTimeEx` added, which corresponds to `TFileTime`, but adds support for nanosecond precision. not directly modifying `TFileTime` is the reason mentioned in 1st, to minimize the places that need to be modified.

3. the `Ex` series functions added:

`in DCBasicTypes`
function FileTimeToDateTimeEx(FileTime: TFileTimeEx) : TDateTime;

`in DCDateTimeUtils`
function DateTimeToFileTimeEx(DateTime : TDateTime): TFileTimeEx;
function UnixFileTimeToDateTimeEx(UnixTime: TFileTimeEx): TDateTime;
function DateTimeToUnixFileTimeEx(DateTime: TDateTime): TFileTimeEx;

`in DCOSUtils`
function mbFileSetTimeEx(const FileName: String; ModificationTime: TFileTimeEx;  CreationTime: TFileTimeEx; LastAccessTime  : TFileTimeEx): Boolean;
function mbFileGetTime(const FileName: String; var ModificationTime: TFileTimeEx; var CreationTime: TFileTimeEx; var LastAccessTime: TFileTimeEx): Boolean;
(mbFileGetTime() extend to support nanosecond precision)

`in uAdministrator`
function FileSetTimeExUAC(const FileName: String; ModificationTime: TFileTimeEx; CreationTime: TFileTimeEx; LastAccessTime: TFileTimeEx): LongBool;

4. modifications in the application layer

`in uFileSystemFileSource`
function TFileSystemFileSource.CreateFile(const APath: String; pSearchRecord: PSearchRecEx): 

`in uFileSystemSetFilePropertyOperation`
function TFileSystemSetFilePropertyOperation.SetNewProperty(aFile: TFile; aTemplateProperty: TFileProperty): TSetFilePropertyResult;

### fully tested on Linux, MacOS 12 and Windows 11.