### PR TITLE
FIX: sync compare — treat equivalent symlink targets as equal

### DIFF
--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -543,6 +543,30 @@ end;
 procedure TFileSyncRec.UpdateState(ignoreDate: Boolean);
 var
   FileTimeDiff: Integer;
+
+  function AreEquivalentLinks: Boolean;
+  var
+    LeftTarget, RightTarget: String;
+    LeftResolved, RightResolved: String;
+  begin
+    Result := False;
+
+    if not (FFileL.IsLink and FFileR.IsLink) then Exit;
+
+    LeftTarget := FFileL.LinkProperty.LinkTo;
+    RightTarget := FFileR.LinkProperty.LinkTo;
+
+    // Fast path: identical link text means semantically identical link.
+    if LeftTarget = RightTarget then Exit(True);
+
+    if (LeftTarget = EmptyStr) or (RightTarget = EmptyStr) then Exit;
+
+    // Also accept different textual forms that resolve to the same target.
+    LeftResolved := GetAbsoluteFileName(FFileL.Path, LeftTarget);
+    RightResolved := GetAbsoluteFileName(FFileR.Path, RightTarget);
+
+    Result := mbCompareFileNames(LeftResolved, RightResolved);
+  end;
 begin
   FState := srsNotEq;
   if Assigned(FFileR) and not Assigned(FFileL) then
@@ -552,7 +576,8 @@ begin
     FState := srsCopyRight
   else begin
     FileTimeDiff := FileTimeCompare(FFileL.ModificationTime, FFileR.ModificationTime, FForm.FNtfsShift);
-    if ((FileTimeDiff = 0) or ignoreDate) and (FFileL.Size = FFileR.Size) then
+    if ((FileTimeDiff = 0) or ignoreDate) and
+       ((FFileL.Size = FFileR.Size) or AreEquivalentLinks) then
       FState := srsEqual
     else
     if not ignoreDate then


### PR DESCRIPTION
## Problem

When synchronizing with symlink handling set to skip/follow-as-link, Double Commander may recreate links with a different textual target representation (for example, a shorter relative path on one side and a longer rebased relative path on the other).

Even when both links resolve to the same real target, sync compare marked them as different because it used mtime + size only. On Linux, symlink size is the link text length, so equivalent links with different textual forms appear unequal.

## Example

- Left link target: ../java.base/ADDITIONAL_LICENSE_INFO (size 36)
- Right link target: ../../../../Programs/pycharm-professional/jbr/legal/java.base/ADDITIONAL_LICENSE_INFO (size 85)

Both resolve to the same file, but were flagged different.

## Fix

In TFileSyncRec.UpdateState (fsyncdirsdlg.pas), add symlink-aware comparison:

- If both sides are links and link text matches, treat as equal.
- Otherwise resolve both link targets to absolute paths and compare resolved targets.
- Keep the existing mtime logic unchanged for regular files.

This preserves original sync intent (semantic equality) and avoids false positives for equivalent links.

## Testing

- Sync two trees containing equivalent symlinks with different textual target forms.
- Verify they are no longer listed as different after sync.
- Verify regular file compare behavior remains unchanged.