### PR TITLE
ADD: Separate split terminals under each panel with smart link/unlink synchronization

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ set -e
 # release - compile in release mode (using by default)
 
 # path to lazbuild
-export lazbuild=$(which lazbuild)
+export lazbuild="$(which lazbuild) --pcp=$(pwd)/.lazarus --lazarusdir=/usr/lib/lazarus"
 
 # Set up widgetset: gtk2 or qt or qt5 or cocoa
 # Set up processor architecture: i386 or x86_64

--- a/components/virtualterminal/source/unix/vtemupty.pas
+++ b/components/virtualterminal/source/unix/vtemupty.pas
@@ -62,6 +62,7 @@ type
     function WriteStr(const Str: string): Integer; override;
     function SetCurrentDir(const Path: String): Boolean; override;
     function SetScreenSize(aCols, aRows: Integer): Boolean; override;
+    function GetChildPid: THandle; override;
   end;
 
 implementation
@@ -215,6 +216,11 @@ begin
     FCols:= aCols;
     FRows:= aRows;
   end;
+end;
+
+function TPtyDevice.GetChildPid: THandle;
+begin
+  Result := FChildPid;
 end;
 
 end.

--- a/components/virtualterminal/source/unix/vtemupty.pas
+++ b/components/virtualterminal/source/unix/vtemupty.pas
@@ -161,6 +161,8 @@ begin
   if FChildPid = 0 then
   begin
     FileCloseOnExecAll;
+    if FInitialDir <> '' then
+      fpChdir(FInitialDir);
     setenv('TERM', 'xterm-256color', 1);
     execl(PAnsiChar(cmd), PAnsiChar(cmd), nil);
     Errors.PError('execl() failed. Command: '+ cmd, cerrno);
@@ -204,18 +206,19 @@ function TPtyDevice.SetScreenSize(aCols, aRows: Integer): Boolean;
 var
   ws: TWinSize;
 begin
-  ws.ws_row:= aRows;
-  ws.ws_col:= aCols;
-  ws.ws_xpixel:= 0;
-  ws.ws_ypixel:= 0;
+  FCols:= aCols;
+  FRows:= aRows;
 
-  Result:= FpIOCtl(Fpty,TIOCSWINSZ,@ws) = 0;
-
-  if Result then
+  if FConnected then
   begin
-    FCols:= aCols;
-    FRows:= aRows;
-  end;
+    ws.ws_row:= aRows;
+    ws.ws_col:= aCols;
+    ws.ws_xpixel:= 0;
+    ws.ws_ypixel:= 0;
+    Result:= FpIOCtl(Fpty,TIOCSWINSZ,@ws) = 0;
+  end
+  else
+    Result:= True;
 end;
 
 function TPtyDevice.GetChildPid: THandle;

--- a/components/virtualterminal/source/vtemuctl.pas
+++ b/components/virtualterminal/source/vtemuctl.pas
@@ -25,7 +25,7 @@ interface
 
 uses
   LCLType, Classes, Controls, StdCtrls, ExtCtrls, Forms, Messages, Graphics,
-  VTEmuEsc, LCLIntf, Types, LazUtf8, LMessages;
+  VTEmuEsc, LCLIntf, Types, LazUtf8, LMessages, Clipbrd;
 
 type
 
@@ -75,12 +75,18 @@ type
   strict private
     FRows: Integer;
     FColumns: Integer;
+    FHistory: array[0..99] of Pointer;
+    FHistoryHead: Integer;
+    FHistoryCount: Integer;
   public
     constructor Create(AOwner: TCustomComTerminal);
     destructor Destroy; override;
     procedure Init(ARows, AColumns: Integer);
     procedure SetChar(Column, Row: Integer; TermChar: TComTermChar);
     function GetChar(Column, Row: Integer): TComTermChar;
+    function GetHistoryChar(Column, HistRow: Integer): TComTermChar;
+    procedure PushHistoryLine(LineData: PByte);
+    function GetHistoryCount: Integer;
     procedure SetTab(Column: Integer; Put: Boolean);
     function GetTab(Column: Integer): Boolean;
     function NextTab(Column: Integer): Integer;
@@ -158,6 +164,9 @@ type
     FTopLeft: TPoint;
     FCaretHeight: Integer;
     FSaveAttr: TTermAttributes;
+    FSelecting: Boolean;
+    FSelStart: TPoint;
+    FSelEnd: TPoint;
     FBuffer: TComTermBuffer;
     FMainBuffer: TComTermBuffer;
     FAlternateBuffer: TComTermBuffer;
@@ -192,6 +201,7 @@ type
     procedure SetMode(AParams: TStrings; OnOff: Boolean);
     procedure ShowCaret;
     procedure StringReceived(Str: string);
+    function IsSelected(AColumn, ARow: Integer): Boolean;
     procedure PaintTerminal(Rect: TRect);
     procedure PaintDesign;
     procedure PutChar(Ch: TUTF8Char);
@@ -225,6 +235,7 @@ type
     procedure KeyPress(var Key: Char); override;
     procedure UTF8KeyPress(var UTF8Key: TUTF8Char); override;
     procedure MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Integer); override;
+    procedure MouseMove(Shift: TShiftState; X, Y: Integer); override;
     procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X, Y: Integer); override;
     procedure CreateWnd; override;
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
@@ -242,6 +253,7 @@ type
     procedure MoveCaret(AColumn, ARow: Integer);
     procedure Write(const Buffer:string; Size: Integer);
     procedure WriteStr(const Str: string);
+    procedure CopyToClipboard;
     procedure WriteEscCode(ACode: TEscapeCode; AParams: TStrings);
     procedure LoadFromStream(Stream: TStream);
     procedure SaveToStream(Stream: TStream);
@@ -355,16 +367,25 @@ const
 
 // create class
 constructor TComTermBuffer.Create(AOwner: TCustomComTerminal);
+var
+  I: Integer;
 begin
   inherited Create;
   FOwner := AOwner;
   FTopLeft := Classes.Point(1, 1);
   FCaretPos := Classes.Point(1, 1);
+  for I := 0 to 99 do FHistory[I] := nil;
+  FHistoryCount := 0;
+  FHistoryHead := 0;
 end;
 
 // destroy class
 destructor TComTermBuffer.Destroy;
+var
+  I: Integer;
 begin
+  for I := 0 to 99 do
+    if FHistory[I] <> nil then FreeMem(FHistory[I]);
   if FBuffer <> nil then
   begin
     FreeMem(FBuffer);
@@ -397,9 +418,49 @@ begin
   Result:= PComTermChar(FBuffer + (Address * SizeOf(TComTermChar)))^;
 end;
 
+function TComTermBuffer.GetHistoryCount: Integer;
+begin
+  Result := FHistoryCount;
+end;
+
+function TComTermBuffer.GetHistoryChar(Column, HistRow: Integer): TComTermChar;
+var
+  Index: Integer;
+  LineData: PComTermChar;
+begin
+  if (Column > FColumns) or (HistRow < 1) or (HistRow > FHistoryCount) then
+    Exit(Default(TComTermChar));
+  Index := (FHistoryHead - HistRow + 100) mod 100;
+  LineData := PComTermChar(FHistory[Index]);
+  if LineData <> nil then
+    Result := LineData[Column - 1]
+  else
+    Result := Default(TComTermChar);
+end;
+
+procedure TComTermBuffer.PushHistoryLine(LineData: PByte);
+var
+  LineSize: Integer;
+begin
+  LineSize := FColumns * SizeOf(TComTermChar);
+  if FHistory[FHistoryHead] = nil then
+    GetMem(FHistory[FHistoryHead], LineSize);
+  Move(LineData^, FHistory[FHistoryHead]^, LineSize);
+  FHistoryHead := (FHistoryHead + 1) mod 100;
+  if FHistoryCount < 100 then
+    Inc(FHistoryCount);
+end;
+
 // scroll down up line
 procedure TComTermBuffer.ScrollDown;
+var
+  LineData: PByte;
 begin
+  if FScrollRange.Top = 1 then
+  begin
+    LineData := FBuffer;
+    PushHistoryLine(LineData);
+  end;
   DeleteLine(FScrollRange.Top, 1);
 end;
 
@@ -864,6 +925,8 @@ begin
       I+= L;
     end;
   finally
+    UpdateScrollRange;
+    UpdateScrollPos;
     ShowCaret;
   end;
 end;
@@ -1098,6 +1161,28 @@ var
 begin
   inherited KeyDown(Key, Shift);
 
+  // Copy: Ctrl+Shift+C or Ctrl+Insert
+  if ((Key = VK_C) and (ssCtrl in Shift) and (ssShift in Shift)) or
+     ((Key = VK_INSERT) and (ssCtrl in Shift)) then
+  begin
+    CopyToClipboard;
+    Key := 0;
+    Exit;
+  end;
+
+  // Paste: Ctrl+Shift+V or Shift+Insert
+  if ((Key = VK_V) and (ssCtrl in Shift) and (ssShift in Shift)) or
+     ((Key = VK_INSERT) and (ssShift in Shift)) then
+  begin
+    if Clipboard.HasFormat(CF_TEXT) then
+    begin
+      if (FPtyDevice <> nil) and (FPtyDevice.Connected) then
+        FPtyDevice.WriteStr(Clipboard.AsText);
+    end;
+    Key := 0;
+    Exit;
+  end;
+
   if (Key in [VK_TAB, VK_ESCAPE]) then
   begin
     SendChar(Chr(Key));
