### PR TITLE
FIX: memory leaks in IFileResource.RetrieveProperties()

### DIFF
--- a/src/filesources/filesystem/ufilesystemfilesource.pas
+++ b/src/filesources/filesystem/ufilesystemfilesource.pas
@@ -67,7 +67,7 @@ type
                                            const FileNamesList: TStringList;
                                            OmitNotExisting: Boolean = False): TFiles;
 
-    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String); override;
+    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String); override;
 
     class function GetFileSource: IFileSystemFileSource;
 
@@ -459,7 +459,7 @@ begin
 end;
 
 procedure TFileSystemFileSource.RetrieveProperties(AFile: TFile;
-  PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String);
+  PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String);
 var
   AIndex: Integer;
   sFullPath: String;

--- a/src/filesources/multilist/umultilistfilesource.pas
+++ b/src/filesources/multilist/umultilistfilesource.pas
@@ -90,7 +90,7 @@ type
     function FileSystemEntryExists(const Path: String): Boolean; override;
 
     function GetRetrievableFileProperties: TFilePropertiesTypes; override;
-    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String); override;
+    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String); override;
     function CanRetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes): Boolean; override;
 
     function CreateListOperation(TargetPath: String): TFileSourceOperation; override;
@@ -193,7 +193,7 @@ begin
 end;
 
 procedure TMultiListFileSource.RetrieveProperties(AFile: TFile;
-  PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String);
+  PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String);
 begin
   FFileSource.RetrieveProperties(AFile, PropertiesToSet, AVariantProperties);
 end;

--- a/src/filesources/ufilesource.pas
+++ b/src/filesources/ufilesource.pas
@@ -62,7 +62,7 @@ type
     function CreateFileObject(const APath: String): TFile;
 
     function CanRetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes): Boolean;
-    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String);
+    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String);
 
     function CreateListOperation(TargetPath: String): TFileSourceOperation;
     function CreateCopyOperation(var SourceFiles: TFiles;
@@ -232,7 +232,7 @@ type
     // Create an empty TFile object with appropriate properties for the file.
     class function CreateFile(const APath: String): TFile; virtual;
 
-    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String); virtual;
+    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String); virtual;
     function CanRetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes): Boolean; virtual;
 
     // These functions create an operation object specific to the file source.
@@ -650,7 +650,7 @@ begin
   Result := CreateFile(APath);
 end;
 
-procedure TFileSource.RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String);
+procedure TFileSource.RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String);
 begin
   // Does not set any properties by default.
 end;

--- a/src/filesources/wfxplugin/uwfxpluginfilesource.pas
+++ b/src/filesources/wfxplugin/uwfxpluginfilesource.pas
@@ -97,7 +97,7 @@ type
     class function CreateFile(const APath: String): TFile; override;
     class function CreateFile(const APath: String; FindData: TWfxFindData): TFile; overload;
 
-    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String); override;
+    procedure RetrieveProperties(AFile: TFile; PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String); override;
 
     // Retrieve operations permitted on the source.  = capabilities?
     function GetOperationsTypes: TFileSourceOperationTypes; override;
@@ -617,7 +617,7 @@ begin
 end;
 
 procedure TWfxPluginFileSource.RetrieveProperties(AFile: TFile;
-  PropertiesToSet: TFilePropertiesTypes; AVariantProperties: array of String);
+  PropertiesToSet: TFilePropertiesTypes; const AVariantProperties: array of String);
 var
   AIndex: Integer;
   AProp: TFilePropertyType;


### PR DESCRIPTION
FIX: memory leaks in IFileResource.RetrieveProperties().

dynamic arrays used for anonymous parameters passed by value, cause memory leaks (maybe a bug of Free Pascal).