### PR TITLE
Support wfx://... paths in command line

### DIFF
--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -6250,14 +6250,17 @@ procedure TfrmMain.LoadTabsCommandLine(Params: TCommandLineParams);
     if Length(aPath) <> 0 then
     begin
       aPath:= ReplaceEnvVars(ReplaceTilde(aPath));
-      if not mbFileSystemEntryExists(aPath) then
+      if not mbFileSystemEntryExists(aPath) and not aPath.StartsWith('wfx://') then
         aPath:= GetDeepestExistingPath(aPath);
       if Length(aPath) <> 0 then
       begin
         if Params.NewTab then
           AddTab(aNoteBook, aPath)
         else
-          aNoteBook.ActivePage.FileView.ChangePathAndSetActiveFile(aPath)
+          if aPath.StartsWith('wfx://') then
+            Commands.cm_ChangeDir([aPath])
+          else
+            aNoteBook.ActivePage.FileView.ChangePathAndSetActiveFile(aPath);
       end;
     end;
   end;

--- a/src/ucmdlineparams.pas
+++ b/src/ucmdlineparams.pas
@@ -31,11 +31,14 @@ uses
 function DecodePath(const Path: String): String;
 begin
   Result := TrimQuotes(Path);
-  if Pos(fileScheme, Result) = 1 then
+  if not Result.StartsWith('wfx://') then
   begin
-    Result:= URIDecode(Copy(Result, 8, MaxInt));
+    if Pos(fileScheme, Result) = 1 then
+    begin
+      Result:= URIDecode(Copy(Result, 8, MaxInt));
+    end;
+    Result:= GetAbsoluteFileName(IncludeTrailingBackslash(GetCurrentDir), Result);
   end;
-  Result:= GetAbsoluteFileName(IncludeTrailingBackslash(GetCurrentDir), Result);
 end;
 
 procedure ProcessCommandLineParams;


### PR DESCRIPTION
Double Commander supports initial FilePanels' paths in command line (with optional -L and/or -R), but currently ignores _paths_ supported by WFX plugins. This pull request is a raw attempt to fix that.