### PR TITLE
ADD: Make cMaxStringItems configurable (and rename it to gMaxStringIt…

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -6021,8 +6021,8 @@ begin
   Result:= True;
 
   InsertFirstItem(sCmd, edtCommand);
-  // only cMaxStringItems(see uGlobs.pas) is stored
-  if edtCommand.Items.Count>cMaxStringItems then
+  // only gMaxStringItems(see uGlobs.pas) is stored
+  if edtCommand.Items.Count>gMaxStringItems then
     edtCommand.Items.Delete(edtCommand.Items.Count-1);
   edtCommand.DroppedDown:= False;
 

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -726,9 +726,6 @@ function GetValidDateTimeFormat(const aFormat, ADefaultFormat: string): string;
 
 procedure RegisterInitialization(InitProc: TProcedure);
 
-const
-  cMaxStringItems=50;
-  
 var
   gConfig: TXmlConfig = nil;
   gStyles: TJsonConfig = nil;
@@ -920,7 +917,7 @@ var
           if LoadObj then begin
             HistoryList.Objects[Idx]:= TObject(UIntPtr(History.GetAttr(Node, 'Tag', 0)));
           end;
-          if HistoryList.Count >= cMaxStringItems then Break;
+          if HistoryList.Count >= gMaxStringItems then Break;
         end;
         Node := Node.NextSibling;
       end;
@@ -974,7 +971,7 @@ var
       if SaveObj then begin
         History.SetAttr(SubNode, 'Tag', UInt32(UIntPtr(HistoryList.Objects[I])));
       end;
-      if I >= cMaxStringItems then Break;
+      if I >= gMaxStringItems then Break;
     end;
   end;
 
@@ -2007,6 +2004,7 @@ begin
   gSaveSearchReplaceHistory := True;
   gSaveDirHistory := True;
   gDirHistoryCount := 30;
+  gMaxStringItems := 50;
   gSaveCmdLineHistory := True;
   gSaveFileMaskHistory := True;
   gSaveVolumeSizeHistory := True;
@@ -2984,6 +2982,7 @@ begin
     gSaveSearchReplaceHistory:= GetAttr(Root, 'History/SearchReplaceHistory/Save', gSaveSearchReplaceHistory);
     gSaveDirHistory := GetAttr(Root, 'History/DirHistory/Save', gSaveDirHistory);
     gDirHistoryCount := GetAttr(Root, 'History/DirHistory/Count', gDirHistoryCount);
+    gMaxStringItems := GetAttr(Root, 'History/MaxStringItems', gMaxStringItems);
     gSaveCmdLineHistory := GetAttr(Root, 'History/CmdLineHistory/Save', gSaveCmdLineHistory);
     gSaveFileMaskHistory := GetAttr(Root, 'History/FileMaskHistory/Save', gSaveFileMaskHistory);
     gSaveVolumeSizeHistory := GetAttr(Root, 'History/VolumeSizeHistory/Save', gSaveVolumeSizeHistory);
@@ -3633,6 +3632,7 @@ begin
     SetAttr(Root, 'History/SearchReplaceHistory/Save', gSaveSearchReplaceHistory);
     SetAttr(Root, 'History/DirHistory/Save', gSaveDirHistory);
     SetAttr(Root, 'History/DirHistory/Count', gDirHistoryCount);
+    SetAttr(Root, 'History/MaxStringItems', gMaxStringItems);
     SetAttr(Root, 'History/CmdLineHistory/Save', gSaveCmdLineHistory);
     SetAttr(Root, 'History/FileMaskHistory/Save', gSaveFileMaskHistory);
     SetAttr(Root, 'History/VolumeSizeHistory/Save', gSaveVolumeSizeHistory);


### PR DESCRIPTION
…ems)

configurable via "Configuration/MaxStringItems"

--
I wasn't sure where to place it, candidates were "Configuration", "Miscellaneous" or something new altogether. Please advise if you are happy with this.