### PR TITLE
FIX: sync — preserve symlink follow/skip choice across file batches

### DIFF
--- a/src/filesources/filesystem/ufilesystemcopyoperation.pas
+++ b/src/filesources/filesystem/ufilesystemcopyoperation.pas
@@ -160,6 +160,7 @@ begin
     TreeBuilder.ExcludeEmptyTemplateDirectories := Self.ExcludeEmptyTemplateDirectories;
 
     TreeBuilder.BuildFromFiles(SourceFiles);
+    Self.SymLinkOption := TreeBuilder.SymLinkOption;
     FSourceFilesTree := TreeBuilder.ReleaseTree;
     FStatistics.TotalFiles := TreeBuilder.FilesCount;
     FStatistics.TotalBytes := TreeBuilder.FilesSize;


### PR DESCRIPTION
## Problem

When synchronising directories that contain symlinks, the "follow all" / "skip all" answer given in the symlink dialog is forgotten after each batch of files. The next batch starts a fresh `TFileSystemCopyOperation` with `FSymLinkOption := gOperationOptionSymLinks` (the global default, usually **ask**), so the dialog reappears for every symlink in every subsequent batch.

## Root cause

In `TFileSystemCopyOperation.Initialize`, `TreeBuilder.BuildFromFiles()` updates `TreeBuilder.FSymLinkOption` when the user answers "follow all" or "skip all". However, the updated value is discarded when `FreeAndNil(TreeBuilder)` is called immediately after, without writing back to `Self.SymLinkOption`.

## Fix

Write back `TreeBuilder.SymLinkOption` to `Self.SymLinkOption` before freeing the builder:

```pascal
TreeBuilder.BuildFromFiles(SourceFiles);
Self.SymLinkOption := TreeBuilder.SymLinkOption;  // preserve user's answer
FSourceFilesTree := TreeBuilder.ReleaseTree;
```

## Testing

- Sync a directory containing multiple symlinks with batched file sets
- Answer "follow all" or "skip all" on the first symlink dialog
- Verify the dialog does **not** reappear for subsequent batches