### PR TITLE
Suggested improvement: delete dialog — per-operation Trash / Delete / Wipe choice + Wipe in context menu

### DIFF
--- a/src/fdeletedlg.lfm
+++ b/src/fdeletedlg.lfm
@@ -34,6 +34,20 @@ inherited frmDeleteDlg: TfrmDeleteDlg
       ShowAccelChar = False
       WordWrap = True
     end
+    object chkUseTrash: TCheckBox[1]
+      AnchorSideLeft.Control = pnlContent
+      AnchorSideTop.Control = lblMessage
+      AnchorSideTop.Side = asrBottom
+      Left = 0
+      Height = 23
+      Top = 1
+      Width = 399
+      Anchors = [akTop, akLeft]
+      Caption = 'Move to &Recycle Bin'
+      TabOrder = 1
+      Visible = False
+      OnChange = chkUseTrashChange
+    end
   end
   inherited pnlButtons: TPanel
     AnchorSideLeft.Control = Owner

--- a/src/fdeletedlg.lfm
+++ b/src/fdeletedlg.lfm
@@ -12,7 +12,7 @@ inherited frmDeleteDlg: TfrmDeleteDlg
   Constraints.MinWidth = 400
   KeyPreview = True
   OnKeyDown = FormKeyDown
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   inherited pnlContent: TPanel
     Height = 1
     Width = 399

--- a/src/fdeletedlg.lfm
+++ b/src/fdeletedlg.lfm
@@ -34,7 +34,7 @@ inherited frmDeleteDlg: TfrmDeleteDlg
       ShowAccelChar = False
       WordWrap = True
     end
-    object chkUseTrash: TCheckBox[1]
+    object rbTrash: TRadioButton[1]
       AnchorSideLeft.Control = pnlContent
       AnchorSideTop.Control = lblMessage
       AnchorSideTop.Side = asrBottom
@@ -46,7 +46,35 @@ inherited frmDeleteDlg: TfrmDeleteDlg
       Caption = 'Move to &Recycle Bin'
       TabOrder = 1
       Visible = False
-      OnChange = chkUseTrashChange
+      OnChange = rbModeChange
+    end
+    object rbDelete: TRadioButton[2]
+      AnchorSideLeft.Control = pnlContent
+      AnchorSideTop.Control = rbTrash
+      AnchorSideTop.Side = asrBottom
+      Left = 0
+      Height = 23
+      Top = 24
+      Width = 399
+      Anchors = [akTop, akLeft]
+      Caption = 'Delete &permanently'
+      TabOrder = 2
+      Visible = False
+      OnChange = rbModeChange
+    end
+    object rbWipe: TRadioButton[3]
+      AnchorSideLeft.Control = pnlContent
+      AnchorSideTop.Control = rbDelete
+      AnchorSideTop.Side = asrBottom
+      Left = 0
+      Height = 23
+      Top = 47
+      Width = 399
+      Anchors = [akTop, akLeft]
+      Caption = '&Wipe (secure erase)'
+      TabOrder = 3
+      Visible = False
+      OnChange = rbModeChange
     end
   end
   inherited pnlButtons: TPanel

--- a/src/fdeletedlg.pas
+++ b/src/fdeletedlg.pas
@@ -9,23 +9,27 @@ uses
   Buttons, Menus, StdCtrls, fButtonForm, uOperationsManager, uFileSource;
 
 type
+  TDeleteMode = (dmTrash, dmDelete, dmWipe);
 
   { TfrmDeleteDlg }
 
   TfrmDeleteDlg = class(TfrmButtonForm)
-    chkUseTrash: TCheckBox;
+    rbTrash: TRadioButton;
+    rbDelete: TRadioButton;
+    rbWipe: TRadioButton;
     lblMessage: TLabel;
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
-    procedure chkUseTrashChange(Sender: TObject);
+    procedure rbModeChange(Sender: TObject);
   private
-    FMsgTrash: String;
-    FMsgNoTrash: String;
+    FMessages: array[TDeleteMode] of String;
   public
     { public declarations }
   end;
 
 function ShowDeleteDialog(TheOwner: TComponent; const Message: String; FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier): Boolean; overload;
