### PR TITLE
UPD: better thread-safe TFileSource reference counting

### DIFF
--- a/src/filesources/filesystem/ufilesystemfilesource.pas
+++ b/src/filesources/filesystem/ufilesystemfilesource.pas
@@ -785,7 +785,7 @@ class function TFileSystemFileSource.GetFileSource: IFileSystemFileSource;
 var
   aFileSource: IFileSource;
 begin
-  aFileSource := FileSourceManager.Find(TFileSystemFileSource, '');
+  aFileSource := FileSourceManager_Find(TFileSystemFileSource, '');
   if not Assigned(aFileSource) then
     Result := TFileSystemFileSource.Create
   else

--- a/src/filesources/uarchivefilesourceutil.pas
+++ b/src/filesources/uarchivefilesourceutil.pas
@@ -49,7 +49,7 @@ begin
     Exit(nil);
 
   // Check if there is a registered WCX plugin for possible archive.
-  Result := FileSourceManager.Find(TWcxArchiveFileSource, ArchiveFileName) as IArchiveFileSource;
+  Result := FileSourceManager_Find(TWcxArchiveFileSource, ArchiveFileName) as IArchiveFileSource;
   if not Assigned(Result) then
   begin
     if ArchiveSign then
@@ -62,7 +62,7 @@ begin
   // Check if there is a registered MultiArc addon for possible archive.
   if not Assigned(Result) then
   begin
-    Result := FileSourceManager.Find(TMultiArchiveFileSource, ArchiveFileName) as IArchiveFileSource;
+    Result := FileSourceManager_Find(TMultiArchiveFileSource, ArchiveFileName) as IArchiveFileSource;
     if not Assigned(Result) then
     begin
       if ArchiveSign then

--- a/src/filesources/ufilesource.pas
+++ b/src/filesources/ufilesource.pas
@@ -211,7 +211,11 @@ type
 
   { TFileSource }
 
-  TFileSource = class(TInterfacedObject, IFileSource)
+  TFileSource = class(TObject, IFileSource)
+    RefCount: Integer;
+    function QueryInterface(constref iid: TGuid; out obj): Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
+    function _AddRef: Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
+    function _Release: Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
 
   private
     FEventListeners: TMethodList;
@@ -295,6 +299,8 @@ type
   public
     constructor Create; virtual; overload;
     constructor Create(const URI: TURI); virtual; overload;
+    procedure AfterConstruction; override;
+    procedure BeforeDestruction; override;
     destructor Destroy; override;
 
     function GetWatcher: TFileSourceWatcher; virtual;
@@ -443,19 +449,6 @@ type
     property AssignedOperation: TFileSourceOperation read GetAssignedOperation;
   end;
 
-  { TFileSources }
-
-  TFileSources = class(TInterfaceList)
-  private
-    function Get(I: Integer): IFileSource;
-    procedure Put(i : Integer;item : IFileSource);
-
-  public
-    procedure Assign(otherFileSources: TFileSources);
-
-    property Items[I: Integer]: IFileSource read Get write Put; default;
-  end;
-
   EFileSourceException = class(Exception);
   EFileNotFound = class(EFileSourceException)
   private
@@ -486,15 +479,6 @@ begin
 
   FEventListeners := TMethodList.Create;
 
-  FileSourceManager.Add(Self); // Increases RefCount
-
-  // We don't want to count the reference in Manager, because we want to detect
-  // when there are no more references other than this single one in the Manager.
-  // So, we remove this reference here.
-  // When RefCount reaches 0 Destroy gets called and the last remaining reference
-  // (in the Manager) is removed there.
-  InterLockedDecrement(frefcount);
-
   DCDebug('Creating ', ClassName);
 end;
 
@@ -513,43 +497,83 @@ begin
   FCurrentAddress:= EncodeURI(AddressURI);
 end;
 
