### PR TITLE
FIX: zip plugin - crash packing large directories as TGZ

### DIFF
--- a/plugins/wcx/zip/src/fparchive/abarctyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abarctyp.pas
@@ -1947,7 +1947,7 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TAbArchive.SaveIfNeeded(aItem : TAbArchiveItem);
 begin
-  if (aItem.Action <> aaNone) then
+  if AutoSave and (aItem.Action <> aaNone) then
     Save;
 end;
 { -------------------------------------------------------------------------- }

--- a/plugins/wcx/zip/src/fparchive/abgztyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abgztyp.pas
@@ -1146,9 +1146,19 @@ begin
 
     try
       {init new archive stream}
-      CreateArchive:= FOwnsStream and (FGzStream.Size = 0) and (FGzStream is TFileStreamEx);
-      if CreateArchive then
-        NewStream := FGzStream
+      { When FTarStream is nil we have a freshly-created gzipped-tar whose
+        LoadArchive was never called — we cannot read back previously-saved
+        items.  Force CreateArchive so we write directly to FGzStream
+        (truncated) and avoid creating a temp file we can never finish. }
+      CreateArchive:= FOwnsStream and (FGzStream is TFileStreamEx) and
+        ((FGzStream.Size = 0) or (IsGzippedTar and TarAutoHandle and (FTarStream = nil)));
+      if CreateArchive then begin
+        if FGzStream.Size > 0 then begin
+          FGzStream.Size := 0;
+          FGzStream.Position := 0;
+        end;
+        NewStream := FGzStream;
+      end
       else begin
         ATempName := GetTempName(FArchiveName);
         NewStream := TFileStreamEx.Create(ATempName, fmCreate or fmShareDenyWrite);
@@ -1158,6 +1168,14 @@ begin
       { save the Tar data }
       if IsGzippedTar and TarAutoHandle then begin
         SwapToTar;
+        { If FStream (=FTarStream) is nil we cannot read back items from a
+          previous save — this happens when SaveIfNeeded triggers a second
+          save on a freshly-created archive whose LoadArchive was never
+          called.  Force those items to be re-read from disk. }
+        if FStream = nil then
+          for i := 0 to pred(Count) do
+            if ItemList[i].Action = aaNone then
+              ItemList[i].Action := aaAdd;
         if FGZItem.Count = 0 then begin
           CurItem := TAbGzipItem.Create;
           FGZItem.Add(CurItem);


### PR DESCRIPTION
When packing a directory with many files (120K+) as .tgz, duplicate path entries (common with symlinks) trigger SaveIfNeeded which force-saves mid-operation regardless of AutoSave=False. After the first intermediate save, FTarStream is nil (no LoadArchive was called for a fresh archive), so subsequent saves crash with EAccessViolation trying to seek a nil FStream.

Fix has two parts:
1. SaveIfNeeded now respects AutoSave — when AutoSave=False (set by the WCX plugin), no intermediate saves are triggered. The single final Arc.Save handles all items in one pass.
2. Defensive fallback in TAbGzipArchive.SaveArchive: if FTarStream is nil (fresh archive) but FGzStream already has data, force CreateArchive mode (truncate and rewrite directly) and reset aaNone items to aaAdd so they re-read from disk instead of from the non-existent archive stream.