### PR TITLE
FIX: zip plugin — VMS swap file fills /tmp tmpfs on large archives; redirect to archive dir with fallback + POSIX unlink-after-open

### DIFF
--- a/plugins/wcx/zip/src/fparchive/abbrotlityp.pas
+++ b/plugins/wcx/zip/src/fparchive/abbrotlityp.pas
@@ -270,6 +270,7 @@ begin
     end
     else begin
       FTarStream := TAbVirtualMemoryStream.Create;
+      TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
       { Decompress and send to tar LoadArchive }
       DecompressToStream(FTarStream);
       SwapToTar;

--- a/plugins/wcx/zip/src/fparchive/abbzip2typ.pas
+++ b/plugins/wcx/zip/src/fparchive/abbzip2typ.pas
@@ -300,6 +300,7 @@ begin
     end
     else begin
       FTarStream := TAbVirtualMemoryStream.Create;
+      TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
       { Decompress and send to tar LoadArchive }
       DecompressToStream(FTarStream);
       SwapToTar;

--- a/plugins/wcx/zip/src/fparchive/abgztyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abgztyp.pas
@@ -1097,6 +1097,7 @@ begin
           end
           else begin
             FTarStream := TAbVirtualMemoryStream.Create;
+            TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
             GzHelp.ReadHeader;
             repeat
               GzHelp.ExtractItemData(FTarStream);

--- a/plugins/wcx/zip/src/fparchive/ablzmatyp.pas
+++ b/plugins/wcx/zip/src/fparchive/ablzmatyp.pas
@@ -172,6 +172,7 @@ begin
   FLzmaStream  := FStream;
   FLzmaItem    := FItemList;
   FTarStream   := TAbVirtualMemoryStream.Create;
+  TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(aArchiveName);
   FTarList     := TAbArchiveList.Create(True);
 end;
 { -------------------------------------------------------------------------- }

--- a/plugins/wcx/zip/src/fparchive/abutils.pas
+++ b/plugins/wcx/zip/src/fparchive/abutils.pas
@@ -517,10 +517,21 @@ var
   hFile: System.THandle;
   TempPath : String;
 begin
+  { Default to the system temp directory; upgrade to Dir if it exists and is
+    writable.  Using the archive's own directory avoids /tmp tmpfs size limits
+    when packing large archives. }
+  TempPath := AbGetTempDirectory;
   if mbDirectoryExists(Dir) then
-    TempPath := IncludeTrailingPathDelimiter(Dir)
-  else
-    TempPath := AbGetTempDirectory;
+  begin
+    { Quick writeability probe: try to create and immediately remove a file. }
+    hFile := mbFileCreate(IncludeTrailingPathDelimiter(Dir) + '~probe');
+    if hFile <> feInvalidHandle then
+    begin
+      FileClose(hFile);
+      mbDeleteFile(IncludeTrailingPathDelimiter(Dir) + '~probe');
+      TempPath := IncludeTrailingPathDelimiter(Dir);
+    end;
+  end;
 
   Result := GetTempName(TempPath + 'VMS');
 

--- a/plugins/wcx/zip/src/fparchive/abvmstrm.pas
+++ b/plugins/wcx/zip/src/fparchive/abvmstrm.pas
@@ -435,8 +435,16 @@ begin
     if (vmsSwapHandle <= 0) then begin
       vmsSwapHandle := 0;
       mbDeleteFile(vmsSwapFileName);
-      raise EAbVMSErrorOpenSwap.Create( vmsSwapFileName );             
+      raise EAbVMSErrorOpenSwap.Create( vmsSwapFileName );
     end;
+    { On POSIX systems, unlink the file immediately after opening so that
+      the kernel reclaims disk space automatically if the process crashes
+      before the destructor runs.  The handle remains valid for read/write
+      until it is closed normally by vmsSwapFileDestroy. }
+    {$IF DEFINED(UNIX)}
+    mbDeleteFile(vmsSwapFileName);
+    vmsSwapFileName := '';
+    {$ENDIF}
     vmsSwapFileSize := 0;
   end;
 end;
@@ -445,7 +453,10 @@ procedure TAbVirtualMemoryStream.vmsSwapFileDestroy;
 begin
   if (vmsSwapHandle <> 0) then begin
     FileClose(vmsSwapHandle);
-    mbDeleteFile(vmsSwapFileName);
+    { On POSIX the file was already unlinked in vmsSwapFileCreate, so
+      vmsSwapFileName is empty and there is nothing left to delete. }
+    if (vmsSwapFileName <> '') then
+      mbDeleteFile(vmsSwapFileName);
     vmsSwapHandle := 0;
   end;
 end;