+procedure TFileSource.AfterConstruction;
+begin
+  inherited AfterConstruction;
+
+  if RefCount <> 0 then
+    DCDebug('Error: AfterConstruction ', ClassName, ' when refcount=', DbgS(refcount));
+
+  EnterCriticalSection(AllFileSourceObjectsCriticalSection);
+  try
+    AllFileSourceObjects.Add(Self);
+  finally
+    LeaveCriticalSection(AllFileSourceObjectsCriticalSection);
+  end;
+end;
+
+procedure TFileSource.BeforeDestruction;
+begin
+  if RefCount <> 0 then
+    DCDebug('Error: BeforeDestruction ', ClassName, ' when refcount=', DbgS(refcount));
+
+  EnterCriticalSection(AllFileSourceObjectsCriticalSection);
+  try
+    AllFileSourceObjects.Remove(Self);
+  finally
+    LeaveCriticalSection(AllFileSourceObjectsCriticalSection);
+  end;
+
+  inherited BeforeDestruction;
+end;
+
 destructor TFileSource.Destroy;
 begin
   DCDebug('Destroying ', ClassName, ' when refcount=', DbgS(refcount));
 
   if RefCount <> 0 then
-  begin
-    // There could have been an exception raised in the constructor
-    // in which case RefCount will be 1, so only issue warning if there was no exception.
-    // This will check for any exception, but it's enough for a warning.
-    if not Assigned(ExceptObject) then
-      DCDebug('Error: RefCount <> 0 for ', Self.ClassName);
-  end;
-
-  if Assigned(FileSourceManager) then
-  begin
-    // Restore reference removed in Create and
-    // remove the instance remaining in Manager.
-
-    // Increase refcount by 2, because we don't want removing the last instance
-    // from Manager to trigger another Destroy.
-
-    // RefCount = 0
-    InterLockedIncrement(frefcount);
-    InterLockedIncrement(frefcount);
-    // RefCount = 2
-    FileSourceManager.Remove(Self);
-    // RefCount = 1
-    InterLockedDecrement(frefcount);
-    // RefCount = 0 (back at the final value)
-  end
-  else
-    DCDebug('Error: Cannot remove file source - manager already destroyed!');
+    DCDebug('Error: RefCount <> 0 for ', ClassName);
 
   FreeAndNil(FChildrenFileSource);
   FreeAndNil(FEventListeners);
 
   inherited Destroy;
+end;
+
+function TFileSource.QueryInterface(constref iid: TGuid; out obj): Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
+begin
+  if GetInterface(iid, obj) then
+    Result:= S_OK
+  else
+    Result:= E_NOINTERFACE;
+end;
+
+function TFileSource._AddRef: Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
+begin
+  EnterCriticalSection(AllFileSourceObjectsCriticalSection);
+  try
+    Result:= RefCount+1;
+    RefCount:= Result;
+  finally
+    LeaveCriticalSection(AllFileSourceObjectsCriticalSection);
+  end;
+end;
+
+function TFileSource._Release: Integer;{$IFNDEF WINDOWS}cdecl{$ELSE}stdcall{$ENDIF};
+begin
+  EnterCriticalSection(AllFileSourceObjectsCriticalSection);
+  try
+    Result:= RefCount-1;
+    RefCount:= Result;
+    // don't destroy if ...
+    if// there are still references or ...
+      (Result<>0) or
+      // during construction or destruction (self is not in AllFileSourceObjects)
+      (AllFileSourceObjects.IndexOf(Self)<0) then Exit;
+  finally
+    LeaveCriticalSection(AllFileSourceObjectsCriticalSection);
+  end;
+  Destroy;
 end;
 
 function TFileSource.GetWatcher: TFileSourceWatcher;
@@ -575,11 +599,9 @@ end;
 
 function TFileSource.IsInterface(InterfaceGuid: TGuid): Boolean;
 var
-  t: TObject;
+  t: Pointer;
 begin
-  Result := (Self.QueryInterface(InterfaceGuid, t) = S_OK);
-  if Result then
-    _Release;  // QueryInterface increases refcount.
+  Result := GetInterfaceWeak(InterfaceGuid, t);
 end;
 
 function TFileSource.IsClass(aClassType: TClass): Boolean;
@@ -1083,30 +1105,6 @@ begin
   finally
     FOperationLock.Release;
   end;
