### PR TITLE
Fix doubled text in Tree View Menu on Qt6/Wayland

### DIFF
--- a/src/ftreeviewmenu.lfm
+++ b/src/ftreeviewmenu.lfm
@@ -74,7 +74,7 @@ object frmTreeViewMenu: TfrmTreeViewMenu
       OnMouseWheelDown = tvMainMenuMouseWheelDown
       OnMouseWheelUp = tvMainMenuMouseWheelUp
       OnSelectionChanged = tvMainMenuSelectionChanged
-      Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoHotTrack, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips, tvoThemedDraw]
+      Options = [tvoAutoExpand, tvoAutoItemHeight, tvoHideSelection, tvoHotTrack, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips]
     end
     object edSearchingEntry: TEdit
       AnchorSideLeft.Control = pnlAll

--- a/src/ftreeviewmenu.pas
+++ b/src/ftreeviewmenu.pas
@@ -253,6 +253,24 @@ begin
   if TCustomTreeView(Sender).Color <> BackgroundColor then
     TCustomTreeView(Sender).Color := BackgroundColor;
 
+  // The default-drawn node text is not always covered exactly by our own
+  // painting done in cdPostPaint (with Qt6/Wayland the two use different
+  // x offsets, leaving the text visibly doubled), so paint the default text
+  // with the row background color to make it invisible instead of relying
+  // on erasing it later. Requires tvoThemedDraw to be off so the default
+  // drawing uses the canvas font color.
+  if Stage = cdPrePaint then
+  begin
+    if cdsSelected in State then
+    begin
+      TTreeView(Sender).Canvas.Font.Color := CursorColor;
+      TTreeView(Sender).Canvas.Brush.Color := CursorColor;
+    end
+    else
+      TTreeView(Sender).Canvas.Font.Color := BackgroundColor;
+    Exit;
+  end;
+
   if Stage = cdPostPaint then
   begin
     if Node <> nil then


### PR DESCRIPTION
Fixes #3000.

On Qt6/Wayland the Tree View Menu (Ctrl+D and the other tree view menus) renders every item with doubled/garbled text.

**Root cause:** in `DoPaintNode` the LCL always draws the default node text before the `cdPostPaint` stage; setting `DefaultDraw := False` at the end of `cdPostPaint` is too late, so the custom-drawn text in `fTreeViewMenu` overlaps the default one.

**Fix:**
- `ftreeviewmenu.pas`: at `cdPrePaint`, make the default text invisible (font color = background/cursor color) so only the custom `cdPostPaint` drawing is visible.
- `ftreeviewmenu.lfm`: drop `tvoThemedDraw` from the tree options — themed drawing ignores the canvas font color on Qt6/Wayland.

Before/after screenshots are attached to #3000. Tested on Arch Linux, Hyprland (Wayland), Qt 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)