### PR TITLE
FIX: macOS/darwin defaults RunTermCmd Terminal.app location

### DIFF
--- a/src/platform/uOSUtils.pas
+++ b/src/platform/uOSUtils.pas
@@ -57,7 +57,7 @@ const
   faFolder = S_IFDIR;
   ReversePathDelim = '\';
   {$IF DEFINED(DARWIN)}
-  RunTermCmd = '/Applications/Utilities/Terminal.app';  // default terminal
+  RunTermCmd = '/System/Applications/Utilities/Terminal.app';  // default terminal
   RunTermParams = '%D';
   RunInTermStayOpenCmd = '%COMMANDER_PATH%/scripts/terminal.sh'; // default run in terminal command AND Stay open after command
   RunInTermStayOpenParams = '''{command}''';


### PR DESCRIPTION
In recent major macOS versions the Terminal.app was moved out of the `/Application` directory into the SIP protected `/System/Application` directory.

Therefore the default installation config for macOS would result in a misconfiguration and the F9 shortcut for `cm_RunTerm` calls a missing target.