-end;
-
-{ TFileSources }
-
-function TFileSources.Get(I: Integer): IFileSource;
-begin
-  if (I >= 0) and (I < Count) then
-    Result := inherited Items[I] as IFileSource
-  else
-    Result := nil;
-end;
-
-procedure TFileSources.Put(i: Integer; item: IFileSource);
-begin
-  inherited Put(i, item);
-end;
-
-procedure TFileSources.Assign(otherFileSources: TFileSources);
-var
-  i: Integer;
-begin
-  Clear;
-  for i := 0 to otherFileSources.Count - 1 do
-    Add(otherFileSources.Items[i]);
 end;
 
 constructor EFileNotFound.Create(const AFilePath: string);

--- a/src/filesources/ufilesourcemanager.pas
+++ b/src/filesources/ufilesourcemanager.pas
@@ -5,32 +5,16 @@ unit uFileSourceManager;
 interface
 
 uses
-  Classes, SysUtils, syncobjs,
+  Classes, SysUtils,
   uFileSource, uFileSourceOperationTypes, uFileSourceUtil,
   uDebug, DCStrUtils;
 
+function FileSourceManager_Find(FileSourceClass: TClass; Address: String; CaseSensitive: Boolean = True): IFileSource;
+
+procedure FileSourceManager_consultOperation( var params: TFileSourceConsultParams );
+procedure FileSourceManager_confirmOperation( var params: TFileSourceConsultParams );
+
 type
-  { TFileSourceManager }
-
-  TFileSourceManager = class
-  private
-    _lockObject: TCriticalSection;
-  private
-    FFileSources: TFileSources;
-  public
-    // Only allow adding and removing to/from Manager by TFileSource constructor and destructor.
-    procedure Add(aFileSource: IFileSource);
-    procedure Remove(aFileSource: IFileSource);
-
-    constructor Create;
-    destructor Destroy; override;
-
-    function Find(FileSourceClass: TClass; Address: String; CaseSensitive: Boolean = True): IFileSource;
-
-    procedure consultOperation( var params: TFileSourceConsultParams );
-    procedure confirmOperation( var params: TFileSourceConsultParams );
-  end;
-
   { TDefaultFileSourceProcessor }
 
   TDefaultFileSourceProcessor = class( TFileSourceProcessor )
@@ -44,100 +28,54 @@ type
   end;
 
 var
-  FileSourceManager: TFileSourceManager;
+  AllFileSourceObjects: TFPList;// item type is TFileSource
+  AllFileSourceObjectsCriticalSection: TRTLCriticalSection;
 
 implementation
 