@@ -1187,13 +1272,49 @@ procedure TCustomComTerminal.MouseDown(Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 begin
   inherited MouseDown(Button, Shift, X, Y);
+  if (not (FTermMode.MouseMode and FTermMode.MouseTrack)) and (Button = mbLeft) then
+  begin
+    FSelecting := True;
+    FSelStart.X := X div FFontWidth + FTopLeft.X;
+    FSelStart.Y := Y div FFontHeight + FTopLeft.Y;
+    FSelEnd := FSelStart;
+    Invalidate;
+  end;
   MouseEvent(ecMouseDown, Button, Shift, X, Y);
+end;
+
+procedure TCustomComTerminal.MouseMove(Shift: TShiftState; X, Y: Integer);
+begin
+  inherited MouseMove(Shift, X, Y);
+  if FSelecting then
+  begin
+    FSelEnd.X := X div FFontWidth + FTopLeft.X;
+    FSelEnd.Y := Y div FFontHeight + FTopLeft.Y;
+    if FSelEnd.X < 1 then FSelEnd.X := 1;
+    if FSelEnd.X > FColumns then FSelEnd.X := FColumns;
+    Invalidate;
+  end;
 end;
 
 procedure TCustomComTerminal.MouseUp(Button: TMouseButton; Shift: TShiftState;
   X, Y: Integer);
 begin
   inherited MouseUp(Button, Shift, X, Y);
+  if FSelecting and (Button = mbLeft) then
+  begin
+    FSelecting := False;
+    FSelEnd.X := X div FFontWidth + FTopLeft.X;
+    FSelEnd.Y := Y div FFontHeight + FTopLeft.Y;
+    Invalidate;
+  end
+  else if (not FSelecting) and (Button in [mbMiddle, mbRight]) then
+  begin
+    if Clipboard.HasFormat(CF_TEXT) then
+    begin
+      if (FPtyDevice <> nil) and (FPtyDevice.Connected) then
+        FPtyDevice.WriteStr(Clipboard.AsText);
+    end;
+  end;
   MouseEvent(ecMouseUp, Button, Shift, X, Y);
 end;
 
@@ -1231,7 +1352,15 @@ begin
     for I := Rect.Left to Rect.Right do
     begin
       X := I + FTopLeft.X - 1;
-      Ch := FBuffer.GetChar(X, Y);
+      if Y < 1 then
+        Ch := FBuffer.GetHistoryChar(X, 1 - Y)
+      else
+        Ch := FBuffer.GetChar(X, Y);
+      if IsSelected(X, Y) then
+      begin
+        Ch.BackColor := clHighlight;
+        Ch.FrontColor := clHighlightText;
+      end;
       if Ch.Ch <> Chr(0) then
         DrawChar(I, J, Ch);
     end;
@@ -1327,6 +1456,73 @@ begin
   end;
 end;
 
+function TCustomComTerminal.IsSelected(AColumn, ARow: Integer): Boolean;
+var
+  SY1, SY2, SX1, SX2: Integer;
+begin
+  if not FSelecting and (FSelStart.Y = 0) and (FSelEnd.Y = 0) then Exit(False);
+
+  if (FSelStart.Y < FSelEnd.Y) or ((FSelStart.Y = FSelEnd.Y) and (FSelStart.X <= FSelEnd.X)) then
+  begin
+    SY1 := FSelStart.Y; SX1 := FSelStart.X;
+    SY2 := FSelEnd.Y;   SX2 := FSelEnd.X;
+  end else
+  begin
+    SY1 := FSelEnd.Y;   SX1 := FSelEnd.X;
+    SY2 := FSelStart.Y; SX2 := FSelStart.X;
+  end;
+
+  if (ARow > SY1) and (ARow < SY2) then
+    Result := True
+  else if SY1 = SY2 then
+    Result := (ARow = SY1) and (AColumn >= SX1) and (AColumn <= SX2)
+  else if ARow = SY1 then
+    Result := AColumn >= SX1
+  else if ARow = SY2 then
+    Result := AColumn <= SX2
+  else
+    Result := False;
+end;
+
+procedure TCustomComTerminal.CopyToClipboard;
+var
+  SY1, SY2, SX1, SX2: Integer;
+  R, C: Integer;
+  S: String;
+  Ch: TComTermChar;
+begin
+  if (FSelStart.X = 0) and (FSelStart.Y = 0) and (FSelEnd.X = 0) and (FSelEnd.Y = 0) then Exit;
+
+  if (FSelStart.Y < FSelEnd.Y) or ((FSelStart.Y = FSelEnd.Y) and (FSelStart.X <= FSelEnd.X)) then
+  begin
+    SY1 := FSelStart.Y; SX1 := FSelStart.X;
+    SY2 := FSelEnd.Y;   SX2 := FSelEnd.X;
+  end else
+  begin
+    SY1 := FSelEnd.Y;   SX1 := FSelEnd.X;
+    SY2 := FSelStart.Y; SX2 := FSelStart.X;
+  end;
+
+  S := '';
+  for R := SY1 to SY2 do
+  begin
+    for C := 1 to FColumns do
+    begin
+      if IsSelected(C, R) then
+      begin
+        if R < 1 then
+          Ch := FBuffer.GetHistoryChar(C, 1 - R)
+        else
+          Ch := FBuffer.GetChar(C, R);
+        if Ch.Ch = #0 then S := S + ' '
+        else S := S + Ch.Ch;
+      end;
+    end;
+    if R < SY2 then S := S + LineEnding;
+  end;
+  Clipboard.AsText := S;
+end;
+
 // move caret after new char is put on screen
 procedure TCustomComTerminal.AdvanceCaret(Kind: TAdvanceCaret);
 var
@@ -1365,10 +1561,10 @@ begin
   end;
   if FAutoFollow then
   begin
-    if (FCaretPos.Y - FTopLeft.Y) > FVisibleRows then
+    if (FCaretPos.Y - FTopLeft.Y) >= FVisibleRows then
     begin
-      I:= FCaretPos.Y - FVisibleRows + 1;
-      ModifyScrollBar(SB_Vert, SB_THUMBPOSITION, I);
+      I := FCaretPos.Y - FVisibleRows + 1;
+      ModifyScrollBar(SB_VERT, SB_THUMBPOSITION, I - 1 + FBuffer.GetHistoryCount);
     end;
   end;
 end;
@@ -1553,7 +1749,7 @@ begin
     Dy := 0;
   end else
   begin
-    FTopLeft.Y := APos + 1;
+    FTopLeft.Y := APos + 1 - FBuffer.GetHistoryCount;
     Dx := 0;
     Dy := (OldPos - APos) * FFontHeight;
   end;
@@ -1572,7 +1768,7 @@ begin
   end;
   if FScrollBars in [ssBoth, ssVertical] then
   begin
-    SetScrollPos(Handle, SB_VERT, FTopLeft.Y - 1, True);
+    SetScrollPos(Handle, SB_VERT, FTopLeft.Y - 1 + FBuffer.GetHistoryCount, True);
   end;
 end;
 
@@ -1635,11 +1831,11 @@ var
     if OldScrollBars in [ssBoth, ssVertical] then
     begin
       ARows := AHeight div FFontHeight;
-      if ARows >= FBuffer.Rows then
+      if (ARows >= FBuffer.Rows) and (FBuffer.GetHistoryCount = 0) then
         SetRange(SB_VERT, 1)  // screen is high enough, hide scroll bar
       else
       begin
-        Max := FBuffer.Rows - (ARows - 1);
+        Max := FBuffer.Rows + FBuffer.GetHistoryCount - (ARows - 1);
         SetRange(SB_VERT, Max);
       end;
     end;

--- a/components/virtualterminal/source/vtemuctl.pas
+++ b/components/virtualterminal/source/vtemuctl.pas
@@ -37,6 +37,7 @@ type
   protected
     FOnRxBuf: TOnRxBuf;
     FConnected: Boolean;
+    FInitialDir: String;
   protected
     procedure SetConnected(AValue: Boolean); virtual; abstract;
   public
@@ -47,6 +48,7 @@ type
     property ChildPid: THandle read GetChildPid;
     property OnRxBuf: TOnRxBuf read FOnRxBuf write FOnRxBuf;
     property Connected: Boolean read FConnected write SetConnected default False;
+    property InitialDir: String read FInitialDir write FInitialDir;
   end;
 
   TCustomComTerminal = class;  // forward declaration

--- a/components/virtualterminal/source/vtemuctl.pas
+++ b/components/virtualterminal/source/vtemuctl.pas
@@ -43,6 +43,8 @@ type
     function WriteStr(const Str: string): Integer; virtual; abstract;
     function SetCurrentDir(const Path: String): Boolean; virtual; abstract;
     function SetScreenSize(aCols, aRows: Integer): Boolean; virtual; abstract;
+    function GetChildPid: THandle; virtual; abstract;
+    property ChildPid: THandle read GetChildPid;
     property OnRxBuf: TOnRxBuf read FOnRxBuf write FOnRxBuf;
     property Connected: Boolean read FConnected write SetConnected default False;
   end;

--- a/components/virtualterminal/source/win/vtemupty.pas
+++ b/components/virtualterminal/source/win/vtemupty.pas
@@ -58,6 +58,7 @@ type
     function WriteStr(const Str: string): Integer; override;
     function SetCurrentDir(const Path: String): Boolean; override;
     function SetScreenSize(aCols, aRows: Integer): Boolean; override;
+    function GetChildPid: THandle; override;
   end;
 
 implementation
@@ -469,6 +470,11 @@ end;
 
 initialization
   Initialize;
+
+function TPtyDevice.GetChildPid: THandle;
+begin
+  Result := 0; // Not fully implemented for Windows pseudo console here
+end;
 
 end.
 

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -732,6 +732,9 @@ type
     FTerminalSyncTimer: TTimer;
     FLastTermCwdLeft: String;
     FLastTermCwdRight: String;
+    FLeftTermNeedInit: Boolean;
+    FRightTermNeedInit: Boolean;
+    FTermNeedInit: Boolean;
     FCommands: TMainCommands;
     FInitializedView: Boolean;
     {en
@@ -2518,6 +2521,46 @@ begin
     DCDebug('ActiveFrame = nil');
   end;
   HiddenToTray := False;
+
+  if gTermWindow then
+  begin
+    if gTermWindowSplit then
+    begin
+      if Assigned(ConsLeft) then
+      begin
+        if not ConsLeft.Connected then
+        begin
+          if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
+            ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
+          ConsLeft.Connected := True;
+          FLeftTermNeedInit := True;
+        end;
+      end;
+      if Assigned(ConsRight) then
+      begin
+        if not ConsRight.Connected then
+        begin
+          if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
+            ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
+          ConsRight.Connected := True;
+          FRightTermNeedInit := True;
+        end;
+      end;
+    end
+    else
+    begin
+      if Assigned(Cons) then
+      begin
+        if not Cons.Connected then
+        begin
+          if Assigned(ActiveFrame) then
+            Cons.InitialDir := ActiveFrame.CurrentPath;
+          Cons.Connected := True;
+          FTermNeedInit := True;
+        end;
+      end;
+    end;
+  end;
 end;
 
 procedure TfrmMain.frmMainShow(Sender: TObject);
@@ -5508,8 +5551,33 @@ end;
 procedure TfrmMain.TerminalSyncTimerTimer(Sender: TObject);
 var
   Target: AnsiString;
+const
+  Ticks: Integer = 0;
 begin
+  // Process any pending TThread.Synchronize calls (e.g. from PTY reader threads)
+  CheckSynchronize;
+
+  if FLeftTermNeedInit and Assigned(ConsLeft) and ConsLeft.Connected then
+  begin
+    ConsLeft.WriteStr(#13);
+    FLeftTermNeedInit := False;
+  end;
+  if FRightTermNeedInit and Assigned(ConsRight) and ConsRight.Connected then
+  begin
+    ConsRight.WriteStr(#13);
+    FRightTermNeedInit := False;
+  end;
+  if FTermNeedInit and Assigned(Cons) and Cons.Connected then
+  begin
+    Cons.WriteStr(#13);
+    FTermNeedInit := False;
+  end;
+
   if not gTermWindowSplit then Exit;
+
+  Inc(Ticks);
+  if Ticks mod 5 <> 0 then Exit;
+  Ticks := 0;
 
   if Assigned(ConsLeft) and (gTermSyncModeLeft = 2) then
   begin
@@ -5518,9 +5586,10 @@ begin
     if Target <> FLastTermCwdLeft then
     begin
       FLastTermCwdLeft := Target;
-      if (Target <> '') and (Target <> nbLeft.ActivePage.FileView.CurrentPath) then
+      if (Target <> '') and Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
       begin
-        nbLeft.ActivePage.FileView.CurrentPath := Target;
+        if Target <> nbLeft.ActivePage.FileView.CurrentPath then
+          nbLeft.ActivePage.FileView.CurrentPath := Target;
       end;
     end;
     {$ENDIF}
@@ -5533,9 +5602,10 @@ begin
     if Target <> FLastTermCwdRight then
     begin
       FLastTermCwdRight := Target;
-      if (Target <> '') and (Target <> nbRight.ActivePage.FileView.CurrentPath) then
+      if (Target <> '') and Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
       begin
-        nbRight.ActivePage.FileView.CurrentPath := Target;
+        if Target <> nbRight.ActivePage.FileView.CurrentPath then
+          nbRight.ActivePage.FileView.CurrentPath := Target;
       end;
     end;
     {$ENDIF}
@@ -5783,16 +5853,29 @@ begin
       UpdateTermSyncButtons(True);
 
       cmdConsoleLeft := TVirtualTerminal.Create(pnlTermContainerLeft);
+      cmdConsoleLeft.Width := 400;
+      cmdConsoleLeft.Height := 176;
       cmdConsoleLeft.Parent := pnlTermContainerLeft;
       cmdConsoleLeft.Align := alClient;
       cmdConsoleLeft.ShowHint := False;
+
+      // Adjust Z-order: splitter needs to be above the container.
+      // So container must be backmost (processed first), then splitter.
+      splitTermLeft.SendToBack;
+      pnlTermContainerLeft.SendToBack;
     end;
     FontOptionsToFont(gFonts[dcfConsole], cmdConsoleLeft.Font);
     if not Assigned(ConsLeft) then
     begin
       ConsLeft := TPtyDevice.Create(Self);
       cmdConsoleLeft.PtyDevice := ConsLeft;
-      ConsLeft.Connected := True;
+      if FInitializedView then
+      begin
+        if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
+          ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
+        ConsLeft.Connected := True;
+        FLeftTermNeedInit := True;
+      end;
     end;
 
     if not Assigned(pnlTermContainerRight) then
@@ -5839,16 +5922,29 @@ begin
       UpdateTermSyncButtons(False);
 
       cmdConsoleRight := TVirtualTerminal.Create(pnlTermContainerRight);
+      cmdConsoleRight.Width := 400;
+      cmdConsoleRight.Height := 176;
       cmdConsoleRight.Parent := pnlTermContainerRight;
       cmdConsoleRight.Align := alClient;
       cmdConsoleRight.ShowHint := False;
+
+      // Adjust Z-order: splitter needs to be above the container.
+      // So container must be backmost (processed first), then splitter.
+      splitTermRight.SendToBack;
+      pnlTermContainerRight.SendToBack;
     end;
     FontOptionsToFont(gFonts[dcfConsole], cmdConsoleRight.Font);
     if not Assigned(ConsRight) then
     begin
       ConsRight := TPtyDevice.Create(Self);
       cmdConsoleRight.PtyDevice := ConsRight;
-      ConsRight.Connected := True;
+      if FInitializedView then
+      begin
+        if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
+          ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
+        ConsRight.Connected := True;
+        FRightTermNeedInit := True;
+      end;
     end;
 
     pnlTermContainerLeft.Visible := True;
@@ -5860,7 +5956,7 @@ begin
     if not Assigned(FTerminalSyncTimer) then
     begin
       FTerminalSyncTimer := TTimer.Create(Self);
-      FTerminalSyncTimer.Interval := 1000;
+      FTerminalSyncTimer.Interval := 200;
       FTerminalSyncTimer.OnTimer := @TerminalSyncTimerTimer;
     end;
     FTerminalSyncTimer.Enabled := True;
@@ -5890,14 +5986,25 @@ begin
     begin
       Cons:= TPtyDevice.Create(Self);
       cmdConsole.PtyDevice:= Cons;
-      Cons.Connected:= True;
+      if FInitializedView then
+      begin
+        if Assigned(ActiveFrame) then
+          Cons.InitialDir := ActiveFrame.CurrentPath;
+        Cons.Connected:= True;
+        FTermNeedInit := True;
+      end;
     end;
     nbConsole.Visible := True;
     ConsoleSplitter.Visible := True;
 
-    // Stop polling timer when using single terminal
-    if Assigned(FTerminalSyncTimer) then
-      FTerminalSyncTimer.Enabled := False;
+    // Keep polling timer enabled to wake up event loop
+    if not Assigned(FTerminalSyncTimer) then
+    begin
+      FTerminalSyncTimer := TTimer.Create(Self);
+      FTerminalSyncTimer.Interval := 200;
+      FTerminalSyncTimer.OnTimer := @TerminalSyncTimerTimer;
+    end;
+    FTerminalSyncTimer.Enabled := True;
 
     // Hide/destroy split terminals
     if Assigned(pnlTermContainerLeft) then
@@ -5907,8 +6014,6 @@ begin
       pnlTermContainerRight.Visible := False;
       splitTermRight.Visible := False;
     end;
-    if Assigned(FTerminalSyncTimer) then
-      FTerminalSyncTimer.Enabled := False;
   end
   else
   begin

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -938,6 +938,8 @@ type
     procedure ReLoadTabs(ANoteBook: TFileViewNotebook);
     procedure ShowOptionsLayout(Data: PtrInt);
     procedure ToggleFullscreenConsole;
+    procedure GetOrCreateTabTerminal(Page: TFileViewPage; AParent: TWinControl);
+    procedure SwitchTabTerminal(Notebook: TFileViewNotebook);
 
     {en
        This function is called from various points to handle dropping files
@@ -2524,28 +2526,37 @@ begin
 
   if gTermWindow then
   begin
-    if gTermWindowSplit then
+    if gTermWindowMode >= twmPerPanel then
     begin
-      if Assigned(ConsLeft) then
+      if gTermWindowMode = twmPerPanel then
       begin
-        if not ConsLeft.Connected then
+        if Assigned(ConsLeft) then
         begin
-          if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
-            ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
-          ConsLeft.Connected := True;
-          FLeftTermNeedInit := True;
+          if not ConsLeft.Connected then
+          begin
+            if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
+              ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
+            ConsLeft.Connected := True;
+            FLeftTermNeedInit := True;
+          end;
         end;
-      end;
-      if Assigned(ConsRight) then
+      end
+      else SwitchTabTerminal(nbLeft);
+      
+      if gTermWindowMode = twmPerPanel then
       begin
-        if not ConsRight.Connected then
+        if Assigned(ConsRight) then
         begin
-          if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
-            ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
-          ConsRight.Connected := True;
-          FRightTermNeedInit := True;
+          if not ConsRight.Connected then
+          begin
+            if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
+              ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
+            ConsRight.Connected := True;
+            FRightTermNeedInit := True;
+          end;
         end;
-      end;
+      end
+      else SwitchTabTerminal(nbRight);
     end
     else
     begin
@@ -2729,6 +2740,12 @@ begin
   Page := Notebook.ActivePage;
   if Assigned(Page) then
   begin
+    if gTermWindowMode = twmPerTab then
+    begin
+      SwitchTabTerminal(Notebook);
+      UpdateTermSyncButtons(Notebook.Side = fpLeft);
+    end;
+
     if Page.LockState = tlsPathResets then // if locked with directory change
       ChooseFileSource(Page.FileView, Page.LockPath);
 
@@ -4936,16 +4953,32 @@ begin
 
       if (fspDirectAccess in FileView.FileSource.GetProperties) then
       begin
-        if gTermWindow and gTermWindowSplit then
+        if gTermWindow and (gTermWindowMode >= twmPerPanel) then
         begin
-          if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) and Assigned(ConsLeft) then
+          if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) then
           begin
-            if gTermSyncModeLeft = 1 then
+            if gTermWindowMode = twmPerTab then
+            begin
+              if (gTermSyncModeLeft = 1) and
+                 Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+                 (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+                TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+            end
+            else if (gTermSyncModeLeft = 1) and TFileViewPage(FileView.NotebookPage).IsActive and
+                    Assigned(ConsLeft) and (not FLeftTermNeedInit) then
               ConsLeft.SetCurrentDir(FileView.CurrentPath);
           end
-          else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) and Assigned(ConsRight) then
+          else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) then
           begin
-            if gTermSyncModeRight = 1 then
+            if gTermWindowMode = twmPerTab then
+            begin
+              if (gTermSyncModeRight = 1) and
+                 Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+                 (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+                TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+            end
+            else if (gTermSyncModeRight = 1) and TFileViewPage(FileView.NotebookPage).IsActive and
+                    Assigned(ConsRight) and (not FRightTermNeedInit) then
               ConsRight.SetCurrentDir(FileView.CurrentPath);
           end;
         end;
@@ -4965,6 +4998,38 @@ begin
       UpdateFreeSpace(Page.Notebook.Side, False);
     end;
   UpdateFileView;
+
+  // Sync terminal on tab change when in Panel→Terminal mode
+  if gTermWindow and (gTermWindowMode >= twmPerPanel) and
+     (fspDirectAccess in FileView.FileSource.GetProperties) then
+  begin
+    if (FileView.NotebookPage is TFileViewPage) and
+       (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) then
+    begin
+      if gTermWindowMode = twmPerTab then
+      begin
+        if (gTermSyncModeLeft = 1) and
+           Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+           (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+          TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+      end
+      else if (gTermSyncModeLeft = 1) and Assigned(ConsLeft) and (not FLeftTermNeedInit) then
+        ConsLeft.SetCurrentDir(FileView.CurrentPath);
+    end
+    else if (FileView.NotebookPage is TFileViewPage) and
+            (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) then
+    begin
+      if gTermWindowMode = twmPerTab then
+      begin
+        if (gTermSyncModeRight = 1) and
+           Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+           (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+          TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+      end
+      else if (gTermSyncModeRight = 1) and Assigned(ConsRight) and (not FRightTermNeedInit) then
+        ConsRight.SetCurrentDir(FileView.CurrentPath);
+    end;
+  end;
 end;
 
 procedure TfrmMain.FileViewFilesChanged(FileView: TFileView);
@@ -4993,16 +5058,30 @@ begin
   FileView.SetFocus;
   if (fspDirectAccess in FileView.FileSource.GetProperties) then
   begin
-    if gTermWindow and gTermWindowSplit then
+    if gTermWindow and (gTermWindowMode >= twmPerPanel) then
     begin
-      if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) and Assigned(ConsLeft) then
+      if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) then
       begin
-        if gTermSyncModeLeft = 1 then
+        if gTermWindowMode = twmPerTab then
+        begin
+          if (gTermSyncModeLeft = 1) and
+             Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+             (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+            TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+        end
+        else if (gTermSyncModeLeft = 1) and Assigned(ConsLeft) and (not FLeftTermNeedInit) then
           ConsLeft.SetCurrentDir(FileView.CurrentPath);
       end
-      else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) and Assigned(ConsRight) then
+      else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) then
       begin
-        if gTermSyncModeRight = 1 then
+        if gTermWindowMode = twmPerTab then
+        begin
+          if (gTermSyncModeRight = 1) and
+             Assigned(TFileViewPage(FileView.NotebookPage).PtyDevice) and
+             (not TFileViewPage(FileView.NotebookPage).TermNeedInit) then
+            TFileViewPage(FileView.NotebookPage).PtyDevice.SetCurrentDir(FileView.CurrentPath);
+        end
+        else if (gTermSyncModeRight = 1) and Assigned(ConsRight) and (not FRightTermNeedInit) then
           ConsRight.SetCurrentDir(FileView.CurrentPath);
       end;
     end
@@ -5549,10 +5628,12 @@ begin
 end;
 
 procedure TfrmMain.TerminalSyncTimerTimer(Sender: TObject);
-var
-  Target: AnsiString;
 const
   Ticks: Integer = 0;
+var
+  Target: String;
+  LeftPty, RightPty: TCustomPtyDevice;
+  Page: TFileViewPage;
 begin
   // Process any pending TThread.Synchronize calls (e.g. from PTY reader threads)
   CheckSynchronize;
@@ -5561,28 +5642,70 @@ begin
   begin
     ConsLeft.WriteStr(#13);
     FLeftTermNeedInit := False;
+    if (gTermSyncModeLeft = 1) and Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
+      ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath);
   end;
   if FRightTermNeedInit and Assigned(ConsRight) and ConsRight.Connected then
   begin
     ConsRight.WriteStr(#13);
     FRightTermNeedInit := False;
+    if (gTermSyncModeRight = 1) and Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
+      ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath);
   end;
   if FTermNeedInit and Assigned(Cons) and Cons.Connected then
   begin
     Cons.WriteStr(#13);
     FTermNeedInit := False;
+    if (gTermSyncModeLeft = 1) and Assigned(ActiveFrame) then
+      Cons.SetCurrentDir(ActiveFrame.CurrentPath);
   end;
-
-  if not gTermWindowSplit then Exit;
+  if gTermWindowMode = twmPerTab then
+  begin
+    if Assigned(nbLeft.ActivePage) then
+    begin
+      Page := TFileViewPage(nbLeft.ActivePage);
+      if Page.TermNeedInit and Assigned(Page.PtyDevice) and Page.PtyDevice.Connected then
+      begin
+        Page.PtyDevice.WriteStr(#13);
+        Page.TermNeedInit := False;
+        if (gTermSyncModeLeft = 1) and Assigned(Page.FileView) then
+          Page.PtyDevice.SetCurrentDir(Page.FileView.CurrentPath);
+      end;
+    end;
+    if Assigned(nbRight.ActivePage) then
+    begin
+      Page := TFileViewPage(nbRight.ActivePage);
+      if Page.TermNeedInit and Assigned(Page.PtyDevice) and Page.PtyDevice.Connected then
+      begin
+        Page.PtyDevice.WriteStr(#13);
+        Page.TermNeedInit := False;
+        if (gTermSyncModeRight = 1) and Assigned(Page.FileView) then
+          Page.PtyDevice.SetCurrentDir(Page.FileView.CurrentPath);
+      end;
+    end;
+  end;
+  
+  if gTermWindowMode < twmPerPanel then Exit;
 
   Inc(Ticks);
   if Ticks mod 5 <> 0 then Exit;
   Ticks := 0;
 
-  if Assigned(ConsLeft) and (gTermSyncModeLeft = 2) then
+  if gTermWindowMode = twmPerTab then
+  begin
+    if Assigned(nbLeft.ActivePage) then LeftPty := TFileViewPage(nbLeft.ActivePage).PtyDevice else LeftPty := nil;
+    if Assigned(nbRight.ActivePage) then RightPty := TFileViewPage(nbRight.ActivePage).PtyDevice else RightPty := nil;
+  end
+  else
+  begin
+    LeftPty := ConsLeft;
+    RightPty := ConsRight;
+  end;
+
+  if Assigned(LeftPty) and (gTermSyncModeLeft = 2) then
   begin
     {$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
-    Target := fpReadLink('/proc/' + IntToStr(ConsLeft.ChildPid) + '/cwd');
+    Target := fpReadLink('/proc/' + IntToStr(LeftPty.ChildPid) + '/cwd');
     if Target <> FLastTermCwdLeft then
     begin
       FLastTermCwdLeft := Target;
@@ -5594,11 +5717,10 @@ begin
     end;
     {$ENDIF}
   end;
-
-  if Assigned(ConsRight) and (gTermSyncModeRight = 2) then
+  if Assigned(RightPty) and (gTermSyncModeRight = 2) then
   begin
     {$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
-    Target := fpReadLink('/proc/' + IntToStr(ConsRight.ChildPid) + '/cwd');
+    Target := fpReadLink('/proc/' + IntToStr(RightPty.ChildPid) + '/cwd');
     if Target <> FLastTermCwdRight then
     begin
       FLastTermCwdRight := Target;
@@ -5706,17 +5828,43 @@ begin
     // Initialize/sync immediately when turned on
     if IsLeft then
     begin
-      if (gTermSyncModeLeft = 1) and Assigned(ConsLeft) then
-        ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath)
-      else if (gTermSyncModeLeft = 2) and Assigned(ConsLeft) then
-        FLastTermCwdLeft := ''; // Force polling timer to sync CWD immediately
+      if gTermWindowMode = twmPerTab then
+      begin
+        if Assigned(nbLeft.ActivePage) then
+        begin
+          if (gTermSyncModeLeft = 1) and Assigned(TFileViewPage(nbLeft.ActivePage).PtyDevice) then
+            TFileViewPage(nbLeft.ActivePage).PtyDevice.SetCurrentDir(TFileViewPage(nbLeft.ActivePage).FileView.CurrentPath)
+          else if (gTermSyncModeLeft = 2) then
+            FLastTermCwdLeft := '';
+        end;
+      end
+      else
+      begin
+        if (gTermSyncModeLeft = 1) and Assigned(ConsLeft) then
+          ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath)
+        else if (gTermSyncModeLeft = 2) then
+          FLastTermCwdLeft := '';
+      end;
     end
     else
     begin
-      if (gTermSyncModeRight = 1) and Assigned(ConsRight) then
-        ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath)
-      else if (gTermSyncModeRight = 2) and Assigned(ConsRight) then
-        FLastTermCwdRight := '';
+      if gTermWindowMode = twmPerTab then
+      begin
+        if Assigned(nbRight.ActivePage) then
+        begin
+          if (gTermSyncModeRight = 1) and Assigned(TFileViewPage(nbRight.ActivePage).PtyDevice) then
+            TFileViewPage(nbRight.ActivePage).PtyDevice.SetCurrentDir(TFileViewPage(nbRight.ActivePage).FileView.CurrentPath)
+          else if (gTermSyncModeRight = 2) then
+            FLastTermCwdRight := '';
+        end;
+      end
+      else
+      begin
+        if (gTermSyncModeRight = 1) and Assigned(ConsRight) then
+          ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath)
+        else if (gTermSyncModeRight = 2) then
+          FLastTermCwdRight := '';
+      end;
     end;
   end
   else
@@ -5760,13 +5908,29 @@ begin
       // Sync immediately: Panel to Terminal
       if IsLeft then
       begin
-        if Assigned(ConsLeft) then
-          ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath);
+        if gTermWindowMode = twmPerTab then
+        begin
+          if Assigned(nbLeft.ActivePage) and Assigned(TFileViewPage(nbLeft.ActivePage).PtyDevice) then
+            TFileViewPage(nbLeft.ActivePage).PtyDevice.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath);
+        end
+        else
+        begin
+          if Assigned(ConsLeft) then
+            ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath);
+        end;
       end
       else
       begin
-        if Assigned(ConsRight) then
-          ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath);
+        if gTermWindowMode = twmPerTab then
+        begin
+          if Assigned(nbRight.ActivePage) and Assigned(TFileViewPage(nbRight.ActivePage).PtyDevice) then
+            TFileViewPage(nbRight.ActivePage).PtyDevice.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath);
+        end
+        else
+        begin
+          if Assigned(ConsRight) then
+            ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath);
+        end;
       end;
     end;
   end;
