### PR TITLE
Render Sync Dirs with custom font

### DIFF
--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -884,6 +884,7 @@ var
   s: string;
 begin
   if (FVisibleItems = nil) or (aRow >= FVisibleItems.Count) then Exit;
+  FontOptionsToFont(gFonts[dcfSearchResults], MainDrawGrid.Canvas.Font);
   with MainDrawGrid.Canvas do
   begin
     r := TFileSyncRec(FVisibleItems.Objects[aRow]);


### PR DESCRIPTION
The files listed in the Sync Dirs will be rendered using the font configured for the Search Results