### PR TITLE
ADD: Built-in editor menu item "Edit - Time/Date".

### DIFF
--- a/src/feditor.lfm
+++ b/src/feditor.lfm
@@ -820,6 +820,9 @@ object frmEditor: TfrmEditor
       object miGotoLine: TMenuItem
         Action = actEditGotoLine
       end
+      object miTimeDate: TMenuItem
+        Action = actEditTimeDate
+      end
       object N5: TMenuItem
         Caption = '-'
       end
@@ -1030,6 +1033,11 @@ object frmEditor: TfrmEditor
       Category = 'Edit'
       Caption = 'Goto Line...'
       ImageIndex = 16
+      OnExecute = actExecute
+    end
+    object actEditTimeDate: TAction
+      Category = 'Edit'
+      Caption = 'Time/Date'
       OnExecute = actExecute
     end
     object actEditFindPrevious: TAction

--- a/src/feditor.lrj
+++ b/src/feditor.lrj
@@ -51,6 +51,7 @@
 {"hash":42146617,"name":"tfrmeditor.acteditlineendcrlf.caption","sourcebytes":[87,105,110,100,111,119,115,32,40,67,82,76,70,41],"value":"Windows (CRLF)"},
 {"hash":42146617,"name":"tfrmeditor.acteditlineendcrlf.hint","sourcebytes":[87,105,110,100,111,119,115,32,40,67,82,76,70,41],"value":"Windows (CRLF)"},
 {"hash":102945374,"name":"tfrmeditor.acteditgotoline.caption","sourcebytes":[71,111,116,111,32,76,105,110,101,46,46,46],"value":"Goto Line..."},
+{"hash":58979237,"name":"tfrmeditor.actedittimedate.caption","sourcebytes":[84,105,109,101,47,68,97,116,101],"value":"Time/Date"},
 {"hash":97034739,"name":"tfrmeditor.acteditfindprevious.caption","sourcebytes":[70,105,110,100,32,112,114,101,118,105,111,117,115],"value":"Find previous"},
 {"hash":93074804,"name":"tfrmeditor.actfilereload.caption","sourcebytes":[82,101,108,111,97,100],"value":"Reload"}
 ]}

--- a/src/feditor.pas
+++ b/src/feditor.pas
@@ -59,6 +59,7 @@ type
     actEditGotoLine: TAction;
     actEditFindPrevious: TAction;
     actFileReload: TAction;
+    actEditTimeDate: TAction;
     ilBookmarks: TImageList;
     MainMenu1: TMainMenu;
     ActListEdit: TActionList;
@@ -73,6 +74,7 @@ type
     miFileReload: TMenuItem;
     miFindPrevious: TMenuItem;
     miGotoLine: TMenuItem;
+    miTimeDate: TMenuItem;
     miEditLineEndCr: TMenuItem;
     miEditLineEndLf: TMenuItem;
     miEditLineEndCrLf: TMenuItem;
@@ -204,6 +206,7 @@ type
      procedure cm_EditFindNext(const {%H-}Params:array of string);
      procedure cm_EditFindPrevious(const {%H-}Params:array of string);
      procedure cm_EditGotoLine(const {%H-}Params:array of string);
+     procedure cm_EditTimeDate(const {%H-}Params:array of string);
      procedure cm_EditLineEndCr(const {%H-}Params:array of string);
      procedure cm_EditLineEndCrLf(const {%H-}Params:array of string);
      procedure cm_EditLineEndLf(const {%H-}Params:array of string);
@@ -847,6 +850,11 @@ begin
     Editor.TopLine := NewTopLine;
     Editor.SetFocus;
   end;
+end;
+
+procedure TfrmEditor.cm_EditTimeDate(const Params:array of string);
+begin
+     Editor.InsertTextAtCaret (FormatDateTime ('hh:nn ddddd', Now));
 end;
 
 procedure TfrmEditor.cm_EditLineEndCr(const Params:array of string);


### PR DESCRIPTION
The implemented feature inserts current time and date into the current position of the edited text, like it Notepad in Windows does.