@@ -5776,39 +5940,49 @@ end;
 
 function TfrmMain.GetActivePtyDevice: TCustomPtyDevice;
 begin
-  if gTermWindow and gTermWindowSplit then
+  if gTermWindow then
   begin
-    if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
-      Result := ConsLeft
+    if gTermWindowMode = twmPerTab then
+      Result := TFileViewPage(ActiveFrame.NotebookPage).PtyDevice
+    else if gTermWindowMode = twmPerPanel then
+    begin
+      if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
+        Result := ConsLeft
+      else
+        Result := ConsRight;
+    end
     else
-      Result := ConsRight;
+      Result := Cons;
   end
-  else if gTermWindow then
-    Result := Cons
   else
     Result := nil;
 end;
 
 function TfrmMain.GetActiveConsole: TVirtualTerminal;
 begin
-  if gTermWindow and gTermWindowSplit then
+  if gTermWindow then
   begin
-    if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
-      Result := cmdConsoleLeft
+    if gTermWindowMode = twmPerTab then
+      Result := TFileViewPage(ActiveFrame.NotebookPage).Terminal
+    else if gTermWindowMode = twmPerPanel then
+    begin
+      if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
+        Result := cmdConsoleLeft
+      else
+        Result := cmdConsoleRight;
+    end
     else
