### PR TITLE
UPD: File panel - increase touch/pen double-tap tolerance on Windows

### DIFF
--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -88,6 +88,12 @@ type
 {$IFDEF LCLGTK2}
     FLastDoubleClickTime : TDateTime;
 {$ENDIF}
+{$IFDEF LCLWIN32}
+    {en Last left-button-down timestamp and client position, used to detect
+       touch/pen double-taps that LCL's 3 px double-click threshold rejected. }
+    FLastTouchClickTime : QWord;
+    FLastTouchClickPoint: TPoint;
+{$ENDIF}
     FMainControl: TWinControl;
 
     { Events for drag&drop from external applications }
@@ -513,6 +519,14 @@ begin
   FHintFileIndex := -1;
 {$IFDEF LCLGTK2}
   FLastDoubleClickTime := Now;
+{$ENDIF}
+{$IFDEF LCLWIN32}
+  // Touch/pen input on Windows generates finger/nib wobble that easily
+  // exceeds the LCL default drag threshold (5px), turning simple taps into
+  // accidental drag operations. 10 logical pixels is still tiny for a mouse
+  // (sub-millimetre) but absorbs normal touch jitter at 1080p/2K/4K.
+  if Mouse.DragThreshold < 10 then
+    Mouse.DragThreshold := 10;
 {$ENDIF}
   FStartDrag := False;
 
@@ -986,6 +1000,27 @@ begin
 {$IF DEFINED(LCLWIN32)}
   FMouseFocus:= MainControl.Focused;
   SetFocus;
+  // Touch/pen double-tap fix: LCL's CheckMouseButtonDownUp (controls.pp)
+  // applies its own 3px position check on top of Windows' WM_LBUTTONDBLCLK,
+  // silently downgrading it to LM_LBUTTONDOWN when two taps land >3px apart
+  // (very common with fingers/pen). We compensate with 10 logical pixels,
+  // which is DPI-invariant and correct at 1080p, 2K and 4K.
+  // Only acts when ssDouble is absent (LCL rejected the dblclick) and we are
+  // in double-click mode; single-click mode already opens items on MouseUp so
+  // the fix is not needed there and would cause a double execution.
+  if (Button = mbLeft) and (not (ssDouble in Shift)) and (gMouseSingleClickStart = 0) then
+  begin
+    if (GetTickCount64 - FLastTouchClickTime <= QWord(GetDoubleClickTime)) and
+       (Abs(X - FLastTouchClickPoint.X) <= 10) and
+       (Abs(Y - FLastTouchClickPoint.Y) <= 10) then
+    begin
+      FLastTouchClickTime := 0; // consume - prevent accidental triple-fire
+      DoMainControlFileWork;
+      Exit;
+    end;
+    FLastTouchClickTime := GetTickCount64;
+    FLastTouchClickPoint := Classes.Point(X, Y);
+  end;
 {$ELSEIF DEFINED(LCLCOCOA)}
   FMouseFocus:= MainControl.Focused;
   MainControl.Invalidate;


### PR DESCRIPTION
## Background

Double Commander already handles double-click navigation correctly for mouse users. However, touch screens and pen/stylus input require noticeably more precise tapping than a mouse to trigger it reliably — the two-tap sequence has to land within 3 px for LCL to recognise it as a double-click, which is demanding for finger or pen input.

The reason is a **stacked threshold**: Windows delivers `WM_LBUTTONDBLCLK` based on the system's own time + distance settings, but LCL's `CheckMouseButtonDownUp` (`controls.pp`) then applies an additional **hardcoded 3 px** position filter on top. Touch and pen taps routinely land 4–10 px apart due to natural wobble; the OS considers that a valid double-click, but the extra LCL layer downgrades it to a single click before DC sees it. Total Commander (native Win32) handles `WM_LBUTTONDBLCLK` directly and is not affected.

## Changes (Windows-only, `{$IFDEF LCLWIN32}` guards throughout — zero effect on Linux/macOS)

### 1. Raise `Mouse.DragThreshold` from 5 px to 10 px at file view startup

The 5 px default means a gentle tap that drifts slightly while pressing down is interpreted as the start of a drag, swallowing the click entirely. Raising it to 10 logical pixels absorbs normal touch/pen jitter while remaining sub-millimetre for a conventional mouse at any common DPI — imperceptible in practice.

### 2. Software double-tap compensator in `MainControlMouseDown`

Track `FLastTouchClickTime` and `FLastTouchClickPoint` per file view. On every left-button-down that **lacks** `ssDouble` in `Shift` (LCL did not promote it to a double-click) **and** is in double-click open mode (`gMouseSingleClickStart = 0`):

- If the tap arrives within `GetDoubleClickTime` ms and within 10 logical pixels of the previous tap → call `DoMainControlFileWork` directly and reset the timer (prevents accidental triple-fire).
- Otherwise → record this tap as the new baseline.

The `gMouseSingleClickStart = 0` guard skips this path entirely in single-click mode, where `MouseUp` already handles opening, avoiding double execution.