### PR TITLE
FIX: sync dialog — enable smooth progress bars

### DIFF
--- a/src/fsyncdirsdlg.lfm
+++ b/src/fsyncdirsdlg.lfm
@@ -592,6 +592,7 @@ object frmSyncDirsDlg: TfrmSyncDirsDlg
         Top = 17
         Width = 222
         Max = 222
+        Smooth = True
         ParentFont = False
         TabOrder = 0
         BarShowText = True
@@ -637,6 +638,7 @@ object frmSyncDirsDlg: TfrmSyncDirsDlg
         Top = 17
         Width = 222
         Max = 222
+        Smooth = True
         ParentFont = False
         TabOrder = 0
         BarShowText = True


### PR DESCRIPTION
## Problem

In the sync dialog, progress bars render with segmented/stepped appearance while regular file operation dialogs use smooth progress rendering. This makes sync progress look visually inconsistent and less polished.

## Root cause

TKASProgressBar controls in fsyncdirsdlg.lfm did not set Smooth = True, unlike fFileOpDlg.lfm where smooth mode is explicitly enabled.

## Fix

Enable smooth mode for both sync progress bars:

- ProgressBar
- ProgressBarDelete

## Notes

This is UI-only and cross-platform. It affects Windows and Linux visual rendering consistently (no logic changes).

## Testing

- Open Synchronize Directories dialog
- Start a sync operation
- Verify both progress bars render smoothly (not segmented)