-      Result := cmdConsoleRight;
+      Result := cmdConsole;
   end
-  else if gTermWindow then
-    Result := cmdConsole
   else
     Result := nil;
 end;
 
 procedure TfrmMain.ToggleConsole;
 begin
-  if gTermWindow and gTermWindowSplit then
+  if gTermWindow and (gTermWindowMode >= twmPerPanel) then
   begin
-    // Split terminals enabled
+    // Split terminals enabled (per panel or per tab)
     if not Assigned(pnlTermContainerLeft) then
     begin
       pnlTermContainerLeft := TPanel.Create(Self);
@@ -5831,7 +6005,7 @@ begin
 
       btnTermLinkLeft := TSpeedButton.Create(Self);
       btnTermLinkLeft.Parent := tlbTermLeft;
-      btnTermLinkLeft.Align := alLeft;
+      btnTermLinkLeft.Align := alRight;
       btnTermLinkLeft.Width := 36;
       btnTermLinkLeft.ShowHint := True;
       btnTermLinkLeft.GroupIndex := 10;
@@ -5841,7 +6015,7 @@ begin
 
       btnTermDirLeft := TSpeedButton.Create(Self);
       btnTermDirLeft.Parent := tlbTermLeft;
-      btnTermDirLeft.Align := alLeft;
+      btnTermDirLeft.Align := alRight;
       btnTermDirLeft.Width := 36;
       btnTermDirLeft.ShowHint := True;
       btnTermDirLeft.GroupIndex := 11;
@@ -5852,30 +6026,10 @@ begin
       // Initialize the button states and captions/hints based on the loaded sync mode
       UpdateTermSyncButtons(True);
 
-      cmdConsoleLeft := TVirtualTerminal.Create(pnlTermContainerLeft);
-      cmdConsoleLeft.Width := 400;
-      cmdConsoleLeft.Height := 176;
-      cmdConsoleLeft.Parent := pnlTermContainerLeft;
-      cmdConsoleLeft.Align := alClient;
-      cmdConsoleLeft.ShowHint := False;
-
       // Adjust Z-order: splitter needs to be above the container.
       // So container must be backmost (processed first), then splitter.
       splitTermLeft.SendToBack;
       pnlTermContainerLeft.SendToBack;
-    end;
-    FontOptionsToFont(gFonts[dcfConsole], cmdConsoleLeft.Font);
-    if not Assigned(ConsLeft) then
-    begin
-      ConsLeft := TPtyDevice.Create(Self);
-      cmdConsoleLeft.PtyDevice := ConsLeft;
-      if FInitializedView then
-      begin
-        if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
-          ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
-        ConsLeft.Connected := True;
-        FLeftTermNeedInit := True;
-      end;
     end;
 
     if not Assigned(pnlTermContainerRight) then
@@ -5900,7 +6054,7 @@ begin
 
       btnTermLinkRight := TSpeedButton.Create(Self);
       btnTermLinkRight.Parent := tlbTermRight;
-      btnTermLinkRight.Align := alLeft;
+      btnTermLinkRight.Align := alRight;
       btnTermLinkRight.Width := 36;
       btnTermLinkRight.ShowHint := True;
       btnTermLinkRight.GroupIndex := 20;
@@ -5910,7 +6064,7 @@ begin
 
       btnTermDirRight := TSpeedButton.Create(Self);
       btnTermDirRight.Parent := tlbTermRight;
-      btnTermDirRight.Align := alLeft;
+      btnTermDirRight.Align := alRight;
       btnTermDirRight.Width := 36;
       btnTermDirRight.ShowHint := True;
       btnTermDirRight.GroupIndex := 21;
@@ -5921,30 +6075,73 @@ begin
       // Initialize the button states and captions/hints based on the loaded sync mode
       UpdateTermSyncButtons(False);
 
-      cmdConsoleRight := TVirtualTerminal.Create(pnlTermContainerRight);
-      cmdConsoleRight.Width := 400;
-      cmdConsoleRight.Height := 176;
-      cmdConsoleRight.Parent := pnlTermContainerRight;
-      cmdConsoleRight.Align := alClient;
-      cmdConsoleRight.ShowHint := False;
-
       // Adjust Z-order: splitter needs to be above the container.
       // So container must be backmost (processed first), then splitter.
       splitTermRight.SendToBack;
       pnlTermContainerRight.SendToBack;
     end;
-    FontOptionsToFont(gFonts[dcfConsole], cmdConsoleRight.Font);
-    if not Assigned(ConsRight) then
+
+    if gTermWindowMode = twmPerPanel then
     begin
-      ConsRight := TPtyDevice.Create(Self);
-      cmdConsoleRight.PtyDevice := ConsRight;
-      if FInitializedView then
+      // Create left terminal
+      if not Assigned(cmdConsoleLeft) then
       begin
-        if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
-          ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
-        ConsRight.Connected := True;
-        FRightTermNeedInit := True;
+        cmdConsoleLeft := TVirtualTerminal.Create(pnlTermContainerLeft);
+        cmdConsoleLeft.Width := 400;
+        cmdConsoleLeft.Height := 176;
+        cmdConsoleLeft.Parent := pnlTermContainerLeft;
+        cmdConsoleLeft.Align := alClient;
+        cmdConsoleLeft.ShowHint := False;
       end;