-{ TFileSourceManager }
-
-constructor TFileSourceManager.Create;
-begin
-  _lockObject:= TCriticalSection.Create;;
-  FFileSources := TFileSources.Create;
-end;
-
-destructor TFileSourceManager.Destroy;
-var
-  i: Integer;
-begin
-  if FFileSources.Count > 0 then
-  begin
-    DCDebug('Warning: Destroying manager with existing file sources!');
-
-    for i := 0 to FFileSources.Count - 1 do
-    begin
-      // Restore the reference taken in TFileSource.Create before removing
-      // all file sources from the list.
-      FFileSources[i]._AddRef;
-      // Free instance.
-      FFileSources[i]:= nil;
-    end;
-  end;
-
-  FreeAndNil(FFileSources);
-  FreeAndNil( _lockObject );
-
-  inherited Destroy;
-end;
-
-procedure TFileSourceManager.Add(aFileSource: IFileSource);
-begin
-  _lockObject.Acquire;
-  try
-    if FFileSources.IndexOf(aFileSource) < 0 then
-    begin
-      FFileSources.Add(aFileSource);
-    end
-    else
-      DCDebug('Error: File source already exists in manager!');
-  finally
-    _lockObject.Release;
-  end;
-end;
-
-procedure TFileSourceManager.Remove(aFileSource: IFileSource);
-begin
-  _lockObject.Acquire;
-  try
-    FFileSources.Remove(aFileSource);
-  finally
-    _lockObject.Release;
-  end;
-end;
-
-function TFileSourceManager.Find(FileSourceClass: TClass; Address: String;
+function FileSourceManager_Find(FileSourceClass: TClass; Address: String;
   CaseSensitive: Boolean): IFileSource;
+type
+  TFileSourcePointer = ^TFileSource;
 var
-  I: Integer;
   StrCmp: function(const S1, S2: String): Integer;
-  fs: IFileSource;
+  fl: TFileSourcePointer;
+  i: Integer;
+  f: TFileSource;
+  SilentResult: Pointer absolute Result;// no auto reference counting on assign!
 begin
   if CaseSensitive then
     StrCmp:= @CompareStr
   else begin
     StrCmp:= @CompareText;
   end;
+  SilentResult:= nil;
 
-  _lockObject.Acquire;
+  EnterCriticalSection(AllFileSourceObjectsCriticalSection);
   try
-    for I := 0 to FFileSources.Count - 1 do
+    fl:= TFileSourcePointer(AllFileSourceObjects.List);
+    for i:= 0 to AllFileSourceObjects.Count-1 do
     begin
-      fs:= FFileSources[I];
-      if (fs.IsClass(FileSourceClass)) and
-         (StrCmp(fs.CurrentAddress, Address) = 0) then
+      f:= fl[i];
+      // (f.RefCount<>0) check to avoid finding objects that:
+      //   1. constructed (after AfterConstruction) but didn't yet gain a reference
+      // or
+      //   2. lost all references but not yet called BeforeDestruction
+      if (f.RefCount<>0) and (f is FileSourceClass) and (StrCmp(f.CurrentAddress, Address)=0) then
       begin
-        Result := fs;
-        Exit;
+        // inc(f.RefCount) instead of f._AddRef to not EnterCriticalSection(AllFileSourceObjectsCriticalSection) again
+        inc(f.RefCount);
+        // IFileSource(f) doesn't call anything
+        SilentResult:= IFileSource(f);
+        Break;
       end;
     end;
   finally
-    _lockObject.Release;
+    LeaveCriticalSection(AllFileSourceObjectsCriticalSection);
   end;
-
-  Result := nil;
 end;
 
-procedure TFileSourceManager.consultOperation( var params: TFileSourceConsultParams);
+procedure FileSourceManager_consultOperation( var params: TFileSourceConsultParams);
 var
   fs: IFileSource;
   processor: TFileSourceProcessor;
@@ -170,7 +108,7 @@ begin
     processor.consultOperation( params );
 end;
 
-procedure TFileSourceManager.confirmOperation(var params: TFileSourceConsultParams);
+procedure FileSourceManager_confirmOperation(var params: TFileSourceConsultParams);
 var
   fs: IFileSource;
   processor: TFileSourceProcessor;
@@ -289,12 +227,12 @@ begin
 end;
 
 initialization
-  FileSourceManager := TFileSourceManager.Create;
-  defaultFileSourceProcessor:= TDefaultFileSourceProcessor.Create;
+  AllFileSourceObjects:= TFPList.Create;
+  InitCriticalSection(AllFileSourceObjectsCriticalSection);
 
 finalization
-  FreeAndNil(FileSourceManager);
-  FreeAndNil(defaultFileSourceProcessor);
+  if AllFileSourceObjects.Count > 0 then
+    DCDebug('Warning: AllFileSourceObjects has existing file sources!');
 
 end.
 

--- a/src/filesources/ufilesourceutil.pas
+++ b/src/filesources/ufilesourceutil.pas
@@ -178,7 +178,7 @@ begin
   if aFileView.FileSource.IsClass(TVfsFileSource) then
   begin
     // Check if there is a registered WFX plugin by file system root name.
-    FileSource := FileSourceManager.Find(TWfxPluginFileSource, 'wfx://' + aFile.Name);
+    FileSource := FileSourceManager_Find(TWfxPluginFileSource, 'wfx://' + aFile.Name);
     if not Assigned(FileSource) then
       FileSource := TWfxPluginFileSource.CreateByRootName(aFile.Name);
 
@@ -188,7 +188,7 @@ begin
       VfsModule:= gVfsModuleList.VfsModule[aFile.Name];
       if Assigned(VfsModule) then
       begin
-        FileSource := FileSourceManager.Find(VfsModule.FileSourceClass, aFile.Name);
+        FileSource := FileSourceManager_Find(VfsModule.FileSourceClass, aFile.Name);
         if not Assigned(FileSource) then
           FileSource := VfsModule.FileSourceClass.Create;
       end;
@@ -217,7 +217,7 @@ begin
           URI:= ParseURI(aPath);
           aPath:= NormalizePathDelimiters(URI.Path + URI.Document);
           aPath:= IncludeTrailingPathDelimiter(aPath);
-          Result:= FileSourceManager.Find(aFileSourceClass,
+          Result:= FileSourceManager_Find(aFileSourceClass,
                                               URI.Protocol + '://' + URI.Host,
                                               not SameText(URI.Protocol, 'smb')
                                               );

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -3659,7 +3659,7 @@ begin
     params.targetFS:= TargetFileSource;
     params.files:= SourceFiles;
     params.targetPath:= TargetPath;
-    FileSourceManager.consultOperation( params );
+    FileSourceManager_consultOperation( params );
 
     if params.consultResult = fscrCancel then
       Exit;
@@ -3711,7 +3711,7 @@ begin
           Exit;
 
         params.targetPath := CopyDialog.edtDst.Text;
-        FileSourceManager.confirmOperation( params );
+        FileSourceManager_confirmOperation( params );
 
         if SourceFileSource.IsClass(TArchiveFileSource) then
           BaseDir := ExtractFilePath(SourceFileSource.CurrentAddress)
@@ -3740,7 +3740,7 @@ begin
       QueueIdentifier := CopyDialog.QueueIdentifier;
     end
     else begin
-      FileSourceManager.confirmOperation( params );
+      FileSourceManager_confirmOperation( params );
       GetDestinationPathAndMask(SourceFiles, TargetFileSource, params.resultTargetPath,
                                 SourceFiles.Path, TargetPath, sDstMaskTemp);
       params.resultTargetPath:= TargetPath;
@@ -3850,7 +3850,7 @@ begin
     params.targetFS:= TargetFileSource;
     params.files:= SourceFiles;
     params.targetPath:= TargetPath;
-    FileSourceManager.consultOperation( params );
+    FileSourceManager_consultOperation( params );
 
     SourceFileSource:= params.sourceFS;
     bMove:= (params.consultResult = fscrSuccess);
@@ -3891,7 +3891,7 @@ begin
           Exit;
 
         params.targetPath := MoveDialog.edtDst.Text;
-        FileSourceManager.confirmOperation( params );
+        FileSourceManager_confirmOperation( params );
 
         GetDestinationPathAndMask(SourceFiles, SourceFileSource,
                                   TargetFileSource, params.resultTargetPath,
@@ -3914,7 +3914,7 @@ begin
       QueueIdentifier := MoveDialog.QueueIdentifier;
     end
     else begin
-      FileSourceManager.confirmOperation( params );
+      FileSourceManager_confirmOperation( params );
       GetDestinationPathAndMask(SourceFiles, TargetFileSource, params.resultTargetPath,
                                 SourceFiles.Path, TargetPath, sDstMaskTemp);
       params.resultTargetPath:= TargetPath;

--- a/src/platform/unix/darwin/uiclouddriver.pas
+++ b/src/platform/unix/darwin/uiclouddriver.pas
@@ -704,7 +704,7 @@ class function TiCloudDriverFileSource.GetFileSource: TiCloudDriverFileSource;
 var
   aFileSource: IFileSource;
 begin
-  aFileSource := FileSourceManager.Find(TiCloudDriverFileSource, iCloudDriverConfig.scheme );
+  aFileSource := FileSourceManager_Find(TiCloudDriverFileSource, iCloudDriverConfig.scheme );
   if not Assigned(aFileSource) then
     Result:= TiCloudDriverFileSource.Create
   else


### PR DESCRIPTION
1. works with latest freepascal ( https://gitlab.com/freepascal.org/fpc/source/-/commit/c3f80014b41db2cb4a6fa50a50c2548a03000124#note_2431141761 )
2. impossible to find IFileSource during constructing or destructing

note: there is code like: find {subclass of `IFileSource`} or create it if not found

https://github.com/doublecmd/doublecmd/blob/b7b47b21c17e47b35f60c972bdf242139b835a06/src/filesources/uarchivefilesourceutil.pas#L52-L61

that is not thread safe, multiple of {subclass of `IFileSource`} can be created if code like that runs on multiple threads