### PR TITLE
Fix terminal scroll: AutoFollow off-by-one and clear resets viewport

### DIFF
--- a/components/virtualterminal/source/vtemuctl.pas
+++ b/components/virtualterminal/source/vtemuctl.pas
@@ -785,7 +785,9 @@ end;
 procedure TCustomComTerminal.ClearScreen;
 begin
   FBuffer.Init(0, 0);
+  FTopLeft := Classes.Point(1, 1);
   MoveCaret(1, 1);
+  UpdateScrollRange;
   Invalidate;
 end;
 
@@ -1361,7 +1363,7 @@ begin
   end;
   if FAutoFollow then
   begin
-    if (FCaretPos.Y - FTopLeft.Y) > FVisibleRows then
+    if (FCaretPos.Y - FTopLeft.Y) >= FVisibleRows then
     begin
       I:= FCaretPos.Y - FVisibleRows + 1;
       ModifyScrollBar(SB_Vert, SB_THUMBPOSITION, I);
@@ -1773,7 +1775,9 @@ begin
       ecEraseScreen:
       begin
         FBuffer.EraseScreenRight(1, 1);
-        MoveCaret(1, 1)
+        FTopLeft := Classes.Point(1, 1);
+        MoveCaret(1, 1);
+        UpdateScrollRange;
       end;
       ecEraseChar: FBuffer.EraseChar(FCaretPos.X, FCaretPos.Y, GetParam(1, AParams));
       ecDeleteChar: FBuffer.DeleteChar(FCaretPos.X, FCaretPos.Y, GetParam(1, AParams));


### PR DESCRIPTION
Two bugs in the embedded terminal panel (VirtualTerminal component):

1. AutoFollow off-by-one: The condition that scrolls the view to follow the caret used strict '>' instead of '>=', so the caret could sit one row below the bottom of the visible area before scrolling fired. Commands that produce long output left the prompt just off-screen. Fix: change '>' to '>=' in TCustomComTerminal.AdvanceCaret.

2. ClearScreen / ESC[2J leave viewport at wrong position: After bash 'clear' (or any ESC[2J / form-feed), the buffer content was erased and the caret was moved to row 1, but FTopLeft was never reset, so the visible area stayed wherever it was (e.g. near the bottom of a long buffer). The user saw blank rows and had to scroll up manually to reach the new prompt. Fix: reset FTopLeft to (1,1) and call UpdateScrollRange in both ClearScreen() and the ecEraseScreen handler.