+      FontOptionsToFont(gFonts[dcfConsole], cmdConsoleLeft.Font);
+      if not Assigned(ConsLeft) then
+      begin
+        ConsLeft := TPtyDevice.Create(Self);
+        cmdConsoleLeft.PtyDevice := ConsLeft;
+        if FInitializedView then
+        begin
+          if Assigned(nbLeft.ActivePage) and Assigned(nbLeft.ActivePage.FileView) then
+            ConsLeft.InitialDir := nbLeft.ActivePage.FileView.CurrentPath;
+          ConsLeft.Connected := True;
+          FLeftTermNeedInit := True;
+        end;
+      end;
+
+      // Create right terminal
+      if not Assigned(cmdConsoleRight) then
+      begin
+        cmdConsoleRight := TVirtualTerminal.Create(pnlTermContainerRight);
+        cmdConsoleRight.Width := 400;
+        cmdConsoleRight.Height := 176;
+        cmdConsoleRight.Parent := pnlTermContainerRight;
+        cmdConsoleRight.Align := alClient;
+        cmdConsoleRight.ShowHint := False;
+      end;
+      FontOptionsToFont(gFonts[dcfConsole], cmdConsoleRight.Font);
+      if not Assigned(ConsRight) then
+      begin
+        ConsRight := TPtyDevice.Create(Self);
+        cmdConsoleRight.PtyDevice := ConsRight;
+        if FInitializedView then
+        begin
+          if Assigned(nbRight.ActivePage) and Assigned(nbRight.ActivePage.FileView) then
+            ConsRight.InitialDir := nbRight.ActivePage.FileView.CurrentPath;
+          ConsRight.Connected := True;
+          FRightTermNeedInit := True;
+        end;
+      end;
+    end
+    else
+    begin
+      // twmPerTab mode
+      // Destroy per-panel terminals if they exist
+      if Assigned(cmdConsoleLeft) then FreeAndNil(cmdConsoleLeft);
+      if Assigned(ConsLeft) then FreeAndNil(ConsLeft);
+      if Assigned(cmdConsoleRight) then FreeAndNil(cmdConsoleRight);
+      if Assigned(ConsRight) then FreeAndNil(ConsRight);
+      
+      SwitchTabTerminal(nbLeft);
+      SwitchTabTerminal(nbRight);
     end;
 
     pnlTermContainerLeft.Visible := True;
@@ -5971,7 +6168,7 @@ begin
     nbConsole.Visible := False;
     ConsoleSplitter.Visible := False;
   end
-  else if gTermWindow and not gTermWindowSplit then
+  else if gTermWindow and (gTermWindowMode = twmSingle) then
   begin
     // Single terminal enabled
     if not Assigned(cmdConsole) then
@@ -6013,6 +6210,10 @@ begin
       splitTermLeft.Visible := False;
       pnlTermContainerRight.Visible := False;
       splitTermRight.Visible := False;
+      if Assigned(cmdConsoleLeft) then FreeAndNil(cmdConsoleLeft);
+      if Assigned(ConsLeft) then FreeAndNil(ConsLeft);
+      if Assigned(cmdConsoleRight) then FreeAndNil(cmdConsoleRight);
+      if Assigned(ConsRight) then FreeAndNil(ConsRight);
     end;
   end
   else
@@ -6034,10 +6235,76 @@ begin
       splitTermLeft.Visible := False;
       pnlTermContainerRight.Visible := False;
       splitTermRight.Visible := False;
+      if Assigned(cmdConsoleLeft) then FreeAndNil(cmdConsoleLeft);
+      if Assigned(ConsLeft) then FreeAndNil(ConsLeft);
+      if Assigned(cmdConsoleRight) then FreeAndNil(cmdConsoleRight);
+      if Assigned(ConsRight) then FreeAndNil(ConsRight);
     end;
     if Assigned(FTerminalSyncTimer) then
       FTerminalSyncTimer.Enabled := False;
   end;
+end;
+
+procedure TfrmMain.GetOrCreateTabTerminal(Page: TFileViewPage; AParent: TWinControl);
+begin
+  if not Assigned(Page.Terminal) then
+  begin
+    Page.Terminal := TVirtualTerminal.Create(Page);
+    Page.Terminal.Width := 400;
+    Page.Terminal.Height := 176;
+    Page.Terminal.ShowHint := False;
+    
+    FontOptionsToFont(gFonts[dcfConsole], Page.Terminal.Font);
+    
+    Page.PtyDevice := TPtyDevice.Create(Page);
+    Page.Terminal.PtyDevice := Page.PtyDevice;
+    Page.Terminal.Parent := AParent;
+    
+    if Assigned(Page.FileView) then
+      Page.PtyDevice.InitialDir := Page.FileView.CurrentPath;
+      
+    Page.PtyDevice.Connected := True;
+    Page.TermInitialized := True;
+    Page.TermNeedInit := True;
+  end;
+end;
+
+procedure TfrmMain.SwitchTabTerminal(Notebook: TFileViewNotebook);
+var
+  i: Integer;
+  Page: TFileViewPage;
+  Container: TPanel;
+begin
+  if not gTermWindow or (gTermWindowMode <> twmPerTab) then Exit;
+  if not Assigned(Notebook) or not Assigned(Notebook.ActivePage) then Exit;
+  
+  if Notebook = nbLeft then
+    Container := pnlTermContainerLeft
+  else
+    Container := pnlTermContainerRight;
+    
+  if not Assigned(Container) then Exit;
+
+  for i := 0 to Notebook.PageCount - 1 do
+  begin
+    Page := TFileViewPage(Notebook.Page[i]);
+    if Assigned(Page.Terminal) then
+    begin
+      Page.Terminal.Hide;
+      Page.Terminal.Parent := nil;
+    end;
+  end;
+  
+  Page := TFileViewPage(Notebook.ActivePage);
+  GetOrCreateTabTerminal(Page, Container);
+  Page.Terminal.Parent := Container;
+  Page.Terminal.Align := alClient;
+  Page.Terminal.Show;
+
+  if Notebook = nbLeft then
+    UpdateTermSyncButtons(True)
+  else
+    UpdateTermSyncButtons(False);
 end;
 
 procedure TfrmMain.ShowOptionsLayout(Data: PtrInt);
@@ -6052,9 +6319,9 @@ begin
     if MessageDlg(rsMsgTerminalDisabled, mtWarning, [mbYes, mbNo], 0, mbYes) = mrYes then
       Application.QueueAsyncCall(@ShowOptionsLayout, 0);
   end
-  else if gTermWindowSplit then
+  else if gTermWindowMode >= twmPerPanel then
   begin
