### PR TITLE
Update multiarc.ini

### DIFF
--- a/default/multiarc.ini
+++ b/default/multiarc.ini
@@ -23,7 +23,7 @@ Debug=0
 [7Z (ro)]
 Archiver=7z
 Description=7-Zip - www.7-zip.org
-Extension=cab,z,taz,lzh,lha,iso,wim,swm,dmg,xar,hfs,ntfs,fat,vhd,mbr
+Extension=apfs,ar,cab,chm,cpio,cramfs,dmg,ext,fat,gpt,hfs,ihex,ima,img,iso,lha,lzh,lzma,mbr,msi,nsis,ntfs,qcow2,rar,rpm,squashfs,swm,taz,udf,uefi,vdi,vhd,vhdx,vmdk,wim,xar,z
 Start=^-------------------
 End=^-------------------
 Format0=yyyy tt dd hh mm ss aaaaa zzzzzzzzzzzz pppppppppppp  n+


### PR DESCRIPTION
Additional extensions for `7z (ro)` taken from https://7-zip.org/index.html - removed `arj` - added `ima` and `img`