-function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, NoTrashMessage: String; FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier; var UseTrash: Boolean): Boolean; overload;
+function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, DeleteMessage, WipeMessage: String;
+  FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier;
+  ShowTrash, ShowWipe: Boolean; var DeleteMode: TDeleteMode): Boolean; overload;
 
 implementation
 
@@ -45,23 +49,33 @@ begin
   end;
 end;
 
-function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, NoTrashMessage: String;
+function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, DeleteMessage, WipeMessage: String;
   FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier;
-  var UseTrash: Boolean): Boolean;
+  ShowTrash, ShowWipe: Boolean; var DeleteMode: TDeleteMode): Boolean;
 begin
   with TfrmDeleteDlg.Create(TheOwner, FileSource) do
   begin
     Caption:= Application.Title;
-    FMsgTrash:= TrashMessage;
-    FMsgNoTrash:= NoTrashMessage;
-    chkUseTrash.Visible:= True;
-    chkUseTrash.Checked:= UseTrash;
-    if UseTrash then
-      lblMessage.Caption:= TrashMessage
-    else
-      lblMessage.Caption:= NoTrashMessage;
+    FMessages[dmTrash]  := TrashMessage;
+    FMessages[dmDelete] := DeleteMessage;
+    FMessages[dmWipe]   := WipeMessage;
+    rbTrash.Visible  := ShowTrash;
+    rbDelete.Visible := True;
+    rbWipe.Visible   := ShowWipe;
+    // Set initial selection; fall back to dmDelete if the preferred mode is unavailable
+    case DeleteMode of
+      dmTrash:  if ShowTrash then rbTrash.Checked  := True else rbDelete.Checked := True;
+      dmWipe:   if ShowWipe  then rbWipe.Checked   := True else rbDelete.Checked := True;
+      else           rbDelete.Checked := True;
+    end;
+    lblMessage.Caption:= FMessages[DeleteMode];
     Result:= ShowModal = mrOK;
-    if Result then UseTrash:= chkUseTrash.Checked;
+    if Result then
+    begin
+      if rbTrash.Checked then DeleteMode := dmTrash
+      else if rbWipe.Checked then DeleteMode := dmWipe
+      else DeleteMode := dmDelete;
+    end;
     QueueId:= QueueIdentifier;
     Free;
   end;
@@ -81,12 +95,14 @@ begin
   end;
 end;
 
-procedure TfrmDeleteDlg.chkUseTrashChange(Sender: TObject);
+procedure TfrmDeleteDlg.rbModeChange(Sender: TObject);
+var
+  Mode: TDeleteMode;
 begin
-  if chkUseTrash.Checked then
-    lblMessage.Caption:= FMsgTrash
-  else
-    lblMessage.Caption:= FMsgNoTrash;
+  if rbTrash.Checked then Mode := dmTrash
+  else if rbWipe.Checked then Mode := dmWipe
+  else Mode := dmDelete;
+  lblMessage.Caption := FMessages[Mode];
 end;
 
 end.

--- a/src/fdeletedlg.pas
+++ b/src/fdeletedlg.pas
@@ -38,46 +38,52 @@ uses
 
 function ShowDeleteDialog(TheOwner: TComponent; const Message: String; FileSource: IFileSource;
   out QueueId: TOperationsManagerQueueIdentifier): Boolean;
+var
+  Dlg: TfrmDeleteDlg;
 begin
-  with TfrmDeleteDlg.Create(TheOwner, FileSource) do
-  begin
-    Caption:= Application.Title;
-    lblMessage.Caption:= Message;
-    Result:= ShowModal = mrOK;
-    QueueId:= QueueIdentifier;
-    Free;
+  Dlg := TfrmDeleteDlg.Create(TheOwner, FileSource);
+  try
+    Dlg.Caption := Application.Title;
+    Dlg.lblMessage.Caption := Message;
+    Result := Dlg.ShowModal = mrOK;
+    QueueId := Dlg.QueueIdentifier;
+  finally
+    Dlg.Free;
   end;
 end;
 
 function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, DeleteMessage, WipeMessage: String;
   FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier;
   ShowTrash, ShowWipe: Boolean; var DeleteMode: TDeleteMode): Boolean;
+var
+  Dlg: TfrmDeleteDlg;
 begin
