### PR TITLE
Add running file-position index in the panel footer (with Ctrl+G jump)

### DIFF
--- a/src/fileviews/ufileviewwithpanels.pas
+++ b/src/fileviews/ufileviewwithpanels.pas
@@ -40,11 +40,13 @@ type
   protected
     FSelectedCount: Integer;
     lblInfo: TLabel;
+    lblPosition: TLabel;  //<en Running index: cursor position within the listing
 
     pnlFooter: TPanel;
     pnlHeader: TFileViewHeader;
 
     procedure UpdateStatusBarFont;
+    procedure UpdatePositionIndex; virtual;  //<en Update running index label (cursor pos / total)
     procedure AfterChangePath; override;
     procedure CreateDefault(AOwner: TWinControl); override;
     procedure DisplayFileListChanged; override;
@@ -85,6 +87,7 @@ procedure TFileViewWithPanels.UpdateStatusBarFont;
 begin
   FontOptionsToFont(gFonts[dcfStatusBar], lblInfo.Font);
   lblInfo.Height := lblInfo.Canvas.TextHeight('Wg');
+  FontOptionsToFont(gFonts[dcfStatusBar], lblPosition.Font);
 end;
 
 procedure TFileViewWithPanels.AfterChangePath;
@@ -112,6 +115,15 @@ begin
   pnlFooter.BevelOuter     := bvNone;
   pnlFooter.AutoSize       := True;
   pnlFooter.DoubleBuffered := True;
+
+  lblPosition           := TLabel.Create(pnlFooter);
+  lblPosition.Parent    := pnlFooter;
+  lblPosition.AutoSize  := False;
+  lblPosition.Width     := 110;
+  lblPosition.Align     := alRight;
+  lblPosition.Alignment := taRightJustify;
+  lblPosition.BorderSpacing.Left  := 8;
+  lblPosition.BorderSpacing.Right := 6;
 
   lblInfo          := TLabel.Create(pnlFooter);
   lblInfo.Parent   := pnlFooter;
@@ -266,6 +278,14 @@ begin
   end
   else if not (csDestroying in ComponentState) then
     lblInfo.Caption := '';
+
+  UpdatePositionIndex;
+end;
+
+procedure TFileViewWithPanels.UpdatePositionIndex;
+begin
+  // Base has no notion of the active index; ordered views override this.
+  if Assigned(lblPosition) then lblPosition.Caption := EmptyStr;
 end;
 
 end.

--- a/src/fileviews/ufileviewwithpanels.pas
+++ b/src/fileviews/ufileviewwithpanels.pas
@@ -285,7 +285,11 @@ end;
 procedure TFileViewWithPanels.UpdatePositionIndex;
 begin
   // Base has no notion of the active index; ordered views override this.
-  if Assigned(lblPosition) then lblPosition.Caption := EmptyStr;
+  if Assigned(lblPosition) then
+  begin
+    lblPosition.Visible := gShowPositionIndex;
+    lblPosition.Caption := EmptyStr;
+  end;
 end;
 
 end.

--- a/src/fileviews/uorderedfileview.pas
+++ b/src/fileviews/uorderedfileview.pas
@@ -43,7 +43,11 @@ type
   TOrderedFileView = class(TFileViewWithPanels)
   private
     pmOperationsCancel: TPopupMenu;
+    edtJump: TEdit;  //<en Inline input for "jump to position"
     procedure lblFilterClick(Sender: TObject);
+    procedure PositionLabelClick(Sender: TObject);  //<en Click index -> inline input -> jump
+    procedure JumpEditKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure JumpEditExit(Sender: TObject);
     procedure pmOperationsCancelClick(Sender: TObject);
     procedure quickSearchChangeSearch(Sender: TObject; ASearchText: String; const ASearchOptions: TQuickSearchOptions; InvertSelection: Boolean = False);
     procedure quickSearchChangeFilter(Sender: TObject; AFilterText: String; const AFilterOptions: TQuickSearchOptions);
@@ -66,6 +70,7 @@ type
     procedure AfterChangePath; override;
     procedure CreateDefault(AOwner: TWinControl); override;
     procedure DoFileIndexChanged(NewFileIndex, TopRowIndex: PtrInt);
