### PR TITLE
FIX: IntToStrTS when ThousandSeparator is NUL

### DIFF
--- a/src/udcutils.pas
+++ b/src/udcutils.pas
@@ -388,33 +388,32 @@ begin
 end;
 
 function IntToStrTS(const APositiveValue: Int64): String;
-var i, vSrcLen, vSrcI, vSrcNumberNo, vResLen: byte;
+var
+  // 25 is length of '9,223,372,036,854,775,807' (max Int64 with thousand separators)
+  ShortStringResult: String[25];
+  SmallI, BigI: Byte;
 begin
-  if APositiveValue < 0 then
-    Exit(IntToStr(APositiveValue));
-  Str(APositiveValue, Result);
-  vSrcLen := Result.Length;
-
-  vResLen := vSrcLen + ((vSrcLen - 1) div 3);
-  if vSrcLen = vResLen then
-    Exit;
-
-  SetLength(Result, vResLen);
-
-  vSrcI := vResLen;
-  vSrcNumberNo := 1;
-
-  for i:= vSrcLen downto 1 do
-    begin
-      Result[vSrcI] := Result[i];
-      Dec(vSrcI);
-      if(vSrcNumberNo <> vSrcLen) and (vSrcNumberNo mod 3 = 0) then
-        begin
-          Result[vSrcI] := FormatSettings.ThousandSeparator;
-          Dec(vSrcI);
-        end;
-      Inc(vSrcNumberNo);
-    end;
+  Str(APositiveValue, ShortStringResult);
+  if (APositiveValue > 999) and (DefaultFormatSettings.ThousandSeparator <> #0) then
+  begin
+    SmallI := Length(ShortStringResult);
+    BigI := SmallI + (SmallI - 1) div 3;
+    SetLength(ShortStringResult, BigI);
+    repeat
+      ShortStringResult[BigI] := ShortStringResult[SmallI];
+      Dec(BigI);
+      Dec(SmallI);
+      ShortStringResult[BigI] := ShortStringResult[SmallI];
+      Dec(BigI);
+      Dec(SmallI);
+      ShortStringResult[BigI] := ShortStringResult[SmallI];
+      Dec(BigI);
+      Dec(SmallI);
+      ShortStringResult[BigI] := DefaultFormatSettings.ThousandSeparator;
+      Dec(BigI);
+    until BigI = SmallI;
+  end;
+  Result := ShortStringResult;
 end;
 
 function cnvFormatFileSize(const iSize: int64; FSF: TFileSizeFormat; const Number: integer): string;


### PR DESCRIPTION
also simplify IntToStrTS (smaller, less variables)<table><tr><th colspan="2">LC_ALL=C</th></tr><tr><th>before</th><th>after</th></tr><tr><td><img src="https://github.com/doublecmd/doublecmd/assets/91378413/610075bf-d0a3-463c-80b5-a81cd231598b"></td><td><img src="https://github.com/doublecmd/doublecmd/assets/91378413/14a61a70-86fc-4143-8831-60a90116e04b"></td></tr></table>