-  with TfrmDeleteDlg.Create(TheOwner, FileSource) do
-  begin
-    Caption:= Application.Title;
-    FMessages[dmTrash]  := TrashMessage;
-    FMessages[dmDelete] := DeleteMessage;
-    FMessages[dmWipe]   := WipeMessage;
-    rbTrash.Visible  := ShowTrash;
-    rbDelete.Visible := True;
-    rbWipe.Visible   := ShowWipe;
+  Dlg := TfrmDeleteDlg.Create(TheOwner, FileSource);
+  try
+    Dlg.Caption := Application.Title;
+    Dlg.FMessages[dmTrash]  := TrashMessage;
+    Dlg.FMessages[dmDelete] := DeleteMessage;
+    Dlg.FMessages[dmWipe]   := WipeMessage;
+    Dlg.rbTrash.Visible  := ShowTrash;
+    Dlg.rbDelete.Visible := True;
+    Dlg.rbWipe.Visible   := ShowWipe;
     // Set initial selection; fall back to dmDelete if the preferred mode is unavailable
     case DeleteMode of
-      dmTrash:  if ShowTrash then rbTrash.Checked  := True else rbDelete.Checked := True;
-      dmWipe:   if ShowWipe  then rbWipe.Checked   := True else rbDelete.Checked := True;
-      else           rbDelete.Checked := True;
+      dmTrash:  if ShowTrash then Dlg.rbTrash.Checked  := True else Dlg.rbDelete.Checked := True;
+      dmWipe:   if ShowWipe  then Dlg.rbWipe.Checked   := True else Dlg.rbDelete.Checked := True;
+      else           Dlg.rbDelete.Checked := True;
     end;
-    lblMessage.Caption:= FMessages[DeleteMode];
-    Result:= ShowModal = mrOK;
+    Dlg.lblMessage.Caption := Dlg.FMessages[DeleteMode];
+    Result := Dlg.ShowModal = mrOK;
     if Result then
     begin
-      if rbTrash.Checked then DeleteMode := dmTrash
-      else if rbWipe.Checked then DeleteMode := dmWipe
+      if Dlg.rbTrash.Checked then DeleteMode := dmTrash
+      else if Dlg.rbWipe.Checked then DeleteMode := dmWipe
       else DeleteMode := dmDelete;
     end;
-    QueueId:= QueueIdentifier;
-    Free;
+    QueueId := Dlg.QueueIdentifier;
+  finally
+    Dlg.Free;
   end;
 end;
 
@@ -87,11 +93,36 @@ end;
 
 procedure TfrmDeleteDlg.FormKeyDown(Sender: TObject; var Key: Word;
   Shift: TShiftState);
+var
+  Modes: array[0..2] of TRadioButton;
+  Count, Cur, I: Integer;
 begin
-  if (Key = VK_RETURN) and (ssShift in Shift) then
-  begin
-    btnOK.Click;
-    Key:= 0;
+  case Key of
+    VK_RETURN:
+      begin
+        btnOK.Click;
+        Key := 0;
+      end;
+    VK_UP, VK_DOWN:
+      begin
+        { Build ordered list of visible radio buttons. }
+        Count := 0;
+        Cur   := -1;
+        for I := 0 to 2 do
+          Modes[I] := nil;
+        if rbTrash.Visible  then begin Modes[Count] := rbTrash;  if rbTrash.Checked  then Cur := Count; Inc(Count); end;
+        if rbDelete.Visible then begin Modes[Count] := rbDelete; if rbDelete.Checked then Cur := Count; Inc(Count); end;
+        if rbWipe.Visible   then begin Modes[Count] := rbWipe;   if rbWipe.Checked   then Cur := Count; Inc(Count); end;
+        if Count > 1 then
+        begin
+          if Key = VK_DOWN then
+            Cur := (Cur + 1) mod Count
+          else
+            Cur := (Cur + Count - 1) mod Count;
+          Modes[Cur].Checked := True;
+        end;
+        Key := 0;
+      end;
   end;
 end;
 

--- a/src/fdeletedlg.pas
+++ b/src/fdeletedlg.pas
@@ -13,15 +13,19 @@ type
   { TfrmDeleteDlg }
 
   TfrmDeleteDlg = class(TfrmButtonForm)
