### PR TITLE
FIX: sync — preserve symlink timestamps on Linux

### DIFF
--- a/components/doublecmd/dcosutils.pas
+++ b/components/doublecmd/dcosutils.pas
@@ -619,6 +619,14 @@ begin
           if Assigned(Errors) then Errors^[caoCopyOwnership]:= GetLastOSError;
         end;
       end;
+      if caoCopyTime in Options then
+      begin
+        if DC_SymLinkSetTime(sDst, StatInfo.mtime, StatInfo.atime) = false then
+        begin
+          Include(Result, caoCopyTime);
+          if Assigned(Errors) then Errors^[caoCopyTime]:= GetLastOSError;
+        end;
+      end;
 {$IF DEFINED(HAIKU)}
       if caoCopyXattributes in Options then
       begin

--- a/components/doublecmd/dcunix.pas
+++ b/components/doublecmd/dcunix.pas
@@ -184,6 +184,11 @@ function DC_FileSetTime(const FileName: String;
                         const birthtime: TFileTimeEx;
                         const atime    : TFileTimeEx ): Boolean;
 
+// nanoseconds supported, does not follow symbolic links
+function DC_SymLinkSetTime(const FileName: String;
+                           const mtime    : TFileTimeEx;
+                           const atime    : TFileTimeEx ): Boolean;
+
 
 {en
    Set the close-on-exec flag to all
@@ -371,6 +376,7 @@ end;
 {$ENDIF}
 
 function fputimes( path:pchar; times:Array of UnixType.timeval ): cint; cdecl; external clib name 'utimes';
+function flutimes( path:pchar; times:Array of UnixType.timeval ): cint; cdecl; external clib name 'lutimes';
 
 function DC_FileSetTime(const FileName: String;
                         const mtime    : TFileTimeEx;
@@ -394,6 +400,23 @@ begin
   {$ELSE}
   Result:= MacosFileSetCreationTime( FileName, birthtime );
   {$ENDIF}
+end;
+
+// Like DC_FileSetTime but uses lutimes() instead of utimes(), so the
+// timestamp is set on the symlink itself rather than its target.
+function DC_SymLinkSetTime(const FileName: String;
+                           const mtime    : TFileTimeEx;
+                           const atime    : TFileTimeEx ): Boolean;
+var
+  timevals: Array[0..1] of UnixType.timeval;
+begin
+  // last access time
+  timevals[0].tv_sec:= atime.sec;
+  timevals[0].tv_usec:= round( Extended(atime.nanosec) / 1000.0 );
+  // last modification time
+  timevals[1].tv_sec:= mtime.sec;
+  timevals[1].tv_usec:= round( Extended(mtime.nanosec) / 1000.0 );
+  Result:= flutimes(pchar(UTF8ToSys(FileName)), timevals) = 0;
 end;
 
 {$IF DEFINED(BSD)}


### PR DESCRIPTION
## Problem

After syncing a directory containing symlinks, the symlink's `mtime` is set to the copy time rather than the source's `mtime`. On the next sync comparison, the link always appears as "different", causing an infinite override loop.

## Root cause

Two issues in `mbFileCopyAttr` (dcosutils.pas, Unix path):

1. The `caoCopyTime` block was in the `else` branch of `FPS_ISLNK`, so timestamps were never set for symlinks.
2. Even if reached, `DC_FileSetTime` uses `utimes()` which **follows** symlinks and sets the target's mtime, not the link's own mtime.

## Fix

- **dcunix.pas**: Add `DC_SymLinkSetTime` using `lutimes()` (POSIX), which sets mtime/atime on the symlink itself without following it.
- **dcosutils.pas**: Call `DC_SymLinkSetTime` inside the `FPS_ISLNK` branch when `caoCopyTime in Options`.

This change is inside the `{$ELSE}` (non-Windows) block and does not affect Windows builds.

## Testing

- Sync a directory containing symlinks (relative and absolute targets)
- Verify symlink `mtime` in destination matches source after sync
- Run sync again — links should show as **equal**, not different