### PR TITLE
FIX: Navigate to correct file source when opening path from command line

### DIFF
--- a/src/filesources/winnet/uwinnetfilesource.pas
+++ b/src/filesources/winnet/uwinnetfilesource.pas
@@ -176,7 +176,9 @@ end;
 
 function TWinNetFileSource.IsNetworkPath(const Path: String): Boolean;
 begin
-  Result:= (NumCountChars(PathDelim, ExcludeTrailingPathDelimiter(Path)) < 3);
+  Result:= (Path = PathDelim) or
+           ((Pos(PathDelim + PathDelim, Path) = 1) and
+            (NumCountChars(PathDelim, ExcludeTrailingPathDelimiter(Path)) < 3));
 end;
 
 function TWinNetFileSource.SetCurrentWorkingDirectory(NewDir: String): Boolean;

--- a/src/filesources/winnet/uwinnetfilesource.pas
+++ b/src/filesources/winnet/uwinnetfilesource.pas
@@ -177,7 +177,7 @@ end;
 function TWinNetFileSource.IsNetworkPath(const Path: String): Boolean;
 begin
   Result:= (Path = PathDelim) or
-           ((Pos(PathDelim + PathDelim, Path) = 1) and
+           (StrBegins(Path, '\\') and
             (NumCountChars(PathDelim, ExcludeTrailingPathDelimiter(Path)) < 3));
 end;
 

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -6364,18 +6364,28 @@ end;
 procedure TfrmMain.LoadTabsCommandLine(Params: TCommandLineParams);
 
   procedure LoadPanel(aNoteBook: TFileViewNotebook; aPath: String);
+  var
+    AFileView: TFileView;
   begin
     if Length(aPath) <> 0 then
     begin
       aPath:= ReplaceEnvVars(ReplaceTilde(aPath));
-      if not mbFileSystemEntryExists(aPath) then
+      if not mbFileSystemEntryExists(aPath) and (Pos('\\', aPath) <> 1) then
         aPath:= GetDeepestExistingPath(aPath);
       if Length(aPath) <> 0 then
       begin
         if Params.NewTab then
           AddTab(aNoteBook, aPath)
-        else
-          aNoteBook.ActivePage.FileView.ChangePathAndSetActiveFile(aPath)
+        else begin
+          AFileView:= aNoteBook.ActivePage.FileView;
+          if mbFileExists(aPath) then
+          begin
+            if ChooseFileSource(AFileView, ExtractFileDir(aPath)) then
+              AFileView.SetActiveFile(ExtractFileName(aPath));
+          end
+          else
+            ChooseFileSource(AFileView, aPath);
+        end;
       end;
     end;
   end;

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -969,7 +969,7 @@ uses
   Laz2_XMLRead, DCOSUtils, DCStrUtils, fOptions, fOptionsFrame, fOptionsToolbar, uClassesEx,
   uHotDir, uFileSorting, DCBasicTypes, foptionsDirectoryHotlist, uConnectionManager,
   fOptionsToolbarBase, fOptionsToolbarMiddle, fEditor, uColumns, StrUtils, uSysFolders,
-  uColumnsFileView, dmHigh, uFileSourceOperationMisc
+  uColumnsFileView, dmHigh, uFileSourceOperationMisc, uVfsModule
 {$IFDEF MSWINDOWS}
   , uShellFileSource, uNetworkThread
 {$ENDIF}
@@ -6370,8 +6370,11 @@ procedure TfrmMain.LoadTabsCommandLine(Params: TCommandLineParams);
     if Length(aPath) <> 0 then
     begin
       aPath:= ReplaceEnvVars(ReplaceTilde(aPath));
-      if not mbFileSystemEntryExists(aPath) and (Pos('\\', aPath) <> 1) then
-        aPath:= GetDeepestExistingPath(aPath);
+      if (gVfsModuleList.GetFileSource(aPath) = nil) then
+      begin
+        if not mbFileSystemEntryExists(aPath) then
+          aPath:= GetDeepestExistingPath(aPath);
+      end;
       if Length(aPath) <> 0 then
       begin
         if Params.NewTab then


### PR DESCRIPTION
## Summary

Solves issue #2891.

- Routes command-line paths through file-source selection when reusing an existing panel, so local paths are not forced through the currently active network file source.
- Captures the active `FileView` before calling `ChooseFileSource`, so selecting a file after navigation targets the same view that was navigated.
- Narrows Windows network root detection so local drive paths like `C:\` are not treated as network browsing paths.

## Bug Fix

- Fixes opening a local drive path from a second instance when the target pane is currently on a UNC/network location.
- Fixes command-line file paths by switching to the correct directory/file source before selecting the file.
- Avoids collapsing UNC command-line paths through deepest-existing-local-path fallback.

## Solved Cases

- Existing instance active on a UNC/network pane, then running `doublecmd C:\` opens the local `C:\` path instead of the network root.
- Existing instance active on a UNC/network pane, then running `doublecmd C:\path\file.ext` opens the local directory and selects `file.ext`.
- Existing instance receiving a UNC path like `doublecmd \\server\share` keeps the network path route instead of treating it as a local-drive fallback case.