+    chkUseTrash: TCheckBox;
     lblMessage: TLabel;
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure chkUseTrashChange(Sender: TObject);
   private
-    { private declarations }
+    FMsgTrash: String;
+    FMsgNoTrash: String;
   public
     { public declarations }
   end;
 
-function ShowDeleteDialog(TheOwner: TComponent; const Message: String; FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier): Boolean;
+function ShowDeleteDialog(TheOwner: TComponent; const Message: String; FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier): Boolean; overload;
+function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, NoTrashMessage: String; FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier; var UseTrash: Boolean): Boolean; overload;
 
 implementation
 
@@ -41,6 +45,28 @@ begin
   end;
 end;
 
+function ShowDeleteDialog(TheOwner: TComponent; const TrashMessage, NoTrashMessage: String;
+  FileSource: IFileSource; out QueueId: TOperationsManagerQueueIdentifier;
+  var UseTrash: Boolean): Boolean;
+begin
+  with TfrmDeleteDlg.Create(TheOwner, FileSource) do
+  begin
+    Caption:= Application.Title;
+    FMsgTrash:= TrashMessage;
+    FMsgNoTrash:= NoTrashMessage;
+    chkUseTrash.Visible:= True;
+    chkUseTrash.Checked:= UseTrash;
+    if UseTrash then
+      lblMessage.Caption:= TrashMessage
+    else
+      lblMessage.Caption:= NoTrashMessage;
+    Result:= ShowModal = mrOK;
+    if Result then UseTrash:= chkUseTrash.Checked;
+    QueueId:= QueueIdentifier;
+    Free;
+  end;
+end;
+
 {$R *.lfm}
 
 { TfrmDeleteDlg }
@@ -53,6 +79,14 @@ begin
     btnOK.Click;
     Key:= 0;
   end;
+end;
+
+procedure TfrmDeleteDlg.chkUseTrashChange(Sender: TObject);
+begin
+  if chkUseTrash.Checked then
+    lblMessage.Caption:= FMsgTrash
+  else
+    lblMessage.Caption:= FMsgNoTrash;
 end;
 
 end.

--- a/src/filesources/filesystem/ufilesystemdeleteoperation.pas
+++ b/src/filesources/filesystem/ufilesystemdeleteoperation.pas
@@ -11,7 +11,8 @@ uses
   uFileSourceOperationOptions,
   uFileSourceOperationUI,
   uFile,
-  uDescr, uGlobs, uLog;
+  uDescr, uGlobs, uLog
+  {$IF DEFINED(UNIX)}, uKde{$ENDIF};
 
 type
 
@@ -125,6 +126,13 @@ end;
 procedure TFileSystemDeleteOperation.MainExecute;
 begin
   ProcessList(FFullFilesTreeToDelete);
+{$IF DEFINED(UNIX)}
+  // Notify KDE trash widget to refresh after a recycle operation.
+  // kioclient5 move /dev/null trash:/ fails intentionally but triggers the
+  // KDE widget to pick up external changes to the trash directory.
+  // See: https://github.com/doublecmd/doublecmd/issues/2688
+  if FRecycle then RefreshKdeTrashWidget;
+{$ENDIF}
 end;
 
 procedure TFileSystemDeleteOperation.Finalize;

--- a/src/fmain.lfm
+++ b/src/fmain.lfm
@@ -2943,6 +2943,9 @@ object frmMain: TfrmMain
     object mnuContextRenameOnly: TMenuItem
       Action = actRenameOnly
     end
+    object mnuContextWipe: TMenuItem
+      Action = actWipe
+    end
     object mnuContextDelete: TMenuItem
       Action = actDelete
     end

--- a/src/platform/unix/ukde.pas
+++ b/src/platform/unix/ukde.pas
@@ -29,9 +29,11 @@ uses
   Classes, SysUtils, uMyUnix;
 
 function KioOpen(const URL: String): Boolean;
+procedure RefreshKdeTrashWidget;
 
 var
   HasKdeOpen: Boolean = False;
+  KdeOpen: String = 'kioclient';
 
 implementation
 
@@ -40,7 +42,6 @@ uses
 
 var
   KdeVersion: String;
