### PR TITLE
FIX: LANG: zh_CN: Fix translations

### DIFF
--- a/language/doublecmd.zh_CN.po
+++ b/language/doublecmd.zh_CN.po
@@ -8323,7 +8323,7 @@ msgstr ""
 #: tfrmquicksearch.sbfiles.hint
 msgctxt "tfrmquicksearch.sbfiles.hint"
 msgid "Files"
-msgstr "个文件"
+msgstr "文件"
 
 #: tfrmquicksearch.sbmatchbeginning.caption
 msgid "{"
@@ -11319,7 +11319,7 @@ msgstr "删除部分复制的文件？"
 #: ulng.rsmsgdelfldr
 #, object-pascal-format
 msgid "Delete %d selected files/directories?"
-msgstr "确定婪删除 %d 个选中的文件/文件夹吗？"
+msgstr "确定要删除 %d 个选中的文件/文件夹吗？"
 
 #: ulng.rsmsgdelfldrt
 #, object-pascal-format


### PR DESCRIPTION
I found some wrong translation:
**婪**删除  -> should be **要**删除 
"个文件" -> should be “文件”

screenshot:
![Screenshot 2025-05-01 010132](https://github.com/user-attachments/assets/4cd3f9bf-352d-4605-b152-663daa7a5c3a)
![Screenshot 2025-05-01 010220](https://github.com/user-attachments/assets/23a29096-fdad-46f0-bf87-668ddcd379b9)

Could you help to check it? Thanks!