### PR TITLE
Fix: folder sync — suspend panel watcher during bulk copy/delete (avoid O(n²) reload)

### DIFF
--- a/src/fileviews/ufileview.pas
+++ b/src/fileviews/ufileview.pas
@@ -443,6 +443,13 @@ type
     function Reload(const PathToReload: String): Boolean; overload;
     procedure Reload(AForced: Boolean);
     procedure ReloadIfNeeded;
+    {en
+       Suspend/resume the directory watcher around an app-initiated bulk
+       operation. While suspended, inotify changes are not turned into
+       repeated full reloads (which is O(n²) for large folders); resuming
+       performs a single reconciling reload. No-op for non-filesystem views.
+    }
+    procedure SetWatcherEnabled(AEnabled: Boolean);
     procedure StopWorkers; virtual;
 
     // For now we use here the knowledge that there are tabs.
@@ -3388,6 +3395,22 @@ begin
     FileSource.GetWatcher.removeWatch(FWatchPath, @WatcherEvent);
     FWatchPath := EmptyStr;
   end;
+end;
+
+procedure TFileView.SetWatcherEnabled(AEnabled: Boolean);
+begin
+  if AEnabled then
+  begin
+    // Only the filesystem watcher causes the per-file reload storm, so only
+    // it was suspended; re-enable and do one reload to catch up on changes.
+    if Assigned(FileSource) and FileSource.IsClass(TFileSystemFileSource) then
+    begin
+      EnableWatcher(True);
+      Reload(True);
+    end;
+  end
+  else if WatcherActive then
+    EnableWatcher(False);
 end;
 
 procedure TFileView.SetFlatView(AFlatView: Boolean);

--- a/src/fsyncdirsdlg.pas
+++ b/src/fsyncdirsdlg.pas
@@ -166,6 +166,9 @@ type
     FCmpFileSourceL, FCmpFileSourceR: IFileSource;
     FCmpFilePathL, FCmpFilePathR: string;
     FAddressL, FAddressR: string;
+    // The two source panels, kept so their directory watchers can be
+    // suspended during bulk copy/delete (avoids the per-file reload storm).
+    FFileView1, FFileView2: TFileView;
     hCols: array [0..6] of record Left, Width: Integer end;
     CheckContentThread: TObject;
     Ftotal, Fequal, Fnoneq, FuniqueL, FuniqueR: Integer;
@@ -189,6 +192,7 @@ type
     procedure SetSyncRecState(AState: TSyncRecState);
     procedure DeleteFiles(ALeft, ARight: Boolean);
     function DeleteFiles(FileSource: IFileSource; var Files: TFiles): Boolean;
+    procedure SetPanelWatchers(AEnabled: Boolean);
     procedure UpdateList(ALeft, ARight: TFiles; ARemoveLeft, ARemoveRight: Boolean);
     procedure SetProgressBytes(AProgressBar: TKASProgressBar; CurrentBytes: Int64; TotalBytes: Int64);
     procedure SetProgressFiles(AProgressBar: TKASProgressBar; CurrentFiles: Int64; TotalFiles: Int64);
@@ -783,6 +787,8 @@ begin
       pnlCopyProgress.Visible:= CopyLeft or CopyRight;
       pnlDeleteProgress.Visible:= DeleteLeft or DeleteRight;
 
+      SetPanelWatchers(False);
+      try
       i := 0;
       while i < FVisibleItems.Count do
       begin
@@ -833,6 +839,9 @@ begin
         end
         else DeleteRightFiles.Free;
         if not pnlProgress.Visible then Break;
+      end;
+      finally
+        SetPanelWatchers(True);
       end;
       EnableControls(True);
       btnCompare.Click;
@@ -1836,6 +1845,16 @@ begin
   end;
 end;
 
+procedure TfrmSyncDirsDlg.SetPanelWatchers(AEnabled: Boolean);
+begin
+  // Suspend the source panels' directory watchers while we copy/delete, so a
+  // large local operation does not trigger one full O(n) panel reload per ~100
+  // changes (which makes a big delete behave as O(n²), ~1 file/sec). Resuming
+  // does a single reconciling reload of each panel.
+  if Assigned(FFileView1) then FFileView1.SetWatcherEnabled(AEnabled);
+  if Assigned(FFileView2) then FFileView2.SetWatcherEnabled(AEnabled);
+end;
+
 procedure TfrmSyncDirsDlg.DeleteFiles(ALeft, ARight: Boolean);
 var
   Message: String;
@@ -1883,8 +1902,13 @@ begin
       EnableControls(False);
       pnlCopyProgress.Visible:= False;
       pnlDeleteProgress.Visible:= True;
-      if ALeft then DeleteFiles(FCmpFileSourceL, ALeftList);
-      if ARight then DeleteFiles(FCmpFileSourceR, ARightList);
+      SetPanelWatchers(False);
+      try
+        if ALeft then DeleteFiles(FCmpFileSourceL, ALeftList);
+        if ARight then DeleteFiles(FCmpFileSourceR, ARightList);
+      finally
+        SetPanelWatchers(True);
+      end;
       UpdateList(nil, nil, ALeft, ARight);
       EnableControls(True);
     end;
@@ -2049,6 +2073,8 @@ begin
   FFoundItems := TStringListEx.Create;
   FFoundItems.CaseSensitive := FileNameCaseSensitive;
   FFoundItems.Sorted := True;
+  FFileView1 := FileView1;
+  FFileView2 := FileView2;
   FFileSourceL := FileView1.FileSource;
   FFileSourceR := FileView2.FileSource;
   FAddressL := FileView1.CurrentAddress;


### PR DESCRIPTION
## Problem

A folder-sync copy/delete on a large **local** directory crawls at roughly **1 file/second**. The cost is not the file operation itself (a raw `unlink` runs hundreds–thousands/sec) but the source panel's **directory watcher**:

- each changed file fires a watcher event;
- once more than 100 (or >25% of the listing) pending changes accumulate, `TFileView` reloads the **whole** directory, rate-limited to once per second;
- during a bulk operation that full reload keeps re-firing, so the operation degrades to **O(n²)** and stalls. The sync runs the operation inline on the GUI thread, so each reload directly blocks it.

Verified locally: raw `unlink` on the same drive ran 650–2500 files/sec, while the sync delete of the same folder ran at ~1/sec until the watcher was suspended.

## Fix

- Add `TFileView.SetWatcherEnabled` — a public wrapper over the existing protected `EnableWatcher`, doing one reconciling reload on resume.
- The sync dialog suspends both source panels' watchers around the copy/delete run and the compare-grid delete buttons, restoring them via `try/finally`. Operations now proceed at filesystem speed; the panels refresh once at the end.

Two files changed. The reload path is platform-agnostic and is fed by inotify (Linux), `ReadDirectoryChangesW` (Windows) and FSEvents (macOS) alike, so the fix applies across platforms.