-  KdeOpen: String = 'kioclient';
 
 function KioOpen(const URL: String): Boolean;
 begin
@@ -60,6 +61,14 @@ begin
   end;
 end;
 
+procedure RefreshKdeTrashWidget;
+begin
+  // This intentionally-failing move triggers KDE to refresh its trash widget.
+  // See: https://github.com/doublecmd/doublecmd/issues/2688
+  if HasKdeOpen then
+    ExecuteProcess(KdeOpen, ['--noninteractive', 'move', '/dev/null', 'trash:/']);
+end;
+
 procedure Initialize;
 begin
   if (DesktopEnv = DE_KDE) then
@@ -67,7 +76,7 @@ begin
     KdeVersion:= GetEnvironmentVariable('KDE_SESSION_VERSION');
     if KdeVersion = '5' then KdeOpen:= 'kioclient5';
     HasKdeOpen:= FindExecutableInSystemPath(KdeOpen);
-    // if HasKdeOpen then FileTrashUtf8:= @FileTrash;
+    if HasKdeOpen then FileTrashUtf8:= @FileTrash;
   end;
 end;
 

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -2592,13 +2592,15 @@ var
   theFilesToDelete: TFiles;
   // 12.05.2009 - if delete to trash, then show another messages
   MsgDelSel, MsgDelFlDr : string;
-  MsgTrash, MsgNoTrash: String;
+  MsgTrash, MsgNoTrash, MsgWipe: String;
   Operation: TFileSourceOperation;
   bRecycle: Boolean;
   bConfirmation, HasConfirmationParam: Boolean;
+  Confirmed: Boolean;
   Param, ParamTrashCan: String;
   BoolValue: Boolean;
-  TrashAvailable: Boolean;
+  TrashAvailable, WipeAvailable: Boolean;
+  DeleteMode: TDeleteMode;
   QueueId: TOperationsManagerQueueIdentifier = FreeOperationsQueueId;
 begin
   with frmMain.ActiveFrame do
@@ -2641,6 +2643,7 @@ begin
     // Save parameter for later use
     TrashAvailable := FileSource.IsClass(TFileSystemFileSource) and
                       mbCheckTrash(CurrentPath);
+    WipeAvailable  := fsoWipe in FileSource.GetOperationsTypes;
     BoolValue := bRecycle;
 
     if bRecycle then
@@ -2679,9 +2682,10 @@ begin
       if (theFilesToDelete.Count = 0) then Exit;
       if (theFilesToDelete.Count = 1) then
       begin
-        MsgTrash   := Format(rsMsgDelSelT, [theFilesToDelete[0].Name]);
-        MsgNoTrash := Format(rsMsgDelSel,  [theFilesToDelete[0].Name]);
-        Message    := Format(MsgDelSel,    [theFilesToDelete[0].Name]);
+        MsgTrash   := Format(rsMsgDelSelT,  [theFilesToDelete[0].Name]);
+        MsgNoTrash := Format(rsMsgDelSel,   [theFilesToDelete[0].Name]);
+        MsgWipe    := Format(rsMsgWipeSel,  [theFilesToDelete[0].Name]);
+        Message    := Format(MsgDelSel,     [theFilesToDelete[0].Name]);
       end
       else begin
         // Build the file list suffix once and share it across all message variants
@@ -2691,11 +2695,21 @@ begin
         if theFilesToDelete.Count > 5 then Message += LineEnding + '...';
         MsgTrash   := Format(rsMsgDelFlDrT, [theFilesToDelete.Count]) + Message;
         MsgNoTrash := Format(rsMsgDelFlDr,  [theFilesToDelete.Count]) + Message;
+        MsgWipe    := Format(rsMsgWipeFlDr, [theFilesToDelete.Count]) + Message;
         Message    := Format(MsgDelFlDr,    [theFilesToDelete.Count]) + Message;
       end;
