### PR TITLE
Options dialog: random window freeze on Qt6/Wayland caused by tooltip grab

### DIFF
--- a/src/foptions.pas
+++ b/src/foptions.pas
@@ -213,6 +213,9 @@ begin
   // Initialize property storage
   InitPropStorage(Self);
   TreeFilterEdit.Visible:= (OptionsSearchCache.Count > 0);
+  // Qt6/Wayland: tooltip popups can steal the input grab and leave the
+  // window unresponsive; the options pages are full of hinted controls.
+  ShowHint:= False;
 {$IFDEF DARWIN}
   self.BorderIcons:= self.BorderIcons - [biMinimize];
 {$ENDIF}


### PR DESCRIPTION
On Qt6/Wayland, clicking through the Options dialog pages (toolbar pages especially) randomly leaves the whole window unresponsive and it has to be closed.

**Diagnosis:** attaching gdb to the frozen process shows the main thread healthy inside the normal event loop (`ppoll` / `g_main_context_iteration`) — it is not a deadlock in Double Commander. The Qt6 tooltip popup takes the Wayland input grab and sometimes never releases it, so the window stops receiving input while the application keeps running.

**Fix:** the options pages don't really need tooltips; setting `ShowHint := False` on the form in `FormCreate` disables them for the whole dialog and the freeze is gone.

Tested on Arch Linux, Hyprland (Wayland), Qt 6.
