### PR TITLE
FIX: SFTP - preserve symlinks when copying local folder to SFTP

### DIFF
--- a/plugins/wfx/ftp/src/sftp/sftpsend.pas
+++ b/plugins/wfx/ftp/src/sftp/sftpsend.pas
@@ -228,11 +228,38 @@ var
   TotalBytesToWrite: Int64 = 0;
   TargetHandle: PLIBSSH2_SFTP_HANDLE = nil;
   Flags: cint = LIBSSH2_FXF_CREAT or LIBSSH2_FXF_WRITE;
+{$IFDEF UNIX}
+  LocalStat: BaseUnix.TStat;
+  LinkTarget: String;
+{$ENDIF}
 begin
   if FCopySCP then begin
     Result:= inherited StoreFile(FileName, Restore);
     Exit;
   end;
+
+{$IFDEF UNIX}
+  // If the local source is a symlink, create it on the remote instead of uploading content
+  if fpLStat(FDirectFileName, LocalStat) = 0 then
+  begin
+    if FPS_ISLNK(LocalStat.st_mode) then
+    begin
+      LinkTarget := fpReadLink(FDirectFileName);
+      if Length(LinkTarget) > 0 then
+      begin
+        repeat
+          // libssh2_sftp_symlink(sftp, orig, linkpath):
+          //   orig     = the target the symlink points to
+          //   linkpath = where the symlink is created on the remote
+          FLastError := libssh2_sftp_symlink(FSFTPSession, PAnsiChar(LinkTarget), PAnsiChar(FileName));
+          if FLastError = LIBSSH2_ERROR_EAGAIN then FSock.CanRead(10);
+        until FLastError <> LIBSSH2_ERROR_EAGAIN;
+        Result := (FLastError = 0);
+        Exit;
+      end;
+    end;
+  end;
+{$ENDIF}
 
   SendStream := TFileStreamEx.Create(FDirectFileName, fmOpenRead or fmShareDenyWrite);
 

--- a/src/filesources/wfxplugin/uwfxplugincopyinoperation.pas
+++ b/src/filesources/wfxplugin/uwfxplugincopyinoperation.pas
@@ -137,7 +137,7 @@ begin
   TreeBuilder := TFileSystemTreeBuilder.Create(@AskQuestion, @CheckOperationState);
   try
     ElevateAction:= dupError;
-    TreeBuilder.SymLinkOption:= fsooslFollow;
+    TreeBuilder.SymLinkOption:= fsooslDontFollow;
     TreeBuilder.BuildFromFiles(SourceFiles);
     FSourceFilesTree := TreeBuilder.ReleaseTree;
     FStatistics.TotalFiles := TreeBuilder.FilesCount;

--- a/src/filesources/wfxplugin/uwfxpluginutil.pas
+++ b/src/filesources/wfxplugin/uwfxpluginutil.pas
@@ -364,11 +364,19 @@ begin
     Result := ProcessFile(aNode, AbsoluteTargetFileName)
   else if aNode.SubNodesCount > 0 then
   begin
+    // Symlink was followed: process the resolved target.
     aSubNode := aNode.SubNodes[0];
     if aSubNode.TheFile.AttributesProperty.IsDirectory then
       Result := ProcessDirectory(aSubNode, AbsoluteTargetFileName)
     else
       Result := ProcessFile(aSubNode, AbsoluteTargetFileName);
+  end
+  else
+  begin
+    // Symlink was not followed (fsooslDontFollow) or target was unreachable.
+    // Pass the symlink itself to ProcessFile; StoreFile/RetrieveFile will
+    // handle it appropriately (e.g. create a remote symlink over SFTP).
+    Result := ProcessFile(aNode, AbsoluteTargetFileName);
   end;
 end;
 


### PR DESCRIPTION
When copying a local directory tree to an SFTP destination, symlinks were silently converted to regular files (if the target existed) or caused copy errors (if the target was missing or broken).

**Root cause — three layered bugs:**

1. `uwfxplugincopyinoperation.pas`: the WFX copy-in tree builder used `fsooslFollow`, which resolved symlinks to their real targets before `StoreFile` was ever called. The plugin never saw the symlink itself.

2. `uwfxpluginutil.pas / ProcessLink`: had no `else` branch for the no-subnode case (which is the normal case when not following links), leaving `Result` uninitialised — an existing latent bug.

3. `sftpsend.pas / StoreFile`: opened the local path unconditionally with `TFileStreamEx`, which follows symlinks on the OS level — so even a symlink to a real file would be uploaded as a plain copy.

**Fix:**

- `sftpsend.pas`: detect symlinks via `fpLStat` before opening the file. If the source is a symlink, read its target with `fpReadLink` and call `libssh2_sftp_symlink` to recreate it on the remote (rsync-like behaviour). Only affects Unix builds (`{ UNIX}`).
- `uwfxplugincopyinoperation.pas`: switch `SymLinkOption` to `fsooslDontFollow` so the symlink path itself reaches `StoreFile` intact.
- `uwfxpluginutil.pas / ProcessLink`: add `else` branch for the no-subnode case to route the symlink node to `ProcessFile`, fixing the uninitialised `Result`.

**Behaviour after fix:** symlinks in a copied folder are recreated as symlinks on the SFTP server (relative or absolute, exactly as on the source), matching rsync's default.