+    procedure UpdatePositionIndex; override;
     procedure DoHandleKeyDown(var Key: Word; Shift: TShiftState); override;
     procedure DoHandleKeyDownWhenLoading(var Key: Word; Shift: TShiftState); override;
     procedure DoSelectionChanged; override; overload;
@@ -133,6 +138,9 @@ uses
   uFileProperty,
   uFileSource,
   uFile;
+
+resourcestring
+  rsPositionJumpHint = 'Click to jump to a position in the list';
 
 const
   CANCEL_FILTER = 0;
@@ -263,6 +271,22 @@ begin
   FLastActiveFileIndex := -1;
   FRangeSelectionState := True;
 
+  // Make the running-index label clickable to jump to a position.
+  lblPosition.OnClick  := @PositionLabelClick;
+  lblPosition.Cursor   := crHandPoint;
+  lblPosition.ShowHint := True;
+  lblPosition.Hint     := rsPositionJumpHint;
+
+  // Small borderless inline editor for jumping to a position (shown on demand).
+  edtJump            := TEdit.Create(Self);
+  edtJump.Parent     := Self;
+  edtJump.Visible    := False;
+  edtJump.AutoSize   := True;
+  edtJump.Width      := 70;
+  edtJump.AutoSelect := True;
+  edtJump.OnKeyDown  := @JumpEditKeyDown;
+  edtJump.OnExit     := @JumpEditExit;
+
   lblFilter         := TLabel.Create(pnlFooter);
   lblFilter.Parent  := pnlFooter;
   lblFilter.Align   := alRight;
@@ -304,6 +328,112 @@ begin
 
     if FlatView and (FSelectedCount = 0) then UpdateFlatFileName;
   end;
+  UpdatePositionIndex;
+end;
+
+procedure TOrderedFileView.UpdatePositionIndex;
+var
+  idx, total, pos: Integer;
+  hasDotDot: Boolean;
+begin
+  if (csDestroying in ComponentState) or (lblPosition = nil) then Exit;
+  if not Assigned(FFiles) or (FFiles.Count = 0) then
+  begin
+    lblPosition.Caption := EmptyStr;
+    Exit;
+  end;
+  // ".." is not counted (it sits at index 0 when present).
+  hasDotDot := (FFiles[0].FSFile.Name = '..');
+  total := FFiles.Count;
+  if hasDotDot then Dec(total);
+  if total <= 0 then
+  begin
+    lblPosition.Caption := EmptyStr;
+    Exit;
+  end;
+  idx := GetActiveFileIndex;
+  if (idx < 0) or (idx >= FFiles.Count) or (FFiles[idx].FSFile.Name = '..') then
+    // No real file focused (e.g. on '..'): show total only.
+    lblPosition.Caption := Format('- / %d', [total])
+  else begin
+    pos := idx + 1;
+    if hasDotDot then Dec(pos);
+    lblPosition.Caption := Format('%d / %d', [pos, total]);
+  end;
+end;
+
+procedure TOrderedFileView.PositionLabelClick(Sender: TObject);
+var
+  total, cur, idx: Integer;
+  hasDotDot: Boolean;
+begin
+  if not Assigned(FFiles) or (FFiles.Count = 0) then Exit;
+  hasDotDot := (FFiles[0].FSFile.Name = '..');
+  total := FFiles.Count;
+  if hasDotDot then Dec(total);
+  if total <= 0 then Exit;
+
+  // Pre-fill with the current position.
+  idx := GetActiveFileIndex;
+  if (idx >= 0) and (idx < FFiles.Count) and (FFiles[idx].FSFile.Name <> '..') then
+  begin
+    cur := idx + 1;
+    if hasDotDot then Dec(cur);
+  end
+  else
+    cur := 1;
+  edtJump.Text := IntToStr(cur);
+
+  // Pop up the small editor just above-left of the index label.
+  edtJump.Left := pnlFooter.Left + lblPosition.Left - 10;
+  if edtJump.Left < 0 then edtJump.Left := 0;
+  edtJump.Top := pnlFooter.Top - edtJump.Height - 2;
+  if edtJump.Top < 0 then edtJump.Top := 0;
+  edtJump.Visible := True;
+  edtJump.BringToFront;
+  edtJump.SetFocus;
+  edtJump.SelectAll;
+end;
+
+procedure TOrderedFileView.JumpEditKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+var
+  total, n, ffIndex: Integer;
+  hasDotDot: Boolean;
+begin
+  case Key of
+    VK_RETURN:
+      begin
+        Key := 0;
+        edtJump.Visible := False;
+        if Assigned(FFiles) and (FFiles.Count > 0) and TryStrToInt(Trim(edtJump.Text), n) then
+        begin
+          hasDotDot := (FFiles[0].FSFile.Name = '..');
+          total := FFiles.Count;
+          if hasDotDot then Dec(total);
+          if total > 0 then
+          begin
+            if n < 1 then n := 1;
+            if n > total then n := total;
+            ffIndex := n - 1;
+            if hasDotDot then Inc(ffIndex);  // skip '..' at index 0
+            SetActiveFile(ffIndex, True);
+          end;
+        end;
+        SetFocus;
+      end;
+    VK_ESCAPE:
+      begin
+        Key := 0;
+        edtJump.Visible := False;
+        SetFocus;
+      end;
+  end;
+end;
+
+procedure TOrderedFileView.JumpEditExit(Sender: TObject);
+begin
+  // Dismiss when focus is lost (e.g. clicking elsewhere).
+  edtJump.Visible := False;
 end;
 
 procedure TOrderedFileView.DoHandleKeyDown(var Key: Word; Shift: TShiftState);

