### PR TITLE
FIX: shell execute parameters

### DIFF
--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -1404,7 +1404,7 @@ var
 begin
   if Length(Params) > 0 then
     with frmMain do
-    ShellExecute(PrepareParameter(Params[0]))
+    ExecCmdFork(PrepareParameter(Params[0]))
   else
     with frmMain.ActiveFrame do
     begin


### PR DESCRIPTION
Extend the capability of cm_ShellExecute to take parameters.
Now cm_ShellExecute can be used to run external programs **with** parameters
