### PR TITLE
FIX: memory leaks in udarwinfswatch

### DIFF
--- a/src/platform/unix/darwin/udarwinfswatch.pas
+++ b/src/platform/unix/darwin/udarwinfswatch.pas
@@ -534,11 +534,14 @@ procedure cdeclFSEventsCallback(
   eventFlags: FSEventStreamEventFlagsPtr;
   {%H-}eventIds: FSEventStreamEventIdPtr ); cdecl;
 var
+  pool: NSAutoReleasePool;
   watcher: TDarwinFSWatcher absolute clientCallBackInfo;
   session: TDarwinFSWatchEventSession;
 begin
+  pool:= NSAutoreleasePool.alloc.init;
   session:= TDarwinFSWatchEventSession.create( numEvents, eventPaths, eventFlags );
   watcher.handleEvents( session );
+  pool.release;
   // seesion released in handleEvents()
 end;
 

--- a/src/platform/unix/darwin/udarwinfswatch.pas
+++ b/src/platform/unix/darwin/udarwinfswatch.pas
@@ -648,12 +648,16 @@ begin
 end;
 
 procedure TDarwinFSWatcher.start;
+var
+  pool: NSAutoReleasePool;
 begin
   _running:= true;
   _runLoop:= CFRunLoopGetCurrent();
   _thread:= TThread.CurrentThread;
 
   repeat
+
+    pool:= NSAutoreleasePool.alloc.init;
 
     _lockObject.Acquire;
     try
@@ -666,6 +670,8 @@ begin
       CFRunLoopRun
     else
       waitPath;
+
+    pool.release;
 
   until not _running;
 end;


### PR DESCRIPTION
In Cocoa, as a created and resident thread, NSAutoreleasePool needs to be added to release memory for the Autorelease variable, otherwise it will not be released until the thread ends.