-    // Fullscreen toggle not currently supported for split terminals
+    // Fullscreen toggle not currently supported for split/tab terminals
   end
   else if nbConsole.Height < (nbConsole.Height + pnlNotebooks.Height - 1) then
   begin

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -1,4 +1,4 @@
-﻿{
+{
    Double Commander
    -------------------------------------------------------------------------
    Licence  : GNU GPL v 2.0
@@ -723,6 +723,15 @@ type
     HidingTrayIcon: Boolean; // @true if the icon is in the process of hiding
     nbLeft, nbRight: TFileViewNotebook;
     cmdConsole: TVirtualTerminal;
+    pnlTermContainerLeft, pnlTermContainerRight: TPanel;
+    tlbTermLeft, tlbTermRight: TPanel;
+    cmdConsoleLeft, cmdConsoleRight: TVirtualTerminal;
+    splitTermLeft, splitTermRight: TSplitter;
+    btnTermLinkLeft, btnTermDirLeft: TSpeedButton;
+    btnTermLinkRight, btnTermDirRight: TSpeedButton;
+    FTerminalSyncTimer: TTimer;
+    FLastTermCwdLeft: String;
+    FLastTermCwdRight: String;
     FCommands: TMainCommands;
     FInitializedView: Boolean;
     {en
@@ -756,6 +765,12 @@ type
     FDelayedEventCtr: Integer;
     FDelayedWMMove, FDelayedWMSize: Boolean;
 
+    function GetActivePtyDevice: TCustomPtyDevice;
+    function GetActiveConsole: TVirtualTerminal;
+    procedure TerminalSyncTimerTimer(Sender: TObject);
+    procedure TermLinkButtonClick(Sender: TObject);
+    procedure TermDirButtonClick(Sender: TObject);
+    procedure UpdateTermSyncButtons(AIsLeft: Boolean);
     procedure DelayedEvent(Data: PtrInt);
 
     procedure CheckCommandLine(ShiftEx: TShiftState; var Key: Word);
@@ -952,6 +967,8 @@ var
   frmMain: TfrmMain;
   onFileViewUpdated: TFileViewUpdatedHandler;
   Cons: TCustomPtyDevice = nil;
+  ConsLeft: TCustomPtyDevice = nil;
+  ConsRight: TCustomPtyDevice = nil;
 
 implementation
 
@@ -972,6 +989,9 @@ uses
   uColumnsFileView, dmHigh, uFileSourceOperationMisc
 {$IFDEF MSWINDOWS}
   , uShellFileSource, uNetworkThread
+{$ENDIF}
+{$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
+  , BaseUnix
 {$ENDIF}
   ;
 
@@ -4871,11 +4891,22 @@ begin
       if Assigned(onFileViewUpdated) then
         onFileViewUpdated(FileView);
 
-      {if (fspDirectAccess in FileView.FileSource.GetProperties) then
+      if (fspDirectAccess in FileView.FileSource.GetProperties) then
+      begin
+        if gTermWindow and gTermWindowSplit then
         begin
-          if gTermWindow and Assigned(Cons) then
-            Cons.Terminal.SetCurrentDir(FileView.CurrentPath);
-        end;}
+          if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) and Assigned(ConsLeft) then
+          begin
+            if gTermSyncModeLeft = 1 then
+              ConsLeft.SetCurrentDir(FileView.CurrentPath);
+          end
+          else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) and Assigned(ConsRight) then
+          begin
+            if gTermSyncModeRight = 1 then
+              ConsRight.SetCurrentDir(FileView.CurrentPath);
+          end;
+        end;
+      end;
     end;
 end;
 
@@ -4919,7 +4950,20 @@ begin
   FileView.SetFocus;
   if (fspDirectAccess in FileView.FileSource.GetProperties) then
   begin
-    if gTermWindow and Assigned(Cons) then
+    if gTermWindow and gTermWindowSplit then
+    begin
+      if (TFileViewPage(FileView.NotebookPage).Notebook = nbLeft) and Assigned(ConsLeft) then
+      begin
+        if gTermSyncModeLeft = 1 then
+          ConsLeft.SetCurrentDir(FileView.CurrentPath);
+      end
+      else if (TFileViewPage(FileView.NotebookPage).Notebook = nbRight) and Assigned(ConsRight) then
+      begin
+        if gTermSyncModeRight = 1 then
+          ConsRight.SetCurrentDir(FileView.CurrentPath);
+      end;
+    end
+    else if gTermWindow and Assigned(Cons) then
       Cons.SetCurrentDir(FileView.CurrentPath);
   end;
 end;
@@ -5461,37 +5505,434 @@ begin
   end; // if Destination<>tclNone then
 end;
 
+procedure TfrmMain.TerminalSyncTimerTimer(Sender: TObject);
+var
+  Target: AnsiString;
+begin
+  if not gTermWindowSplit then Exit;
+
+  if Assigned(ConsLeft) and (gTermSyncModeLeft = 2) then
+  begin
+    {$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
+    Target := fpReadLink('/proc/' + IntToStr(ConsLeft.ChildPid) + '/cwd');
+    if Target <> FLastTermCwdLeft then
+    begin
+      FLastTermCwdLeft := Target;
+      if (Target <> '') and (Target <> nbLeft.ActivePage.FileView.CurrentPath) then
+      begin
+        nbLeft.ActivePage.FileView.CurrentPath := Target;
+      end;
+    end;
+    {$ENDIF}
+  end;
+
+  if Assigned(ConsRight) and (gTermSyncModeRight = 2) then
+  begin
+    {$IF DEFINED(UNIX) and not DEFINED(DARWIN)}
+    Target := fpReadLink('/proc/' + IntToStr(ConsRight.ChildPid) + '/cwd');
+    if Target <> FLastTermCwdRight then
+    begin
+      FLastTermCwdRight := Target;
+      if (Target <> '') and (Target <> nbRight.ActivePage.FileView.CurrentPath) then
+      begin
+        nbRight.ActivePage.FileView.CurrentPath := Target;
+      end;
+    end;
+    {$ENDIF}
+  end;
+end;
+
+procedure TfrmMain.UpdateTermSyncButtons(AIsLeft: Boolean);
+var
+  BtnLink, BtnDir: TSpeedButton;
+  SyncMode: Integer;
+begin
+  if AIsLeft then
+  begin
+    BtnLink := btnTermLinkLeft;
+    BtnDir := btnTermDirLeft;
+    SyncMode := gTermSyncModeLeft;
+  end
+  else
+  begin
+    BtnLink := btnTermLinkRight;
+    BtnDir := btnTermDirRight;
+    SyncMode := gTermSyncModeRight;
+  end;
+
+  if not Assigned(BtnLink) or not Assigned(BtnDir) then Exit;
+
+  // Set Down states based on SyncMode
+  case SyncMode of
+    1: // Panel to Terminal
+      begin
+        BtnLink.Down := True;
+        BtnDir.Down := False;
+      end;
+    2: // Terminal to Panel
+      begin
+        BtnLink.Down := True;
+        BtnDir.Down := True;
+      end;
+    else // Detached
+      begin
+        BtnLink.Down := False;
+      end;
+  end;
+
+  // Update Captions and Hints
+  if BtnLink.Down then
+  begin
+    BtnLink.Caption := #$F0#$9F#$94#$97; // '🔗' (Link)
+    BtnLink.Hint := 'Link Enabled (Click to Unlink)';
+  end
+  else
+  begin
+    BtnLink.Caption := #$E2#$9B#$93#$EF#$B8#$8F#$E2#$80#$8D#$F0#$9F#$92#$A5; // '⛓️‍💥' (Broken Chain / Unlink)
+    BtnLink.Hint := 'Link Disabled (Click to Link)';
+  end;
+
+  if BtnDir.Down then
+  begin
+    BtnDir.Caption := #$F0#$9F#$A1#$85; // '🡅' (Arrow Up)
+    BtnDir.Hint := 'Sync Direction: Terminal to Panel (Click to change)';
+  end
+  else
+  begin
+    BtnDir.Caption := #$F0#$9F#$A1#$87; // '🡇' (Arrow Down)
+    BtnDir.Hint := 'Sync Direction: Panel to Terminal (Click to change)';
+  end;
+end;
+
+procedure TfrmMain.TermLinkButtonClick(Sender: TObject);
+var
+  IsLeft: Boolean;
+  BtnLink, BtnDir: TSpeedButton;
+begin
+  IsLeft := (Sender = btnTermLinkLeft);
+  if IsLeft then
+  begin
+    BtnLink := btnTermLinkLeft;
+    BtnDir := btnTermDirLeft;
+  end
+  else
+  begin
+    BtnLink := btnTermLinkRight;
+    BtnDir := btnTermDirRight;
+  end;
+
+  if BtnLink.Down then
+  begin
+    // If Link was turned ON, determine state from Direction button
+    if BtnDir.Down then
+    begin
+      if IsLeft then gTermSyncModeLeft := 2 else gTermSyncModeRight := 2;
+    end
+    else
+    begin
+      if IsLeft then gTermSyncModeLeft := 1 else gTermSyncModeRight := 1;
+    end;
+    
+    // Initialize/sync immediately when turned on
+    if IsLeft then
+    begin
+      if (gTermSyncModeLeft = 1) and Assigned(ConsLeft) then
+        ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath)
+      else if (gTermSyncModeLeft = 2) and Assigned(ConsLeft) then
+        FLastTermCwdLeft := ''; // Force polling timer to sync CWD immediately
+    end
+    else
+    begin
+      if (gTermSyncModeRight = 1) and Assigned(ConsRight) then
+        ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath)
+      else if (gTermSyncModeRight = 2) and Assigned(ConsRight) then
+        FLastTermCwdRight := '';
+    end;
+  end
+  else
+  begin
+    // Link turned OFF
+    if IsLeft then gTermSyncModeLeft := 0 else gTermSyncModeRight := 0;
+  end;
+
+  UpdateTermSyncButtons(IsLeft);
+end;
+
+procedure TfrmMain.TermDirButtonClick(Sender: TObject);
+var
+  IsLeft: Boolean;
+  BtnLink, BtnDir: TSpeedButton;
+begin
+  IsLeft := (Sender = btnTermDirLeft);
+  if IsLeft then
+  begin
+    BtnLink := btnTermLinkLeft;
+    BtnDir := btnTermDirLeft;
+  end
+  else
+  begin
+    BtnLink := btnTermLinkRight;
+    BtnDir := btnTermDirRight;
+  end;
+
+  // If Link is ON, update sync mode and trigger immediate sync
+  if BtnLink.Down then
+  begin
+    if BtnDir.Down then
+    begin
+      if IsLeft then gTermSyncModeLeft := 2 else gTermSyncModeRight := 2;
+      // Sync immediately: Terminal to Panel
+      if IsLeft then FLastTermCwdLeft := '' else FLastTermCwdRight := '';
+    end
+    else
+    begin
+      if IsLeft then gTermSyncModeLeft := 1 else gTermSyncModeRight := 1;
+      // Sync immediately: Panel to Terminal
+      if IsLeft then
+      begin
+        if Assigned(ConsLeft) then
+          ConsLeft.SetCurrentDir(nbLeft.ActivePage.FileView.CurrentPath);
+      end
+      else
+      begin
+        if Assigned(ConsRight) then
+          ConsRight.SetCurrentDir(nbRight.ActivePage.FileView.CurrentPath);
+      end;
+    end;
+  end;
+
+  UpdateTermSyncButtons(IsLeft);
+end;
+
+function TfrmMain.GetActivePtyDevice: TCustomPtyDevice;
+begin
+  if gTermWindow and gTermWindowSplit then
+  begin
+    if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
+      Result := ConsLeft
+    else
+      Result := ConsRight;
+  end
+  else if gTermWindow then
+    Result := Cons
+  else
+    Result := nil;
+end;
+
+function TfrmMain.GetActiveConsole: TVirtualTerminal;
+begin
+  if gTermWindow and gTermWindowSplit then
+  begin
+    if TFileViewPage(ActiveFrame.NotebookPage).Notebook = nbLeft then
+      Result := cmdConsoleLeft
+    else
+      Result := cmdConsoleRight;
+  end
+  else if gTermWindow then
+    Result := cmdConsole
+  else
+    Result := nil;
+end;
+
 procedure TfrmMain.ToggleConsole;
 begin
-  if gTermWindow then
+  if gTermWindow and gTermWindowSplit then
+  begin
+    // Split terminals enabled
+    if not Assigned(pnlTermContainerLeft) then
     begin
-      if not Assigned(cmdConsole) then
-      begin
-        cmdConsole:= TVirtualTerminal.Create(pgConsole);
-        cmdConsole.Parent:= pgConsole;
-        cmdConsole.Align:= alClient;
-        cmdConsole.ShowHint:= False;
-      end;
-      FontOptionsToFont(gFonts[dcfConsole], cmdConsole.Font); //We set the font here because if we're coming back from configuration the font in options, we'll later pass here to affect that font if ever displayed.
-      if not Assigned(Cons) then
-        begin
-          Cons:= TPtyDevice.Create(Self);
-          cmdConsole.PtyDevice:= Cons;
-          Cons.Connected:= True;
-        end;
-    end
-  else
+      pnlTermContainerLeft := TPanel.Create(Self);
+      pnlTermContainerLeft.Parent := pnlLeft;
+      pnlTermContainerLeft.Align := alBottom;
+      pnlTermContainerLeft.Height := 200;
+      pnlTermContainerLeft.BevelOuter := bvNone;
+
+      splitTermLeft := TSplitter.Create(Self);
+      splitTermLeft.Parent := pnlLeft;
+      splitTermLeft.Align := alBottom;
+      splitTermLeft.Height := 5;
+      splitTermLeft.ResizeAnchor := akBottom;
+
+      tlbTermLeft := TPanel.Create(Self);
+      tlbTermLeft.Parent := pnlTermContainerLeft;
+      tlbTermLeft.Align := alTop;
+      tlbTermLeft.Height := 24;
+      tlbTermLeft.BevelOuter := bvNone;
+
+      btnTermLinkLeft := TSpeedButton.Create(Self);
+      btnTermLinkLeft.Parent := tlbTermLeft;
+      btnTermLinkLeft.Align := alLeft;
+      btnTermLinkLeft.Width := 36;
+      btnTermLinkLeft.ShowHint := True;
+      btnTermLinkLeft.GroupIndex := 10;
+      btnTermLinkLeft.AllowAllUp := True;
+      btnTermLinkLeft.Flat := gInterfaceFlat;
+      btnTermLinkLeft.OnClick := @TermLinkButtonClick;
+
+      btnTermDirLeft := TSpeedButton.Create(Self);
+      btnTermDirLeft.Parent := tlbTermLeft;
+      btnTermDirLeft.Align := alLeft;
+      btnTermDirLeft.Width := 36;
+      btnTermDirLeft.ShowHint := True;
+      btnTermDirLeft.GroupIndex := 11;
+      btnTermDirLeft.AllowAllUp := True;
+      btnTermDirLeft.Flat := gInterfaceFlat;
+      btnTermDirLeft.OnClick := @TermDirButtonClick;
+
+      // Initialize the button states and captions/hints based on the loaded sync mode
+      UpdateTermSyncButtons(True);
+
+      cmdConsoleLeft := TVirtualTerminal.Create(pnlTermContainerLeft);
+      cmdConsoleLeft.Parent := pnlTermContainerLeft;
+      cmdConsoleLeft.Align := alClient;
+      cmdConsoleLeft.ShowHint := False;
+    end;
+    FontOptionsToFont(gFonts[dcfConsole], cmdConsoleLeft.Font);
+    if not Assigned(ConsLeft) then
     begin
-      if Assigned(cmdConsole) then
-      begin
-        cmdConsole.Hide;
-        FreeAndNil(cmdConsole);
-      end;
-      FreeAndNil(Cons);
+      ConsLeft := TPtyDevice.Create(Self);
+      cmdConsoleLeft.PtyDevice := ConsLeft;
+      ConsLeft.Connected := True;
     end;
 
-  nbConsole.Visible:= gTermWindow;
-  ConsoleSplitter.Visible:= gTermWindow;
+    if not Assigned(pnlTermContainerRight) then
+    begin
+      pnlTermContainerRight := TPanel.Create(Self);
+      pnlTermContainerRight.Parent := pnlRight;
+      pnlTermContainerRight.Align := alBottom;
+      pnlTermContainerRight.Height := 200;
+      pnlTermContainerRight.BevelOuter := bvNone;
+
+      splitTermRight := TSplitter.Create(Self);
+      splitTermRight.Parent := pnlRight;
+      splitTermRight.Align := alBottom;
+      splitTermRight.Height := 5;
+      splitTermRight.ResizeAnchor := akBottom;
+
+      tlbTermRight := TPanel.Create(Self);
+      tlbTermRight.Parent := pnlTermContainerRight;
+      tlbTermRight.Align := alTop;
+      tlbTermRight.Height := 24;
+      tlbTermRight.BevelOuter := bvNone;
+
+      btnTermLinkRight := TSpeedButton.Create(Self);
+      btnTermLinkRight.Parent := tlbTermRight;
+      btnTermLinkRight.Align := alLeft;
+      btnTermLinkRight.Width := 36;
+      btnTermLinkRight.ShowHint := True;
+      btnTermLinkRight.GroupIndex := 20;
+      btnTermLinkRight.AllowAllUp := True;
+      btnTermLinkRight.Flat := gInterfaceFlat;
+      btnTermLinkRight.OnClick := @TermLinkButtonClick;
+
+      btnTermDirRight := TSpeedButton.Create(Self);
+      btnTermDirRight.Parent := tlbTermRight;
+      btnTermDirRight.Align := alLeft;
+      btnTermDirRight.Width := 36;
+      btnTermDirRight.ShowHint := True;
+      btnTermDirRight.GroupIndex := 21;
+      btnTermDirRight.AllowAllUp := True;
+      btnTermDirRight.Flat := gInterfaceFlat;
+      btnTermDirRight.OnClick := @TermDirButtonClick;
+
+      // Initialize the button states and captions/hints based on the loaded sync mode
+      UpdateTermSyncButtons(False);
+
+      cmdConsoleRight := TVirtualTerminal.Create(pnlTermContainerRight);
+      cmdConsoleRight.Parent := pnlTermContainerRight;
+      cmdConsoleRight.Align := alClient;
+      cmdConsoleRight.ShowHint := False;
+    end;
+    FontOptionsToFont(gFonts[dcfConsole], cmdConsoleRight.Font);
+    if not Assigned(ConsRight) then
+    begin
+      ConsRight := TPtyDevice.Create(Self);
+      cmdConsoleRight.PtyDevice := ConsRight;
+      ConsRight.Connected := True;
+    end;
+
+    pnlTermContainerLeft.Visible := True;
+    splitTermLeft.Visible := True;
+    pnlTermContainerRight.Visible := True;
+    splitTermRight.Visible := True;
+
+    // Start polling timer for terminal-to-panel sync
+    if not Assigned(FTerminalSyncTimer) then
+    begin
+      FTerminalSyncTimer := TTimer.Create(Self);
+      FTerminalSyncTimer.Interval := 1000;
+      FTerminalSyncTimer.OnTimer := @TerminalSyncTimerTimer;
+    end;
+    FTerminalSyncTimer.Enabled := True;
+
+    // Destroy single terminal if it exists
+    if Assigned(cmdConsole) then
+    begin
+      cmdConsole.Hide;
+      FreeAndNil(cmdConsole);
+    end;
+    FreeAndNil(Cons);
+    nbConsole.Visible := False;
+    ConsoleSplitter.Visible := False;
+  end
+  else if gTermWindow and not gTermWindowSplit then
+  begin
+    // Single terminal enabled
+    if not Assigned(cmdConsole) then
+    begin
+      cmdConsole:= TVirtualTerminal.Create(pgConsole);
+      cmdConsole.Parent:= pgConsole;
+      cmdConsole.Align:= alClient;
+      cmdConsole.ShowHint:= False;
+    end;
+    FontOptionsToFont(gFonts[dcfConsole], cmdConsole.Font); //We set the font here because if we're coming back from configuration the font in options, we'll later pass here to affect that font if ever displayed.
+    if not Assigned(Cons) then
+    begin
+      Cons:= TPtyDevice.Create(Self);
+      cmdConsole.PtyDevice:= Cons;
+      Cons.Connected:= True;
+    end;
+    nbConsole.Visible := True;
+    ConsoleSplitter.Visible := True;
+
+    // Stop polling timer when using single terminal
+    if Assigned(FTerminalSyncTimer) then
+      FTerminalSyncTimer.Enabled := False;
+
+    // Hide/destroy split terminals
+    if Assigned(pnlTermContainerLeft) then
+    begin
+      pnlTermContainerLeft.Visible := False;
+      splitTermLeft.Visible := False;
+      pnlTermContainerRight.Visible := False;
+      splitTermRight.Visible := False;
+    end;
+    if Assigned(FTerminalSyncTimer) then
+      FTerminalSyncTimer.Enabled := False;
+  end
+  else
+  begin
+    // No terminal enabled
+    if Assigned(cmdConsole) then
+    begin
+      cmdConsole.Hide;
+      FreeAndNil(cmdConsole);
+    end;
+    FreeAndNil(Cons);
+    nbConsole.Visible := False;
+    ConsoleSplitter.Visible := False;
+
+    // Hide split terminals
+    if Assigned(pnlTermContainerLeft) then
+    begin
+      pnlTermContainerLeft.Visible := False;
+      splitTermLeft.Visible := False;
+      pnlTermContainerRight.Visible := False;
+      splitTermRight.Visible := False;
+    end;
+    if Assigned(FTerminalSyncTimer) then
+      FTerminalSyncTimer.Enabled := False;
+  end;
 end;
 
 procedure TfrmMain.ShowOptionsLayout(Data: PtrInt);
@@ -5505,6 +5946,10 @@ begin
   begin
     if MessageDlg(rsMsgTerminalDisabled, mtWarning, [mbYes, mbNo], 0, mbYes) = mrYes then
       Application.QueueAsyncCall(@ShowOptionsLayout, 0);
+  end
+  else if gTermWindowSplit then
+  begin
+    // Fullscreen toggle not currently supported for split terminals
   end
   else if nbConsole.Height < (nbConsole.Height + pnlNotebooks.Height - 1) then
   begin

--- a/src/frames/foptionslayout.lfm
+++ b/src/frames/foptionslayout.lfm
@@ -190,7 +190,21 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       Width = 152
       BorderSpacing.Top = 2
       Caption = 'Show te&rminal window'
+      OnChange = cbTermWindowChange
       TabOrder = 18
+    end
+    object cbTermSplit: TCheckBox
+      AnchorSideLeft.Control = cbTermWindow
+      AnchorSideTop.Control = cbTermWindow
+      AnchorSideTop.Side = asrBottom
+      Left = 28
+      Height = 22
+      Top = 460
+      Width = 320
+      BorderSpacing.Left = 16
+      BorderSpacing.Top = 2
+      Caption = 'Show separate terminal under each file panel'
+      TabOrder = 19
     end
     object cbFreespaceInd: TCheckBox
       AnchorSideTop.Control = cbShowShortDriveFreeSpace
@@ -204,26 +218,26 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       TabOrder = 9
     end
     object cbProgInMenuBar: TCheckBox
-      AnchorSideTop.Control = cbTermWindow
+      AnchorSideTop.Control = cbTermSplit
       AnchorSideTop.Side = asrBottom
       Left = 12
       Height = 22
-      Top = 460
+      Top = 484
       Width = 236
       BorderSpacing.Top = 2
       Caption = 'Show common progress in menu bar'
-      TabOrder = 19
+      TabOrder = 20
     end
     object cbPanelOfOperations: TCheckBox
       AnchorSideTop.Control = cbProgInMenuBar
       AnchorSideTop.Side = asrBottom
       Left = 12
       Height = 22
-      Top = 484
+      Top = 508
       Width = 248
       BorderSpacing.Top = 2
       Caption = 'Show panel of operation in background'
-      TabOrder = 20
+      TabOrder = 21
     end
     object cbShowDriveFreeSpace: TCheckBox
       AnchorSideTop.Control = cbShowDrivesListButton

--- a/src/frames/foptionslayout.lfm
+++ b/src/frames/foptionslayout.lfm
@@ -1,8 +1,9 @@
 inherited frmOptionsLayout: TfrmOptionsLayout
-  Height = 550
+  Height = 650
   Width = 784
   HelpKeyword = '/configuration.html#ConfigLayout'
-  ClientHeight = 550
+  AutoSize = True
+  ClientHeight = 650
   ClientWidth = 784
   DesignLeft = 276
   DesignTop = 44
@@ -12,7 +13,7 @@ inherited frmOptionsLayout: TfrmOptionsLayout
     AnchorSideRight.Control = Owner
     AnchorSideRight.Side = asrBottom
     Left = 6
-    Height = 530
+    Height = 630
     Top = 6
     Width = 772
     Anchors = [akTop, akLeft, akRight]
@@ -21,7 +22,7 @@ inherited frmOptionsLayout: TfrmOptionsLayout
     Caption = ' Screen layout '
     ChildSizing.LeftRightSpacing = 12
     ChildSizing.TopBottomSpacing = 6
-    ClientHeight = 512
+    ClientHeight = 612
     ClientWidth = 768
     TabOrder = 0
     object cbShowMainMenu: TCheckBox
@@ -193,17 +194,28 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       OnChange = cbTermWindowChange
       TabOrder = 18
     end
-    object cbTermSplit: TCheckBox
+    object rgTermMode: TRadioGroup
       AnchorSideLeft.Control = cbTermWindow
       AnchorSideTop.Control = cbTermWindow
       AnchorSideTop.Side = asrBottom
       Left = 28
-      Height = 22
-      Top = 460
-      Width = 320
+      AutoSize = True
       BorderSpacing.Left = 16
       BorderSpacing.Top = 2
-      Caption = 'Show separate terminal under each file panel'
+      Caption = 'Terminal mode'
+      ChildSizing.LeftRightSpacing = 6
+      ChildSizing.TopBottomSpacing = 6
+      ChildSizing.EnlargeHorizontal = crsHomogenousChildResize
+      ChildSizing.EnlargeVertical = crsHomogenousChildResize
+      ChildSizing.ShrinkHorizontal = crsScaleChilds
+      ChildSizing.ShrinkVertical = crsScaleChilds
+      ChildSizing.Layout = cclLeftToRightThenTopToBottom
+      ChildSizing.ControlsPerLine = 1
+      Items.Strings = (
+        'Single shared terminal'
+        'Terminal per panel'
+        'Terminal per tab'
+      )
       TabOrder = 19
     end
     object cbFreespaceInd: TCheckBox
@@ -218,11 +230,11 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       TabOrder = 9
     end
     object cbProgInMenuBar: TCheckBox
-      AnchorSideTop.Control = cbTermSplit
+      AnchorSideTop.Control = rgTermMode
       AnchorSideTop.Side = asrBottom
       Left = 12
       Height = 22
-      Top = 484
+      Top = 562
       Width = 236
       BorderSpacing.Top = 2
       Caption = 'Show common progress in menu bar'
@@ -233,7 +245,7 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       AnchorSideTop.Side = asrBottom
       Left = 12
       Height = 22
-      Top = 508
+      Top = 586
       Width = 248
       BorderSpacing.Top = 2
       Caption = 'Show panel of operation in background'

--- a/src/frames/foptionslayout.pas
+++ b/src/frames/foptionslayout.pas
@@ -53,12 +53,14 @@ type
     cbShowTabHeader: TCheckBox;
     cbShowTabs: TCheckBox;
     cbTermWindow: TCheckBox;
+    cbTermSplit: TCheckBox;
     cbTwoDiskPanels: TCheckBox;
     cbShowShortDriveFreeSpace: TCheckBox;
     chkShowMiddleToolBar: TCheckBox;
     gbScreenLayout: TGroupBox;
     procedure cbShowDiskPanelChange(Sender: TObject);
     procedure cbShowDriveFreeSpaceChange(Sender: TObject);
+    procedure cbTermWindowChange(Sender: TObject);
   protected
     procedure Load; override;
     function Save: TOptionsEditorSaveFlags; override;
@@ -86,6 +88,12 @@ procedure TfrmOptionsLayout.cbShowDriveFreeSpaceChange(Sender: TObject);
 begin
   cbShowShortDriveFreeSpace.Enabled:= cbShowDriveFreeSpace.Checked;
   if not(cbShowDriveFreeSpace.Checked) then cbShowShortDriveFreeSpace.Checked:= false;
+end;
+
+procedure TfrmOptionsLayout.cbTermWindowChange(Sender: TObject);
+begin
+  cbTermSplit.Enabled := cbTermWindow.Checked;
+  if not(cbTermWindow.Checked) then cbTermSplit.Checked := False;
 end;
 
 class function TfrmOptionsLayout.GetIconIndex: Integer;
@@ -116,6 +124,8 @@ begin
   cbFlatInterface.Checked := gInterfaceFlat;
   cbLogWindow.Checked := gLogWindow;
   cbTermWindow.Checked := gTermWindow;
+  cbTermSplit.Checked := gTermWindowSplit;
+  cbTermSplit.Enabled := gTermWindow;
   cbShowDriveFreeSpace.Checked := gDriveFreeSpace;
   cbFreespaceInd.Checked := gDriveInd;
   cbProgInMenuBar.Checked := gProgInMenuBar;
@@ -143,6 +153,7 @@ begin
   gInterfaceFlat := cbFlatInterface.Checked;
   gLogWindow := cbLogWindow.Checked;
   gTermWindow := cbTermWindow.Checked;
+  gTermWindowSplit := cbTermSplit.Checked;
   gDriveFreeSpace := cbShowDriveFreeSpace.Checked;
   gDriveInd := cbFreespaceInd.Checked;
   gProgInMenuBar := cbProgInMenuBar.Checked;

--- a/src/frames/foptionslayout.pas
+++ b/src/frames/foptionslayout.pas
@@ -27,7 +27,7 @@ unit fOptionsLayout;
 interface
 
 uses
-  Classes, SysUtils, StdCtrls,
+  Classes, SysUtils, StdCtrls, ExtCtrls,
   fOptionsFrame;
 
 type
@@ -53,7 +53,7 @@ type
     cbShowTabHeader: TCheckBox;
     cbShowTabs: TCheckBox;
     cbTermWindow: TCheckBox;
-    cbTermSplit: TCheckBox;
+    rgTermMode: TRadioGroup;
     cbTwoDiskPanels: TCheckBox;
     cbShowShortDriveFreeSpace: TCheckBox;
     chkShowMiddleToolBar: TCheckBox;
@@ -92,8 +92,7 @@ end;
 
 procedure TfrmOptionsLayout.cbTermWindowChange(Sender: TObject);
 begin
-  cbTermSplit.Enabled := cbTermWindow.Checked;
-  if not(cbTermWindow.Checked) then cbTermSplit.Checked := False;
+  rgTermMode.Enabled := cbTermWindow.Checked;
 end;
 
 class function TfrmOptionsLayout.GetIconIndex: Integer;
@@ -124,8 +123,8 @@ begin
   cbFlatInterface.Checked := gInterfaceFlat;
   cbLogWindow.Checked := gLogWindow;
   cbTermWindow.Checked := gTermWindow;
-  cbTermSplit.Checked := gTermWindowSplit;
-  cbTermSplit.Enabled := gTermWindow;
+  rgTermMode.ItemIndex := gTermWindowMode;
+  rgTermMode.Enabled := gTermWindow;
   cbShowDriveFreeSpace.Checked := gDriveFreeSpace;
   cbFreespaceInd.Checked := gDriveInd;
   cbProgInMenuBar.Checked := gProgInMenuBar;
@@ -153,7 +152,7 @@ begin
   gInterfaceFlat := cbFlatInterface.Checked;
   gLogWindow := cbLogWindow.Checked;
   gTermWindow := cbTermWindow.Checked;
-  gTermWindowSplit := cbTermSplit.Checked;
+  gTermWindowMode := rgTermMode.ItemIndex;
   gDriveFreeSpace := cbShowDriveFreeSpace.Checked;
   gDriveInd := cbFreespaceInd.Checked;
   gProgInMenuBar := cbProgInMenuBar.Checked;

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -36,7 +36,7 @@ interface
 uses
   Classes, SysUtils, Controls, ComCtrls, LMessages,
   LCLType, Forms,
-  uFileView, uFilePanelSelect, DCXmlConfig;
+  uFileView, uFilePanelSelect, DCXmlConfig, VTEmuCtl, VTEmuPty;
 
 type
 
@@ -61,6 +61,10 @@ type
     FBackupColumnSet: String;
     FOnChangeFileView: TNotifyEvent;
     FBackupViewClass: TFileViewClass;
+    FTerminal: TVirtualTerminal;
+    FPtyDevice: TCustomPtyDevice;
+    FTermInitialized: Boolean;
+    FTermNeedInit: Boolean;
 
     procedure AssignPage(OtherPage: TFileViewPage);
     procedure AssignProperties(OtherPage: TFileViewPage);
@@ -90,6 +94,7 @@ type
 
   public
     constructor Create(TheOwner: TComponent); override;
+    destructor Destroy; override;
 
     function IsActive: Boolean;
     procedure MakeActive;
@@ -109,6 +114,10 @@ type
     property BackupColumnSet: String read FBackupColumnSet write FBackupColumnSet;
     property BackupViewClass: TFileViewClass read FBackupViewClass write FBackupViewClass;
     property OnChangeFileView: TNotifyEvent read FOnChangeFileView write FOnChangeFileView;
+    property Terminal: TVirtualTerminal read FTerminal write FTerminal;
+    property PtyDevice: TCustomPtyDevice read FPtyDevice write FPtyDevice;
+    property TermInitialized: Boolean read FTermInitialized write FTermInitialized;
+    property TermNeedInit: Boolean read FTermNeedInit write FTermNeedInit;
   end;
 
   { TFileViewNotebook }
@@ -231,6 +240,13 @@ begin
   FLockState := tlsNormal;
   FBackupViewClass := TColumnsFileView;
   inherited Create(TheOwner);
+end;
+
+destructor TFileViewPage.Destroy;
+begin
+  if Assigned(FTerminal) then FTerminal.Free;
+  if Assigned(FPtyDevice) then FPtyDevice.Free;
+  inherited Destroy;
 end;
 
 {$IF DEFINED(LCLWIN32)}

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -234,6 +234,10 @@ const
   // 16 -  Move DirectoryHotList to localconfig.xml
   ConfigVersion = 16;
 
+  twmSingle = 0;
+  twmPerPanel = 1;
+  twmPerTab = 2;
+
   COLORS_JSON = 'colors.json';
 
   // Configuration related filenames
@@ -298,7 +302,6 @@ var
   gCmdLine,
   gLogWindow,
   gTermWindow,
-  gTermWindowSplit,
   gKeyButtons,
   gInterfaceFlat,
   gDriveInd,
@@ -314,6 +317,8 @@ var
   // 0 = Detach, 1 = Sync Panel->Terminal, 2 = Sync Terminal->Panel
   gTermSyncModeLeft: Integer;
   gTermSyncModeRight: Integer;
+
+  gTermWindowMode: Integer;
 
   { Toolbar }
   gMiddleToolBarFlat,
@@ -2027,7 +2032,7 @@ begin
   gCmdLine := True;
   gLogWindow := False;
   gTermWindow := False;
-  gTermWindowSplit := False;
+  gTermWindowMode := twmSingle;
   gTermSyncModeLeft := 0; // Detach
   gTermSyncModeRight := 0; // Detach
   gKeyButtons := True;
@@ -2965,7 +2970,10 @@ begin
       gCmdLine := GetValue(Node, 'CmdLine', gCmdLine);
       gLogWindow := GetValue(Node, 'LogWindow', gLogWindow);
       gTermWindow := GetValue(Node, 'TermWindow', gTermWindow);
-      gTermWindowSplit := GetValue(Node, 'TermWindowSplit', gTermWindowSplit);
+      if GetValue(Node, 'TermWindowSplit', False) then
+        gTermWindowMode := twmPerPanel
+      else
+        gTermWindowMode := GetValue(Node, 'TermWindowMode', gTermWindowMode);
       gTermSyncModeLeft := GetValue(Node, 'TermSyncModeLeft', gTermSyncModeLeft);
       gTermSyncModeRight := GetValue(Node, 'TermSyncModeRight', gTermSyncModeRight);
       gKeyButtons := GetValue(Node, 'KeyButtons', gKeyButtons);
@@ -3685,7 +3693,7 @@ begin
     SetValue(Node, 'CmdLine', gCmdLine);
     SetValue(Node, 'LogWindow', gLogWindow);
     SetValue(Node, 'TermWindow', gTermWindow);
-    SetValue(Node, 'TermWindowSplit', gTermWindowSplit);
+    SetValue(Node, 'TermWindowMode', gTermWindowMode);
     SetValue(Node, 'TermSyncModeLeft', gTermSyncModeLeft);
     SetValue(Node, 'TermSyncModeRight', gTermSyncModeRight);
     SetValue(Node, 'KeyButtons', gKeyButtons);

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -298,6 +298,7 @@ var
   gCmdLine,
   gLogWindow,
   gTermWindow,
+  gTermWindowSplit,
   gKeyButtons,
   gInterfaceFlat,
   gDriveInd,
@@ -310,6 +311,9 @@ var
   gShortFormatDriveInfo: Boolean;
   gDrivesListButtonOptions: TDrivesListButtonOptions;
   gSeparateTree: Boolean;
+  // 0 = Detach, 1 = Sync Panel->Terminal, 2 = Sync Terminal->Panel
+  gTermSyncModeLeft: Integer;
+  gTermSyncModeRight: Integer;
 
   { Toolbar }
   gMiddleToolBarFlat,
@@ -2023,6 +2027,9 @@ begin
   gCmdLine := True;
   gLogWindow := False;
   gTermWindow := False;
+  gTermWindowSplit := False;
+  gTermSyncModeLeft := 0; // Detach
+  gTermSyncModeRight := 0; // Detach
   gKeyButtons := True;
   gInterfaceFlat := True;
   gDriveInd := False;
@@ -2958,6 +2965,9 @@ begin
       gCmdLine := GetValue(Node, 'CmdLine', gCmdLine);
       gLogWindow := GetValue(Node, 'LogWindow', gLogWindow);
       gTermWindow := GetValue(Node, 'TermWindow', gTermWindow);
+      gTermWindowSplit := GetValue(Node, 'TermWindowSplit', gTermWindowSplit);
+      gTermSyncModeLeft := GetValue(Node, 'TermSyncModeLeft', gTermSyncModeLeft);
+      gTermSyncModeRight := GetValue(Node, 'TermSyncModeRight', gTermSyncModeRight);
       gKeyButtons := GetValue(Node, 'KeyButtons', gKeyButtons);
       gInterfaceFlat := GetValue(Node, 'InterfaceFlat', gInterfaceFlat);
       gDriveFreeSpace := GetValue(Node, 'DriveFreeSpace', gDriveFreeSpace);
@@ -3675,6 +3685,9 @@ begin
     SetValue(Node, 'CmdLine', gCmdLine);
     SetValue(Node, 'LogWindow', gLogWindow);
     SetValue(Node, 'TermWindow', gTermWindow);
+    SetValue(Node, 'TermWindowSplit', gTermWindowSplit);
+    SetValue(Node, 'TermSyncModeLeft', gTermSyncModeLeft);
+    SetValue(Node, 'TermSyncModeRight', gTermSyncModeRight);
     SetValue(Node, 'KeyButtons', gKeyButtons);
     SetValue(Node, 'InterfaceFlat', gInterfaceFlat);
     SetValue(Node, 'DriveFreeSpace', gDriveFreeSpace);


### PR DESCRIPTION
### Overview
This pull request introduces an option to split the terminal window so that each file panel (Left and Right) has its own dedicated terminal directly below it, complete with configurable link/direction synchronization toggles. 

When this layout option is enabled, the left directory tree expands to the bottom of the main application window, and both terminals behave independently under their respective file panels.

### Key Features

#### 1. Split Terminal Layout Options
* Added a new configuration option in **Options** ➔ **Layout**: `"Show separate terminal under each file panel"` (nested under the main terminal checkbox).
* Persists the split layout state to `doublecmd.ini` via the `TermWindowSplit` option.

#### 2. Overhauled 2-Button Synchronization Toolbar
Each terminal container now features a compact two-button toolbar controlling its link state:
* **Link/Unlink Toggle Button:**
  * **Link On** (`🔗`): Sync is active in the chosen direction.
  * **Link Off** (`⛓️‍💥`): Panel and terminal are completely independent.
  * *Note: The Link Off icon (`⛓️‍💥`) is compiled with precise UTF-8 bytes to ensure the Zero Width Joiner is preserved, rendering properly as a single broken chain emoji on supported platforms.*
* **Direction Toggle Button:**
  * **Terminal to Panel** (`🡅`): Directory changes inside the terminal (e.g. via `cd`) update the panel path.
  * **Panel to Terminal** (`🡇`): Navigating directories in the panel updates the terminal path.

#### 3. Smart Change-Detection Polling (Terminal to Panel)
* Prevents feedback loops and panel locking. The polling thread tracks the terminal process's working directory (`/proc/<pid>/cwd`) and only updates the panel when the directory *actually changes* from the terminal side.
* If terminal-to-panel sync is active and the user manually navigates in the file panel, the panel is **not** forced back to the terminal's directory.

#### 4. Design & Native Look-and-Feel
* Toggle buttons utilize `Flat := gInterfaceFlat` and standard group configurations. They properly darken and sink when selected, matching native Double Commander speed button behaviors.

---

### File Changes
* **[src/uglobs.pas](file:///home/pplupo/repos/doublecmd/src/uglobs.pas)**: Added globals for split layout option and synchronization settings (`gTermWindowSplit`, `gTermSyncModeLeft`, `gTermSyncModeRight`).
* **[src/fmain.pas](file:///home/pplupo/repos/doublecmd/src/fmain.pas)**: Implemented toolbar creation, state persistence, smart polling change-detection logic, and LCL theme-compliant button configurations.
* **[src/frames/foptionslayout.pas](file:///home/pplupo/repos/doublecmd/src/frames/foptionslayout.pas)** & **[.lfm](file:///home/pplupo/repos/doublecmd/src/frames/foptionslayout.lfm)**: Added the split terminal checkbox to the Layout preferences panel.
* **[components/virtualterminal](file:///home/pplupo/repos/doublecmd/components/virtualterminal/)**: Exposed terminal process PID queries for Linux and Windows platforms to allow CWD directory tracking.