-      if (bConfirmation = False) or
-         (TrashAvailable and ShowDeleteDialog(frmMain, MsgTrash, MsgNoTrash, FileSource, QueueId, bRecycle)) or
-         ((not TrashAvailable) and ShowDeleteDialog(frmMain, Message, FileSource, QueueId)) then
+      // Default delete mode based on current recycle setting
+      if bRecycle then DeleteMode := dmTrash else DeleteMode := dmDelete;
+      // Show confirmation dialog; choose extended or simple variant based on available modes
+      if not bConfirmation then
+        Confirmed := True
+      else if TrashAvailable or WipeAvailable then
+        Confirmed := ShowDeleteDialog(frmMain, MsgTrash, MsgNoTrash, MsgWipe,
+                                      FileSource, QueueId,
+                                      TrashAvailable, WipeAvailable, DeleteMode)
+      else
+        Confirmed := ShowDeleteDialog(frmMain, Message, FileSource, QueueId);
+      if Confirmed then
       begin
         // Restore focus to main window after confirmation dialog closes
         if bConfirmation and frmMain.ActiveFrame.CanSetFocus then
@@ -2730,25 +2744,27 @@ begin
           end;
         end;
 
-        Operation := FileSource.CreateDeleteOperation(theFilesToDelete);
-
-        if Assigned(Operation) then
+        // Dispatch to wipe or delete based on dialog choice
+        if DeleteMode = dmWipe then
+          Operation := FileSource.CreateWipeOperation(theFilesToDelete)
+        else
         begin
+          bRecycle  := (DeleteMode = dmTrash);
+          Operation := FileSource.CreateDeleteOperation(theFilesToDelete);
           // Special case for filesystem - 'recycle' parameter.
-          if Operation is TFileSystemDeleteOperation then
+          if Assigned(Operation) and (Operation is TFileSystemDeleteOperation) then
             with Operation as TFileSystemDeleteOperation do
             begin
               // 30.04.2009 - передаем параметр корзины в поток.
               Recycle := bRecycle;
             end;
-
-          // Start operation.
-          OperationsManager.AddOperation(Operation, QueueId, False);
-        end
-        else
-        begin
-          msgWarning(rsMsgNotImplemented);
         end;
+
+        if Assigned(Operation) then
+          // Start operation.
+          OperationsManager.AddOperation(Operation, QueueId, False)
+        else
+          msgWarning(rsMsgNotImplemented);
       end;
 
     finally

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -2592,11 +2592,13 @@ var
   theFilesToDelete: TFiles;
   // 12.05.2009 - if delete to trash, then show another messages
   MsgDelSel, MsgDelFlDr : string;
+  MsgTrash, MsgNoTrash: String;
   Operation: TFileSourceOperation;
   bRecycle: Boolean;
   bConfirmation, HasConfirmationParam: Boolean;
   Param, ParamTrashCan: String;
   BoolValue: Boolean;
+  TrashAvailable: Boolean;
   QueueId: TOperationsManagerQueueIdentifier = FreeOperationsQueueId;
 begin
   with frmMain.ActiveFrame do
@@ -2637,11 +2639,12 @@ begin
     end;
 
     // Save parameter for later use
+    TrashAvailable := FileSource.IsClass(TFileSystemFileSource) and
+                      mbCheckTrash(CurrentPath);
     BoolValue := bRecycle;
 
     if bRecycle then
-      bRecycle := FileSource.IsClass(TFileSystemFileSource) and
-                  mbCheckTrash(CurrentPath);
+      bRecycle := TrashAvailable;
 
     if not HasConfirmationParam then
     begin
@@ -2675,16 +2678,24 @@ begin
     try
       if (theFilesToDelete.Count = 0) then Exit;
       if (theFilesToDelete.Count = 1) then
-        Message:= Format(MsgDelSel, [theFilesToDelete[0].Name])
+      begin
+        MsgTrash   := Format(rsMsgDelSelT, [theFilesToDelete[0].Name]);
+        MsgNoTrash := Format(rsMsgDelSel,  [theFilesToDelete[0].Name]);
+        Message    := Format(MsgDelSel,    [theFilesToDelete[0].Name]);
+      end
       else begin
