### PR TITLE
FIX: Don't use png for jpg/bmp with uppercase extension

### DIFF
--- a/src/uthumbnails.pas
+++ b/src/uthumbnails.pas
@@ -60,7 +60,7 @@ const
 
 function TThumbnailManager.GetPreviewFileExt(const sFileExt: String): String;
 begin
-  if (sFileExt = 'jpg') or (sFileExt = 'jpeg') or (sFileExt = 'bmp') then
+  if (sFileExt = 'jpg') or (sFileExt = 'jpeg') or (sFileExt = 'bmp') or (sFileExt = 'JPG') or (sFileExt = 'JPEG') or (sFileExt = 'BMP') then
     Result:= 'jpg'
   else
     Result:= 'png';
@@ -395,4 +395,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
Image files with only-uppercase extensions are quite common, e.g. when copied from a digital camera. I observed DC creating png thumbs that take ~10x the space for such files.