### PR TITLE
Fix: copy/sync — overwriting a regular file with a symlink fails with "file exists"

### DIFF
--- a/src/filesources/filesystem/ufilesystemutil.pas
+++ b/src/filesources/filesystem/ufilesystemutil.pas
@@ -1613,7 +1613,13 @@ var
         begin
           if FileIsReadOnly(Attrs) then
             FileSetReadOnlyUAC(AbsoluteTargetFileName, False);
-          if FPS_ISLNK(Attrs) or (FMode = fsohmMove) then
+          // Delete the existing target first when it cannot be overwritten in
+          // place: an existing link, a move, or — crucially — when the source
+          // is an (unfollowed) symlink. A symlink source is recreated via
+          // CreateSymbolicLink, which fails with "file exists" if the target
+          // path is still occupied by the old regular file.
+          if FPS_ISLNK(Attrs) or (FMode = fsohmMove) or
+             (SourceFile.AttributesProperty.IsLink and (aNode.SubNodesCount = 0)) then
           begin
             DeleteFileUAC(AbsoluteTargetFileName);
             Exit(fsoterDeleted);


### PR DESCRIPTION
## Problem

When copying (or folder-syncing with *override*) a **symlink** onto a destination that already holds a **regular file** of the same name, the operation fails with *"cannot create symbolic link … file exists"* (`rsSymErrCreate`).

A symlink source is recreated via `CreateSymbolicLink`, which cannot overwrite an existing path. But in `TFileSystemOperationHelper.TargetExists` → `DoFileExists`, the overwrite case only deletes the existing target when it is itself a link or when the operation is a *move*; otherwise it returns `fsoterNotExists`, expecting an in-place file overwrite. For a symlink source that in-place overwrite never happens, so the old regular file is left in place and `CreateSymbolicLink` fails.

## Repro

1. Left dir: a symlink `foo`.
2. Right dir: a regular file `foo`.
3. Copy `foo` left→right (or folder sync with override).
4. → "error creating symlink, file exists".

## Fix

In `DoFileExists`, also delete the occupying target before returning `fsoterDeleted` when the **source is an (unfollowed) symlink** — i.e. when it will be recreated as a link rather than overwritten in place. Same treatment already applied to the existing link/move cases.

```pascal
if FPS_ISLNK(Attrs) or (FMode = fsohmMove) or
   (SourceFile.AttributesProperty.IsLink and (aNode.SubNodesCount = 0)) then
begin
  DeleteFileUAC(AbsoluteTargetFileName);
  Exit(fsoterDeleted);
end;
```

`SubNodesCount = 0` mirrors the existing `IsLinkFollowed` definition (a followed link is copied as its target, so the normal in-place overwrite still applies and must not be force-deleted).

One file changed. Affects all platforms (the helper is platform-agnostic; `CreateSymbolicLink` behaves the same on Windows/NTFS).