### PR TITLE
Fix: memory leaks in TfrmFileProperties

### DIFF
--- a/src/ffileproperties.pas
+++ b/src/ffileproperties.pas
@@ -257,6 +257,7 @@ destructor TfrmFileProperties.Destroy;
 begin
   FFiles.Free;
   StopCalcFolderSize;
+  FreeAndNil( FOperation );
   inherited Destroy;
   FPropertyFormatter := nil; // free interface
 end;


### PR DESCRIPTION
fix memory leaks in `TfrmFileProperties`.

`FOperation` may not be released.