--- a/src/fileviews/uorderedfileview.pas
+++ b/src/fileviews/uorderedfileview.pas
@@ -48,6 +48,7 @@ type
     procedure PositionLabelClick(Sender: TObject);  //<en Click index -> inline input -> jump
     procedure JumpEditKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure JumpEditExit(Sender: TObject);
+    procedure AsyncShowJumpEditor(Data: PtrInt);  //<en deferred open (after key handling)
     procedure pmOperationsCancelClick(Sender: TObject);
     procedure quickSearchChangeSearch(Sender: TObject; ASearchText: String; const ASearchOptions: TQuickSearchOptions; InvertSelection: Boolean = False);
     procedure quickSearchChangeFilter(Sender: TObject; AFilterText: String; const AFilterOptions: TQuickSearchOptions);
@@ -123,6 +124,7 @@ type
     procedure cm_GoToPrevEntry(const {%H-}Params: array of string);
     procedure cm_GoToFirstFile(const Params: array of string);
     procedure cm_GoToLastFile(const Params: array of string);
+    procedure cm_GoToPosition(const {%H-}Params: array of string);
   end;
 
 implementation
@@ -434,6 +436,18 @@ procedure TOrderedFileView.JumpEditExit(Sender: TObject);
 begin
   // Dismiss when focus is lost (e.g. clicking elsewhere).
   edtJump.Visible := False;
+end;
+
+procedure TOrderedFileView.AsyncShowJumpEditor(Data: PtrInt);
+begin
+  PositionLabelClick(Self);
+end;
+
+procedure TOrderedFileView.cm_GoToPosition(const Params: array of string);
+begin
+  // Keyboard shortcut (default Ctrl+G). Open deferred so the triggering key event
+  // finishes first - otherwise focus bounces back and the editor is dismissed at once.
+  Application.QueueAsyncCall(@AsyncShowJumpEditor, 0);
 end;
 
 procedure TOrderedFileView.DoHandleKeyDown(var Key: Word; Shift: TShiftState);

--- a/src/fileviews/uorderedfileview.pas
+++ b/src/fileviews/uorderedfileview.pas
@@ -339,6 +339,12 @@ var
   hasDotDot: Boolean;
 begin
   if (csDestroying in ComponentState) or (lblPosition = nil) then Exit;
+  lblPosition.Visible := gShowPositionIndex;
+  if not gShowPositionIndex then
+  begin
+    lblPosition.Caption := EmptyStr;
+    Exit;
+  end;
   if not Assigned(FFiles) or (FFiles.Count = 0) then
   begin
     lblPosition.Caption := EmptyStr;
@@ -369,6 +375,7 @@ var
   total, cur, idx: Integer;
   hasDotDot: Boolean;
 begin
+  if not gShowPositionIndex then Exit;
   if not Assigned(FFiles) or (FFiles.Count = 0) then Exit;
   hasDotDot := (FFiles[0].FSFile.Name = '..');
   total := FFiles.Count;
