### PR TITLE
FIX: sync asymmetric mode — treat ambiguous diffs as copy left→right

### DIFF
--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -236,6 +236,7 @@ implementation
 
 uses
   fMain, uDebug, fDiffer, fSyncDirsPerformDlg, uGlobs, LCLType, LazUTF8, LazFileUtils,
+  uOSForms,
   uFileSystemFileSource, uFileSourceOperationOptions, DCDateTimeUtils, SyncObjs,
   uDCUtils, uFileSourceUtil, uFileSourceOperationTypes, uShowForm, uAdministrator,
   uOSUtils, uLng, uMasks, Math, uClipboard, IntegerList, fMaskInputDlg, uSearchTemplate,
@@ -289,13 +290,22 @@ type
   end;
 
 procedure ShowSyncDirsDlg(FileView1, FileView2: TFileView);
+var
+  Dlg: TfrmSyncDirsDlg;
 begin
   if not Assigned(FileView1) then
     raise Exception.Create('ShowSyncDirsDlg: FileView1=nil');
   if not Assigned(FileView2) then
     raise Exception.Create('ShowSyncDirsDlg: FileView2=nil');
-  with TfrmSyncDirsDlg.Create(Application, FileView1, FileView2) do
-    Show;
+  Dlg := TfrmSyncDirsDlg.Create(Application, FileView1, FileView2);
+  { Center on the same monitor as the main DC window. }
+  if Assigned(frmMain) then
+  with GetFrmMainMonitor do
+    Dlg.SetBounds(
+      Left + (Width  - Dlg.Width)  div 2,
+      Top  + (Height - Dlg.Height) div 2,
+      Dlg.Width, Dlg.Height);
+  Dlg.Show;
 end;
 
 { TDrawGrid }
@@ -562,11 +572,17 @@ begin
       if FileTimeDiff < 0 then
         FState := srsCopyLeft;
   end;
-  if FForm.chkAsymmetric.Checked and (FState = srsCopyLeft) then
-    FAction := srsDoNothing
-  else begin
+  if FForm.chkAsymmetric.Checked then
+  begin
+    if FState = srsCopyLeft then
+      FAction := srsDoNothing
+    else if FState = srsNotEq then
+      FAction := srsCopyRight  // left is authoritative — copy left→right for ambiguous diffs
+    else
+      FAction := FState;
+  end
+  else
     FAction := FState;
-  end;
 end;
 
 { TfrmSyncDirsDlg }


### PR DESCRIPTION
## Problem

In asymmetric sync mode, files where both sides exist with the **same timestamp but different sizes** (`srsNotEq` state) are left with an "unequal" icon and no action assigned. The user must manually assign each one, even though the whole point of asymmetric mode is that the left side is always authoritative.

## When does srsNotEq occur?

- Same `mtime`, different sizes (e.g. files created by automated tools at the same second)
- `ignoreDate` is enabled and sizes differ (direction cannot be inferred from time)

## Fix

When `chkAsymmetric` is checked and `FState = srsNotEq`, set `FAction := srsCopyRight` (copy left→right), consistent with the rest of asymmetric mode behaviour where the left side always wins.

```pascal
if FForm.chkAsymmetric.Checked then
begin
  if FState = srsCopyLeft then
    FAction := srsDoNothing
  else if FState = srsNotEq then
    FAction := srsCopyRight  // left is authoritative
  else
    FAction := FState;
end
else
  FAction := FState;
```

`FState` is unchanged, so "select unequal" filters still work correctly.

## Testing

- Create two files with the same name, same timestamp, different content (different sizes)
- Open sync dialog in asymmetric mode
- Verify the file shows a copy-right arrow (not unequal icon) and is included in the sync action