### PR TITLE
FIX: sync — throttle AppProcessMessages to prevent O(n²) slowdown on Linux

### DIFF
--- a/src/filesources/ufilesourceoperation.pas
+++ b/src/filesources/ufilesourceoperation.pas
@@ -181,6 +181,13 @@ type
     FTryAskQuestionResult: Boolean;
 
     {en
+       Timestamp of last AppProcessMessages call (ms). Used to throttle
+       message-pumping when running on the main thread, to avoid O(n²)
+       overhead from inotify-triggered panel reloads with large file sets.
+    }
+    FLastProcessMessagesTime: QWord;
+
+    {en
        Used to determine whether the operation has started or not.
     }
     FOperationInitialized : Boolean;
@@ -805,10 +812,21 @@ begin
 end;
 
 function TFileSourceOperation.AppProcessMessages(CheckState: Boolean): Boolean;
+const
+  // Minimum ms between GTK event-queue pumps. Prevents O(n²) panel-reload
+  // overhead from inotify events when copying/deleting large file sets.
+  ThrottleIntervalMs = 100;
+var
+  Ticks: QWord;
 begin
   if GetCurrentThreadId = MainThreadID then
   begin
-    WidgetSet.AppProcessMessages;
+    Ticks := GetTickCount64;
+    if Ticks - FLastProcessMessagesTime >= ThrottleIntervalMs then
+    begin
+      FLastProcessMessagesTime := Ticks;
+      WidgetSet.AppProcessMessages;
+    end;
   end;
   if CheckState then
   try


### PR DESCRIPTION
## Problem

Directory sync with large file sets (e.g. ~8000 files) takes 5+ minutes on Linux for a trivial local copy of small files. The same operation completes in seconds on Windows.

## Root cause

`AppProcessMessages` is called between **every single file** in the copy/delete loops. On Linux, each call flushes the GTK event queue and processes all pending inotify events. If DC's file panels are watching the source/destination directories, each inotify event triggers a full panel directory reload — O(n) work per file copied. With n files this becomes **O(n²)** total work.

Windows is unaffected because its file-change notifications are coalesced differently and don't trigger per-event panel reloads at the same rate.

## Fix

Add a 100 ms gate in `TFileSourceOperation.AppProcessMessages` using `GetTickCount64`. The GTK event queue is pumped at most once every 100 ms regardless of file count.

The **stop button** continues to work immediately: `CheckOperationState` is called every file via a separate flag-check path that does not pump the event queue.

```pascal
const
  ThrottleIntervalMs = 100;
var
  Ticks: QWord;
begin
  if GetCurrentThreadId = MainThreadID then
  begin
    Ticks := GetTickCount64;
    if Ticks - FLastProcessMessagesTime >= ThrottleIntervalMs then
    begin
      FLastProcessMessagesTime := Ticks;
      WidgetSet.AppProcessMessages;
    end;
  end;
```

`GetTickCount64` is cross-platform in FPC SysUtils — no Windows regression.

## Testing

- Sync a directory with 5000+ small files
- Verify operation completes in seconds rather than minutes
- Verify the Stop button still responds immediately during the operation