### PR TITLE
UPD: MultiArc - cleaning chars in size string w/o additional helpers

### DIFF
--- a/src/filesources/multiarchive/umultiarchiveparser.pas
+++ b/src/filesources/multiarchive/umultiarchiveparser.pas
@@ -41,6 +41,7 @@ type
     procedure Prepare; virtual; abstract;
     procedure ParseLines; virtual; abstract;
     procedure AddLine(const Str: String); virtual; abstract;
+    function CleanSize(Str: String): String;
     property OnGetArchiveItem: TOnGetArchiveItem write FOnGetArchiveItem;
   end;
 
@@ -245,6 +246,20 @@ begin
 
 end;
 
+function TMultiArchiveParser.CleanSize(Str: String): String;
+var
+  I: Integer;
+  Size: String;
+begin
+  Size:= Trim(Str);
+  if FMultiArcItem.FSizeStripChars <> EmptyStr then
+  begin
+    for I:= 1 to Length(FMultiArcItem.FSizeStripChars) do
+      Size:= Size.Replace(FMultiArcItem.FSizeStripChars[I], '');
+  end;
+  Result:= Size;
+end;
+
 procedure TMultiArchiveStaticParser.AddLine(const Str: String);
 begin
   // if next item
@@ -260,9 +275,9 @@ begin
   if FNamePos.Index = FFormatIndex then
     FArchiveItem.FileName := FGetFileName(Trim(GetKeyValue(str, FNamePos)));
   if FUnpSizePos.Index = FFormatIndex then
-    FArchiveItem.UnpSize := StrToInt64Def(Trim(GetKeyValue(str, FUnpSizePos)), -1);
+    FArchiveItem.UnpSize := StrToInt64Def(CleanSize(GetKeyValue(str, FUnpSizePos)), -1);
   if FPackSizePos.Index = FFormatIndex then
-    FArchiveItem.PackSize := StrToInt64Def(Trim(GetKeyValue(str, FPackSizePos)), -1);
+    FArchiveItem.PackSize := StrToInt64Def(CleanSize(GetKeyValue(str, FPackSizePos)), -1);
   if FYearPos.Index = FFormatIndex then
     FArchiveItem.Year := YearShortToLong(StrToIntDef(Trim(GetKeyValue(str, FYearPos)), 0));
   if FMonthPos.Index = FFormatIndex then

--- a/src/umultiarc.pas
+++ b/src/umultiarc.pas
@@ -708,9 +708,9 @@ begin
   Result.FFormMode := Self.FFormMode;
   Result.FEnabled := Self.FEnabled;
   Result.FOutput := Self.FOutput;
-  Result.FDebug := Self.FDebug
+  Result.FDebug := Self.FDebug;
   Result.FSizeStripChars := Self.FSizeStripChars;
-  Result.FAskHistory.Assign(Self.FAskHistory)
+  Result.FAskHistory.Assign(Self.FAskHistory);
 end;
 
 { TSignatureList }

--- a/src/umultiarc.pas
+++ b/src/umultiarc.pas
@@ -129,7 +129,8 @@ type
     FDelete,
     FAdd,
     FAddSelfExtract,
-    FPasswordQuery: String;
+    FPasswordQuery,
+    FSizeStripChars: String;
     FFormMode: Integer;
     FFlags: TMultiArcFlags;
   public
@@ -333,6 +334,7 @@ begin
         FPasswordQuery:= IniFile.ReadString(Section, 'PasswordQuery', EmptyStr);
         // optional
         FFlags:= TMultiArcFlags(IniFile.ReadInteger(Section, 'Flags', 0));
+        FSizeStripChars:= Trim(IniFile.ReadString(Section, 'SizeStripChars', EmptyStr));
         FFormMode:= IniFile.ReadInteger(Section, 'FormMode', 0);
         FEnabled:= IniFile.ReadBool(Section, 'Enabled', True);
         FOutput:= IniFile.ReadBool(Section, 'Output', False);
@@ -391,6 +393,7 @@ begin
         IniFile.WriteString(Section, 'PasswordQuery', FPasswordQuery);
         // optional
         IniFile.WriteInteger(Section, 'Flags', Integer(FFlags));
+        IniFile.WriteString(Section, 'SizeStripChars', FSizeStripChars);
         IniFile.WriteInteger(Section, 'FormMode', FFormMode);
         IniFile.WriteBool(Section, 'Enabled', FEnabled);
         IniFile.WriteBool(Section, 'Output', FOutput);
@@ -466,6 +469,7 @@ begin
     UpdateSignature(Self.Items[Index].FID);
     UpdateSignature(Self.Items[Index].FIDPos);
     UpdateSignature(Self.Items[Index].FIDSeekRange);
+    UpdateSignature(Self.Items[Index].FSizeStripChars);
     Result := crc32(Result, @Self.Items[Index].FFlags, sizeof(Self.Items[Index].FFlags));
     Result := crc32(Result, @Self.Items[Index].FFormMode, sizeof(Self.Items[Index].FFormMode));
     Result := crc32(Result, @Self.Items[Index].FEnabled, sizeof(Self.Items[Index].FEnabled));
@@ -690,6 +694,7 @@ begin
   Result.FEnabled := Self.FEnabled;
   Result.FOutput := Self.FOutput;
   Result.FDebug := Self.FDebug;
+  Result.FSizeStripChars := Self.FSizeStripChars;
 end;
 
 { TSignatureList }


### PR DESCRIPTION
workaround for zpaqfranz/fanext etc which show in the size position thousandth separators, -, -dir- and other fancy stuff that break the parser