### PR TITLE
Fix: directory change to non-normalized paths - issue #130

### DIFF
--- a/components/doublecmd/dcstrutils.pas
+++ b/components/doublecmd/dcstrutils.pas
@@ -375,11 +375,16 @@ const
   AllowPathDelimiters : set of char = ['\','/'];
 var
   I : LongInt;
+  uriPos : Integer;
 begin
   Result:= Path;
   // If path is not URI
-  if Pos('://', Result) = 0 then
-  begin
+  uriPos := Pos('://', Result);
+  if (uriPos = 0)
+{$IF DEFINED(MSWINDOWS)}
+     or ( (uriPos = 2) and  (Path[1] in ['A'..'z']) )
+{$ENDIF} then
+ begin
     for I:= 1 to Length(Path) do
       if Path[I] in AllowPathDelimiters then
         Result[I]:= DirectorySeparator;

--- a/src/udcutils.pas
+++ b/src/udcutils.pas
@@ -358,13 +358,19 @@ end;
 
 function mbExpandFileName(const sFileName: String): String;
 begin
-  if (Pos('://', sFileName) > 0) then
+  if (Pos('://', sFileName) > 2) then
     Result:= sFileName
   else begin
     Result:= NormalizePathDelimiters(sFileName);
     Result:= ReplaceEnvVars(Result);
     if Pos(PathDelim, Result) <> 0 then
       Result:= ExpandFileName(Result);
+
+{$IF DEFINED(MSWINDOWS)}
+// Remove double backslash '\\' after calling 'ExpandFileName'
+    if (Pos(':\\', Result) = 2) and (Result[1] in ['A'..'z'])  then
+      Result:= Result.Remove(2, 1);
+{$ENDIF}
   end;
 end;
 


### PR DESCRIPTION
Fixes #130 
Sometimes when using source code from different sources, non-normalized paths can be a pain and currently double commander can't read those.

A perfect cross platform solution would be the logic in the function `path::lexically_normal()`  found in the following link:
https://github.com/gcc-mirror/gcc/blob/b24acae8f4d315a5b071ffc2574ce91c7a0800ca/libstdc%2B%2B-v3/src/c%2B%2B17/fs_path.cc#L1686

However, in the meantime I introduce this solution:
The WINAPI `GetFullPathName` function is superior to the current double commander implementation, it solves complex cases of non-normalized path forms such as `c:/windows\/system32///\..`