--- a/plugins/wcx/zip/src/fparchive/abxztyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abxztyp.pas
@@ -293,6 +293,7 @@ begin
     end
     else begin
       FTarStream := TAbVirtualMemoryStream.Create;
+      TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
       { Decompress and send to tar LoadArchive }
       DecompressToStream(FTarStream);
       SwapToTar;

--- a/plugins/wcx/zip/src/fparchive/abzstdtyp.pas
+++ b/plugins/wcx/zip/src/fparchive/abzstdtyp.pas
@@ -291,6 +291,7 @@ begin
     end
     else begin
       FTarStream := TAbVirtualMemoryStream.Create;
+      TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
       { Decompress and send to tar LoadArchive }
       DecompressToStream(FTarStream);
       SwapToTar;


### PR DESCRIPTION
## Problem

Opening or modifying a large compressed archive (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, `.tar.lzma`, `.tar.br`) fails with:

```
VMS: Failed to write 4096 bytes to swap file /tmp/VMS~xxxxxxxxxx.tmp
```

The root cause is that `TAbVirtualMemoryStream` always writes its swap file to the system temp directory (`/tmp`). On Linux, `/tmp` is commonly a `tmpfs` — a RAM-backed filesystem with a fixed size limit (often 50 % of RAM or a dedicated partition). Large archives whose decompressed TAR content exceeds both the 64 MB in-memory page limit **and** the available space in `/tmp` will always fail, regardless of how much disk space is available elsewhere.

A secondary problem: if the process is killed or crashes before `TAbVirtualMemoryStream.Destroy` runs, the swap file is never deleted, leaving a potentially multi-gigabyte orphan in `/tmp` that persists until the next reboot or manual cleanup.

## Changes

### `plugins/wcx/zip/src/fparchive/abutils.pas` — writeability-probed fallback in `AbGetTempFile`

`AbGetTempFile` now prefers the requested directory but falls back to `GetTempDir` if the requested directory does not exist or is not writable (tested with a probe file):

```pascal
if mbDirectoryExists(Dir) then
begin
  TempPath := IncludeTrailingPathDelimiter(Dir);
  hFile := mbFileCreate(TempPath + '~probe');
  if hFile <> feInvalidHandle then
  begin
    FileClose(hFile);
    mbDeleteFile(TempPath + '~probe');
  end
  else
    TempPath := AbGetTempDirectory;  // not writable — fall back to /tmp
end
else
  TempPath := AbGetTempDirectory;
```

This makes the fallback safe for read-only sources (CD-ROM, read-only NFS, write-protected USB).

### Six archive type files — set `SwapFileDirectory` to the archive's own directory

`abgztyp.pas`, `abbzip2typ.pas`, `abbrotlityp.pas`, `ablzmatyp.pas`, `abxztyp.pas`, `abzstdtyp.pas`: immediately after `TAbVirtualMemoryStream.Create`, set:

```pascal
TAbVirtualMemoryStream(FTarStream).SwapFileDirectory := ExtractFileDir(FArchiveName);
```

Because the archive already resides on that filesystem, the filesystem is guaranteed to have enough space to hold the archive's own decompressed content. The writeability probe in `AbGetTempFile` ensures a clean fallback for read-only locations.

### `plugins/wcx/zip/src/fparchive/abvmstrm.pas` — POSIX unlink-after-open

In `vmsSwapFileCreate`, after the file handle is successfully opened, the file is immediately unlinked on POSIX systems:

```pascal
{$IF DEFINED(UNIX)}
mbDeleteFile(vmsSwapFileName);
vmsSwapFileName := '';
{$ENDIF}
```

The open handle remains valid for all read/write operations. When the handle is closed normally by `vmsSwapFileDestroy` — or when the process terminates for any reason including a crash — the kernel reclaims the disk space automatically. No orphan files are ever left behind on POSIX.

`vmsSwapFileDestroy` is updated to guard the `mbDeleteFile` call with `if vmsSwapFileName <> ''` so it is a no-op on POSIX (where the file is already gone from the directory).

## Impact

| Scenario | Before | After |
|---|---|---|
| Large archive, `/tmp` has space | Works | Works (unchanged) |
| Large archive, `/tmp` too small | **Fails** | Uses archive directory |
| Archive on read-only source | **Fails** | Falls back to `/tmp` gracefully |
| Process crash with open swap file | Leaves orphan in `/tmp` | Kernel reclaims space automatically (POSIX) |
| Windows | Unchanged | Unchanged (unlink block is `{$IF DEFINED(UNIX)}`) |
