### PR TITLE
Fix Shift+Enter when path has space

### DIFF
--- a/src/platform/uOSUtils.pas
+++ b/src/platform/uOSUtils.pas
@@ -76,7 +76,7 @@ const
   RunTermCmd: String = 'xterm';  // default terminal
   RunTermParams: String = '';
   RunInTermStayOpenCmd: String = 'xterm'; // default run in terminal command AND Stay open after command
-  RunInTermStayOpenParams: String = '-e sh -c ''{command}; echo -n Press ENTER to exit... ; read a''';
+  RunInTermStayOpenParams: String = '-e sh -c ''"{command}"; echo -n Press ENTER to exit... ; read a''';
   RunInTermCloseCmd: String = 'xterm'; // default run in terminal command AND Close after command
   RunInTermCloseParams: String = '-e sh -c ''{command}''';
   MonoSpaceFont: String = 'Monospace';


### PR DESCRIPTION
Fix https://github.com/doublecmd/doublecmd/issues/1966