@@ -445,6 +452,7 @@ end;
 
 procedure TOrderedFileView.cm_GoToPosition(const Params: array of string);
 begin
+  if not gShowPositionIndex then Exit;
   // Keyboard shortcut (default Ctrl+G). Open deferred so the triggering key event
   // finishes first - otherwise focus bounces back and the editor is dismissed at once.
   Application.QueueAsyncCall(@AsyncShowJumpEditor, 0);

--- a/src/frames/foptionslayout.lfm
+++ b/src/frames/foptionslayout.lfm
@@ -1,8 +1,8 @@
 inherited frmOptionsLayout: TfrmOptionsLayout
-  Height = 550
+  Height = 574
   Width = 784
   HelpKeyword = '/configuration.html#ConfigLayout'
-  ClientHeight = 550
+  ClientHeight = 574
   ClientWidth = 784
   DesignLeft = 276
   DesignTop = 44
@@ -224,6 +224,17 @@ inherited frmOptionsLayout: TfrmOptionsLayout
       BorderSpacing.Top = 2
       Caption = 'Show panel of operation in background'
       TabOrder = 20
+    end
+    object cbShowPositionIndex: TCheckBox
+      AnchorSideTop.Control = cbPanelOfOperations
+      AnchorSideTop.Side = asrBottom
+      Left = 12
+      Height = 22
+      Top = 510
+      Width = 248
+      BorderSpacing.Top = 2
+      Caption = 'Show file &position index in footer'
+      TabOrder = 21
     end
     object cbShowDriveFreeSpace: TCheckBox
       AnchorSideTop.Control = cbShowDrivesListButton

--- a/src/frames/foptionslayout.pas
+++ b/src/frames/foptionslayout.pas
@@ -50,6 +50,7 @@ type
     cbShowMainMenu: TCheckBox;
     cbShowMainToolBar: TCheckBox;
     cbShowStatusBar: TCheckBox;
+    cbShowPositionIndex: TCheckBox;
     cbShowTabHeader: TCheckBox;
     cbShowTabs: TCheckBox;
     cbTermWindow: TCheckBox;
@@ -111,6 +112,7 @@ begin
   cbShowCurDir.Checked := gCurDir;
   cbShowTabHeader.Checked := gTabHeader;
   cbShowStatusBar.Checked := gStatusBar;
+  cbShowPositionIndex.Checked := gShowPositionIndex;
   cbShowCmdLine.Checked := gCmdLine;
   cbShowKeysPanel.Checked := gKeyButtons;
   cbFlatInterface.Checked := gInterfaceFlat;
@@ -138,6 +140,7 @@ begin
   gCurDir := cbShowCurDir.Checked;
   gTabHeader := cbShowTabHeader.Checked;
   gStatusBar := cbShowStatusBar.Checked;
+  gShowPositionIndex := cbShowPositionIndex.Checked;
   gCmdLine := cbShowCmdLine.Checked;
   gKeyButtons := cbShowKeysPanel.Checked;
   gInterfaceFlat := cbFlatInterface.Checked;

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -173,7 +173,9 @@ type
 
 const
   { Default hotkey list version number }
-  hkVersion = 72;
+  hkVersion = 73;
+  // 73 - In "Files Panel" context, added:
+  //      "Ctrl+G" for "cm_GoToPosition" (jump to a position in the listing)
   // 72 - In "Viewer" and "Editor" context, for macOS, added:
   //      "Cmd+G" for Find Next
   //      "Cmd+L" for Goto Line
@@ -1308,6 +1310,8 @@ begin
       AddIfNotExists(['Shift+Num-'],[],'cm_UnmarkCurrentExtension');
       AddIfNotExists(['Num*'],[],'cm_MarkInvert');
       AddIfNotExists(['Ctrl+Z'],[],'cm_EditComment');
+      if HotMan.Version < 73 then
+        AddIfNotExists(['Ctrl+G'],[],'cm_GoToPosition');
       AddIfNotExists(['Ctrl+Shift+Home'],[],'cm_ChangeDirToHome');
       AddIfNotExists(['Ctrl+Left'],[],'cm_TransferLeft');
       AddIfNotExists(['Ctrl+Right'],[],'cm_TransferRight');

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -297,6 +297,7 @@ var
   gCurDir,
   gTabHeader,
   gStatusBar,