-         Message:= Format(MsgDelFlDr, [theFilesToDelete.Count]) + LineEnding;
-         for I:= 0 to Min(4, theFilesToDelete.Count - 1) do
-         begin
-           Message+= LineEnding + theFilesToDelete[I].Name;
-         end;
-         if theFilesToDelete.Count > 5 then Message+= LineEnding + '...';
+        // Build the file list suffix once and share it across all message variants
+        Message := LineEnding;
+        for I:= 0 to Min(4, theFilesToDelete.Count - 1) do
+          Message += LineEnding + theFilesToDelete[I].Name;
+        if theFilesToDelete.Count > 5 then Message += LineEnding + '...';
+        MsgTrash   := Format(rsMsgDelFlDrT, [theFilesToDelete.Count]) + Message;
+        MsgNoTrash := Format(rsMsgDelFlDr,  [theFilesToDelete.Count]) + Message;
+        Message    := Format(MsgDelFlDr,    [theFilesToDelete.Count]) + Message;
       end;
-      if (bConfirmation = False) or (ShowDeleteDialog(frmMain, Message, FileSource, QueueId)) then
+      if (bConfirmation = False) or
+         (TrashAvailable and ShowDeleteDialog(frmMain, MsgTrash, MsgNoTrash, FileSource, QueueId, bRecycle)) or
+         ((not TrashAvailable) and ShowDeleteDialog(frmMain, Message, FileSource, QueueId)) then
       begin
         // Restore focus to main window after confirmation dialog closes
         if bConfirmation and frmMain.ActiveFrame.CanSetFocus then


### PR DESCRIPTION
## Problem

DC already has all three delete modes:

| Mode | How to reach it |
|---|---|
| Move to Trash | `Del` (when "Move to Recycle Bin" is on globally) |
| Delete permanently | `Shift+Del`, or turn off the global preference then `Del` |
| Wipe (secure erase) | `Alt+Del`, or Files menu |

This PR surfaces all three options directly in the delete confirmation dialog, so users can make an informed choice right at the moment it matters — before the operation runs.

## Changes

### `src/fmain.lfm` — Wipe entry in the context menu

`actWipe` (already used by the Files menu) is wired into `pmContextMenu`, placed directly above Delete, mirroring the existing Files menu layout. No new code — purely a menu layout change.

### `src/fdeletedlg.pas` + `src/fdeletedlg.lfm` — Dialog redesign

The single `TCheckBox` ("Move to Recycle Bin") is replaced with three `TRadioButton`s:

| Radio button | Shown when | Pre-selected when |
|---|---|---|
| Move to Recycle Bin | trash is available on that filesystem (`mbCheckTrash`) | "Move to Recycle Bin" is the global setting |
| Delete permanently | always (when enhanced dialog is shown) | "Move to Recycle Bin" is **off** globally |
| Wipe (secure erase) | filesystem supports `fsoWipe` (local filesystems) | — |

The pre-selected option always matches the current global preference, so the default behaviour is unchanged — the user just now has the choice to override it per operation.

Selecting a radio button live-updates the message label so the user always sees the exact consequence ("Delete selected X?", "Delete selected X into trash can?", "Wipe selected X?") before confirming.

A new type `TDeleteMode = (dmTrash, dmDelete, dmWipe)` is exported from `fDeleteDlg` and a new `ShowDeleteDialog` overload accepts it alongside `ShowTrash` and `ShowWipe` visibility flags.

The original single-message overload is unchanged — non-filesystem sources (FTP, archives, etc.) still use it.

### `src/umaincommands.pas` — `cm_Delete` dispatch

After dialog confirmation, the chosen mode is dispatched:

- `dmTrash` → existing `CreateDeleteOperation` with `Recycle := True`
- `dmDelete` → existing `CreateDeleteOperation` with `Recycle := False`
- `dmWipe`  → `CreateWipeOperation` (same engine as `cm_Wipe` / `Alt+Del`)

`WipeAvailable` is computed from `fsoWipe in FileSource.GetOperationsTypes`, so the Wipe radio button only appears where it actually works.

## Notes

- The enhanced dialog is shown when at least one extra option is available (trash or wipe); it degrades gracefully to the original form for remote/archive sources.
- `cm_Wipe` / `Alt+Del` and `Shift+Del` continue to work exactly as before — no behaviour change for existing shortcuts or scripts.
- The "Run in background" (queue) button works correctly with all three modes; the operation executes at queue-run time, not at submit time.
- If the maintainers prefer this not to be the default behaviour, the extended dialog can trivially be gated behind a config option — `cm_Delete` in `umaincommands.pas` would simply check a boolean before calling the extended `ShowDeleteDialog` overload.
