### PR TITLE
UPD: Move DirectoryHotList to localconfig.xml

### DIFF
--- a/src/uGlobsPaths.pas
+++ b/src/uGlobsPaths.pas
@@ -16,6 +16,7 @@ var
 //Global Configuration Filename
 const
   gcfExtensionAssociation : string = 'extassoc.xml';
+  gcfLocalConfig : string = 'localconfig.xml';
   
 procedure LoadPaths;
 procedure UpdateEnvironmentVariable;

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -231,7 +231,8 @@ const
   // 13 -  Replace Configuration/UseConfigInProgramDir by doublecmd.inf
   // 14 -  Move some colors to colors.json
   // 15 -  Move custom columns colors to colors.json
-  ConfigVersion = 15;
+  // 16 -  Move DirectoryHotList to localconfig.xml
+  ConfigVersion = 16;
 
   COLORS_JSON = 'colors.json';
 
@@ -996,6 +997,33 @@ begin
   end;
 end;
 
+function LoadLocalConfig(var {%H-}ErrorMessage: String): Boolean;
+var
+  Root: TXmlNode;
+  LocalConfig: TXmlConfig;
+  LocalConfigFileName: String;
+begin
+  LocalConfigFileName := gpCfgDir + gcfLocalConfig;
+
+  if mbFileExists(LocalConfigFileName) then
+  begin
+    LocalConfig:= TXmlConfig.Create(LocalConfigFileName);
+    try
+      LocalConfig.Load;
+      Root:= LocalConfig.RootNode;
+      if Assigned(LocalConfig.FindNode(Root, cSectionOfHotDir)) then
+      begin
+        gDirectoryHotlist.LoadFromXml(LocalConfig, Root);
+        Exit(True);
+      end;
+    finally
+      LocalConfig.Free;
+    end;
+  end;
+
+  Result:= True;
+end;
+
 procedure SaveHistoryConfig;
 var
   Root: TXmlNode;
@@ -1046,6 +1074,23 @@ begin
     History.Save;
   finally
     History.Free;
+  end;
+end;
+
+procedure SaveLocalConfig;
+var
+  Root: TXmlNode;
+  LocalConfig: TXmlConfig;
+  LocalConfigFileName: String;
+begin
+  LocalConfigFileName := gpCfgDir + gcfLocalConfig;
+  LocalConfig:= TXmlConfig.Create(LocalConfigFileName);
+  try
+    Root:= LocalConfig.RootNode;
+    gDirectoryHotlist.SaveToXml(LocalConfig, Root, True);
+    LocalConfig.Save;
+  finally
+    LocalConfig.Free;
   end;
 end;
 
@@ -2486,6 +2531,9 @@ begin
 
   CopySettingsFiles;
 
+  { Local machine-specific configuration }
+  LoadConfigCheckErrors(@LoadLocalConfig, gpCfgDir + gcfLocalConfig, ErrorMessage);
+
   { Internal associations }
   // "LoadExtsConfig" checks itself if file is present or not
   LoadConfigCheckErrors(@LoadExtsConfig, gpCfgDir + gcfExtensionAssociation, ErrorMessage);
@@ -2563,6 +2611,7 @@ begin
   begin
     SaveWithCheck(@SaveEarlyConfig, 'early config', ErrMsg);
     SaveWithCheck(@SaveCfgIgnoreList, 'ignore list', ErrMsg);
+    SaveWithCheck(@SaveLocalConfig, 'local configuration', ErrMsg);
     SaveWithCheck(@SaveCfgMainConfig, 'main configuration', ErrMsg);
     SaveWithCheck(@SaveHighlightersConfig, 'highlighters config', ErrMsg);
     SaveWithCheck(@SaveHistoryConfig, 'various history', ErrMsg);
@@ -2666,6 +2715,12 @@ begin
     if (LoadedConfigVersion < 13) then
     begin
       DeleteNode(Root, 'Configuration/UseConfigInProgramDir');
+    end;
+
+    if (LoadedConfigVersion < 16) then
+    begin
+      gDirectoryHotlist.LoadFromXML(gConfig, Root);
+      DeleteNode(Root, cSectionOfHotDir);
     end;
 
     { Language page }
@@ -3221,9 +3276,6 @@ begin
       gIgnoreListFileEnabled:= GetAttr(Node, 'Enabled', gIgnoreListFileEnabled);
       gIgnoreListFile:= GetValue(Node, 'IgnoreListFile', gIgnoreListFile);
     end;
-
-    { Directories HotList }
-    gDirectoryHotlist.LoadFromXML(gConfig, Root);
 
     { Viewer }
     Node := Root.FindNode('Viewer');
@@ -3823,9 +3875,6 @@ begin
     Node := FindNode(Root, 'IgnoreList', True);
     SetAttr(Node, 'Enabled', gIgnoreListFileEnabled);
     SetValue(Node, 'IgnoreListFile', gIgnoreListFile);
-
-    { Directories HotList }
-    gDirectoryHotlist.SaveToXml(gConfig, Root, TRUE);
 
     { Viewer }
     Node := FindNode(Root, 'Viewer',True);


### PR DESCRIPTION
#  Move DirectoryHotList to localconfig.xml and introduce machine-specific local configuration

  # Description

  This change separates DirectoryHotList from doublecmd.xml and stores it in a new localconfig.xml file.

  The motivation is that filesystem structure differs between systems. A shared doublecmd.xml works well for portable/common settings, but DirectoryHotList often contains machine-specific paths that should not
  be synchronized across different environments.

  This PR also opens a more general-purpose local configuration layer. localconfig.xml is not introduced as a hotlist-only file, it is intended to be the place for settings that are inherently system-specific
  and should remain outside the shared main configuration.

  # What Changed

  - Added a new machine-specific configuration file: localconfig.xml
  - Moved DirectoryHotList serialization/deserialization to localconfig.xml
  - Kept the XML structure under:
```
    <doublecmd>
      <DirectoryHotList>
        ...
      </DirectoryHotList>
    </doublecmd>
```
  - Added migration logic for legacy configurations
  - Bumped config version to trigger one-time migration behavior

  # Migration Behavior

  - Existing configurations still load correctly
  - If localconfig.xml does not yet contain DirectoryHotList, Double Commander falls back to the legacy node in doublecmd.xml
  - For configs older than version 16, the legacy DirectoryHotList node is removed from the in-memory main config after it is migrated, so it disappears from doublecmd.xml on the next save

  # Why This Is Useful

  - Shared configuration becomes cleaner and more portable between systems
  - Machine-specific path data is isolated
  - Establishes a reusable mechanism for future local-only settings

  # Notes

  - doublecmd.xml remains the shared configuration file
  - localconfig.xml is the new machine-specific companion configuration file