+  gShowPositionIndex,
   gCmdLine,
   gLogWindow,
   gTermWindow,
@@ -2025,6 +2026,7 @@ begin
   gCurDir := True;
   gTabHeader := True;
   gStatusBar := True;
+  gShowPositionIndex := True;
   gCmdLine := True;
   gLogWindow := False;
   gTermWindow := False;
@@ -2961,6 +2963,7 @@ begin
       gCurDir := GetValue(Node, 'CurrentDirectory', gCurDir);
       gTabHeader := GetValue(Node, 'TabHeader', gTabHeader);
       gStatusBar := GetValue(Node, 'StatusBar', gStatusBar);
+      gShowPositionIndex := GetValue(Node, 'ShowPositionIndex', gShowPositionIndex);
       gCmdLine := GetValue(Node, 'CmdLine', gCmdLine);
       gLogWindow := GetValue(Node, 'LogWindow', gLogWindow);
       gTermWindow := GetValue(Node, 'TermWindow', gTermWindow);
@@ -3679,6 +3682,7 @@ begin
     SetValue(Node, 'CurrentDirectory', gCurDir);
     SetValue(Node, 'TabHeader', gTabHeader);
     SetValue(Node, 'StatusBar', gStatusBar);
+    SetValue(Node, 'ShowPositionIndex', gShowPositionIndex);
     SetValue(Node, 'CmdLine', gCmdLine);
     SetValue(Node, 'LogWindow', gLogWindow);
     SetValue(Node, 'TermWindow', gTermWindow);

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -208,6 +208,7 @@ type
    procedure cm_GoToNextEntry(const {%H-}Params: array of string);
    procedure cm_GoToPrevEntry(const {%H-}Params: array of string);
    procedure cm_GoToLastFile(const {%H-}Params: array of string);
+   procedure cm_GoToPosition(const {%H-}Params: array of string);
    procedure cm_Minimize(const {%H-}Params: array of string);
    procedure cm_Wipe(const {%H-}Params: array of string);
    procedure cm_Exit(const {%H-}Params: array of string);
@@ -1708,6 +1709,11 @@ end;
 procedure TMainCommands.cm_GoToPrevEntry(const Params: array of string);
 begin
   frmMain.ActiveFrame.ExecuteCommand('cm_GoToPrevEntry', []);
+end;
+
+procedure TMainCommands.cm_GoToPosition(const Params: array of string);
+begin
+  frmMain.ActiveFrame.ExecuteCommand('cm_GoToPosition', []);
 end;
 
 procedure TMainCommands.cm_GoToLastFile(const Params: array of string);


### PR DESCRIPTION
## What

Adds an optional **running file-position index** to the file panel footer, e.g. `6 / 10`,
showing the cursor's position within the current listing. It updates live as the cursor
moves and excludes `..` from the count.

A quick **jump-to-position** is included: clicking the index (or pressing **Ctrl+G**) opens a
small inline editor; typing a number and pressing Enter moves the cursor to that position
(Esc / focus-loss cancels).

## Why

In long listings it is handy to see "where am I" at a glance and to jump straight to the
N-th entry, similar to other file managers.

## Details

- Implemented in `TOrderedFileView`, so it covers the columns, brief and thumbnail views.
- The footer label is right-aligned next to the existing info label and uses the status-bar
  font.
- Files-Panel hotkeys are dispatched to the main form, so a mirror command
  `cm_GoToPosition` in `TMainCommands` delegates to the active view (same pattern as the
  existing `cm_GoToFirstEntry`). Default binding **Ctrl+G** added in
  `LoadDefaultHotkeyBindings` (`hkVersion` 72 -> 73 so existing configs pick it up).
- **Optional:** a new checkbox on **Configuration > Layout** ("Show file position index in
  footer", `gShowPositionIndex`, default on) toggles the whole feature. When off, the label
  is hidden and the click/Ctrl+G jump is inactive.

## Notes

- No new translation strings were forced into the `.lrj`; the one new caption is a literal
  on the Layout page and can be picked up by the normal translation update.
- Tested on Windows (Lazarus 4.8 / FPC 3.2.2): builds cleanly and works in columns/brief/
  thumbnail views, toggling on/off and jumping via click and Ctrl+G.
