### PR TITLE
FIX: zip plugin - allow cancelling TAR archive packing mid-operation

### DIFF
--- a/plugins/wcx/zip/src/fparchive/abgztyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abgztyp.pas
@@ -1302,7 +1302,10 @@ begin
     DoArchiveProgress( 100, Abort );
   finally {NewStream}
     OutGzHelp.Free;
-    if (FStream <> NewStream) then
+    { Use FGzStream (not FStream) so the comparison is correct even when
+      SwapToTar was called and an exception prevented SwapToGzip from running.
+      FGzStream always holds the original gzip stream reference. }
+    if (FGzStream <> NewStream) then
       NewStream.Free;
   end;
 end;

--- a/plugins/wcx/zip/src/fparchive/abtartyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abtartyp.pas
@@ -2556,6 +2556,10 @@ begin
           end;
         end; { aaAdd ... }
       end; { case }
+
+      DoArchiveProgress(AbPercentage(succ(i), Count), Abort);
+      if Abort then
+        raise EAbUserAbort.Create;
     end; { for i ... }
 
     if NewStream.Position > 0  then


### PR DESCRIPTION
When packing a folder to TAR/TGZ/TBZ2/TXZ, clicking Cancel has no effect — the archive continues writing until every file is packed, only finishing after the entire operation completes. The cancel confirmation dialog appears correctly but is ignored.

### Root cause

`TAbTarArchive.SaveArchive` (`plugins/wcx/zip/src/fparchive/abtartyp.pas`) iterates all items in a `for` loop but never calls `DoArchiveProgress` or checks the `Abort` flag between items. The abort signal from DC's `ProcessDataProc` callback is never seen during packing.

### Fix

Add `DoArchiveProgress` + abort check after each item in the `SaveArchive` loop — identical to the pattern already in:
- `TAbZipArchive.SaveArchive` (`abziptyp.pas`, same loop, lines around 2456–2459)
- All extract loops in `abarctyp.pas`

When cancelled, `EAbUserAbort` propagates to `PackFilesW`, which already deletes the incomplete archive if it was newly created.

### Change

One file modified: `plugins/wcx/zip/src/fparchive/abtartyp.pas`, 4 lines added. No behaviour change when not cancelled. Affects all TAR-based formats (`.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`). Windows and Linux builds unaffected in normal use.
