### PR TITLE
FIX: Use cmem unit before cthreads unit (#1553)

### DIFF
--- a/src/doublecmd.lpr
+++ b/src/doublecmd.lpr
@@ -12,10 +12,10 @@ uses
   {$ENDIF}
   {$ENDIF}
   {$IFDEF UNIX}
-  cthreads,
   {$IFNDEF HEAPTRC}
   cmem,
   {$ENDIF}
+  cthreads,
   {$IFDEF DARWIN}
   iosxwstr,
   iosxlocale,


### PR DESCRIPTION
This commit fixes crash during exit if doublecmd compiled with FPC 3.3.1.
This commit doesn't fix or break anything if doublecmd compiled with FPC 3.2.2.

doublecmd compiled with FPC 3.3.1 before this commit was broken like this:
1. unix unit (used by cthreads unit) allocates memory using built-in memory manager
2. cmem unit replaces built-in memory manager with cmem memory manager
3. user exits doublecmd
4. something tries to free memory allocated in step 1 with cmem memory manager