### PR TITLE
FIX: memory leaks in uMyDarwin

### DIFF
--- a/src/platform/unix/darwin/umydarwin.pas
+++ b/src/platform/unix/darwin/umydarwin.pas
@@ -405,6 +405,7 @@ procedure Finalize;
 begin
   if (NetFS <> NilHandle) then FreeLibrary(NetFS);
   if (CoreServices <> NilHandle) then FreeLibrary(CoreServices);
+  FreeAndNil( MacosServiceMenuHelper );
 end;
 
 initialization


### PR DESCRIPTION
FIX: memory leaks in uMyDarwin.

although it is not a real memory leak, it can avoid the memory leak warning of heaptrc.