### PR TITLE
UPD: sync dirs asymmetric mode — left panel unconditionally wins (mirror semantics)

### DIFF
--- a/src/fsyncdirsdlg.lfm
+++ b/src/fsyncdirsdlg.lfm
@@ -197,7 +197,10 @@ object frmSyncDirsDlg: TfrmSyncDirsDlg
         Width = 82
         Caption = 'asymmetric'
         Enabled = False
+        Hint = 'One-way mirror: right panel becomes an exact copy of the left. Right-only files are deleted; right-newer files are overwritten by left.'
         ParentFont = False
+        ParentShowHint = False
+        ShowHint = True
         TabOrder = 0
       end
       object chkSubDirs: TCheckBox

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -465,7 +465,12 @@ begin
             end;
             if R.FAction = srsUnknown then
             begin
-              R.FAction := R.FState;
+              // Mirror asymmetric logic from TFileSyncRec.Recalc:
+              // in asymmetric mode srsNotEq means left wins → srsCopyRight.
+              if chkAsymmetric.Checked and (R.FState = srsNotEq) then
+                R.FAction := srsCopyRight
+              else
+                R.FAction := R.FState;
             end;
           except
             on E: Exception do
@@ -562,11 +567,19 @@ begin
       if FileTimeDiff < 0 then
         FState := srsCopyLeft;
   end;
-  if FForm.chkAsymmetric.Checked and (FState = srsCopyLeft) then
-    FAction := srsDoNothing
-  else begin
+  if FForm.chkAsymmetric.Checked then
+  begin
+    // In asymmetric/mirror mode left is unconditionally authoritative.
+    // srsCopyLeft means right is newer — left still wins (overwrite right).
+    // srsNotEq means ambiguous diff (e.g. content check) — left still wins.
+    if FState in [srsCopyLeft, srsNotEq] then
+      FAction := srsCopyRight
+    else
+      FAction := FState;
+  end
+  else
     FAction := FState;
-  end;
+end;
 end;
 
 { TfrmSyncDirsDlg }


### PR DESCRIPTION
## Background

The documentation for the *asymmetric* option reads:

> *This option is meant to create a backup: a copy of the contents of the left panel should be created in the right panel. Files that do not exist on the left side will be marked for deletion on the right side.*

In practice, the previous behaviour did not fully deliver on that promise: two categories of files were left in an ambiguous or skipped state instead of being marked for overwrite.

## What was wrong

### 1. Right-newer files were silently skipped (`srsCopyLeft → srsDoNothing`)

When the right file had a **newer** timestamp than the left, the action was set to *do nothing*, leaving the right copy untouched. In a true mirror operation the left panel is the authoritative source regardless of which side is newer — the right should be overwritten, not preserved.

### 2. Content-comparison thread bypassed asymmetric rules

When *compare by content* is enabled, equal-sized/same-date pairs that actually differ byte-by-byte are first flagged as `srsUnknown`, then confirmed as `srsNotEq` by the content thread. The thread assigned `FAction := FState` (= `srsNotEq`) directly, bypassing the asymmetric decision made in `TFileSyncRec.Recalc`. Those files were shown as *different* with no clear direction instead of *copy left→right*.

Total Commander, FreeCommander and rsync all treat one-way/asymmetric sync with the same semantic: source always wins, unconditionally.

## Changes

Both are confined to `fsyncdirsdlg.pas` — no platform guards needed, the logic is identical on all OSes.

**`TFileSyncRec.Recalc`** — consolidate the asymmetric action mapping:
- `srsCopyLeft` (right newer) → `srsCopyRight` (left wins, overwrite right)
- `srsNotEq` (ambiguous diff) → `srsCopyRight` (left wins)
- All other states pass through unchanged

**Content-compare thread** — mirror the same rule after byte-by-byte comparison confirms a difference: if asymmetric and state is `srsNotEq`, assign `srsCopyRight` instead of `srsNotEq`.

**UX (`fsyncdirsdlg.lfm`)** — added a tooltip to the *asymmetric* checkbox: *"One-way mirror: right panel becomes an exact copy of the left. Right-only files are deleted; right-newer files are overwritten by left."* The existing overwrite-confirmation dialog still fires before any file is touched, so nothing becomes unprotected.