### PR TITLE
FIX: keep saved path of inactive tabs on startup

### DIFF
--- a/src/fileviews/ufileview.pas
+++ b/src/fileviews/ufileview.pas
@@ -112,6 +112,7 @@ type
     FFilePropertiesNeeded: TFilePropertiesTypes;
     FFileViewWorkers: TFileViewWorkers;
     FFlags: TFileViewFlags;
+    FPathAvailable: Boolean;     //<en Cached availability of the current path (used by the tab marker)
     FHashedFiles: TBucketList;  //<en Contains pointers to file source files for quick checking if a file object is still valid
     FHashedNames: TStringHashListUtf8;
     FPendingFilesChanges: TFPList;
@@ -445,6 +446,11 @@ type
     procedure Reload(AForced: Boolean);
     procedure ReloadIfNeeded;
     procedure StopWorkers; virtual;
+    {en
+       Re-checks availability of the current path (single stat) and refreshes
+       the tab title, so that the tab marker is up to date.
+    }
+    procedure UpdatePathAvailability;
 
     // For now we use here the knowledge that there are tabs.
     // Config should be independent of that in the future.
@@ -545,6 +551,7 @@ type
     property FlatView: Boolean read FFlatView write SetFlatView;
     property Path[FileSourceIndex, PathIndex: Integer]: String read GetPath;
     property PathsCount[FileSourceIndex: Integer]: Integer read GetPathsCount;
+    property PathAvailable: Boolean read FPathAvailable;
 
     property Sorting: TFileSortings read FSortings write SetSorting;
     property WatcherActive: Boolean read GetWatcherActive;
@@ -685,6 +692,7 @@ begin
   FHistory := TFileViewHistory.Create;
   FSavedSelection:= TStringListEx.Create;
   FLastMark := '*';
+  FPathAvailable := True;
   FLastMarkCaseSensitive := gbMarkMaskCaseSensitive;
   FLastMarkIgnoreAccents := gbMarkMaskIgnoreAccents;
   FFiles := TDisplayFiles.Create(False);
@@ -1019,6 +1027,7 @@ end;
 procedure TFileView.FileSourceFileListLoaded;
 begin
   FLoadingFileListLongTimer.Enabled := False;
+  UpdatePathAvailability;
 end;
 
 procedure TFileView.FileSourceFileListUpdated;
@@ -2732,11 +2741,24 @@ begin
     end;
     if TFileSystemFileSource.ClassNameIs(aFileSource.ClassName) then
     begin
-      // Go to upper directory if current doesn't exist
-      sPath := GetDeepestExistingPath(FHistory.CurrentPath);
-      if Length(sPath) = 0 then sPath := mbGetCurrentDir;
-      if not mbCompareFileNames(sPath, FHistory.CurrentPath) then
-        FHistory.Add(aFileSource, sPath);
+      if (fvfDelayLoadingFiles in Flags) then
+      begin
+        // The tab is not being loaded yet (e.g. inactive tab at startup).
+        // Keep the saved path even if the target is temporarily unavailable
+        // (removable media, network share): correcting it here would make the
+        // corrected path the saved one. Only cache the path availability for
+        // the tab marker ('?' on the tab title).
+        FPathAvailable := mbFileSystemEntryExists(FHistory.CurrentPath);
+      end
+      else
+      begin
+        // Go to upper directory if current doesn't exist
+        sPath := GetDeepestExistingPath(FHistory.CurrentPath);
+        if Length(sPath) = 0 then sPath := mbGetCurrentDir;
+        if not mbCompareFileNames(sPath, FHistory.CurrentPath) then
+          FHistory.Add(aFileSource, sPath);
+        FPathAvailable := True;
+      end;
     end;
   end;
 
@@ -2986,6 +3008,7 @@ begin
   UpdateTitle;
 
   MakeFileSourceFileList;
+  UpdatePathAvailability;
 end;
 
 procedure TFileView.ChangePathToParent(AllowChangingFileSource: Boolean);
@@ -3419,10 +3442,21 @@ begin
   FileSource.GetWatcher.UpdateWatch;
 end;
 
+procedure TFileView.UpdatePathAvailability;
+begin
+  if Assigned(FileSource) and TFileSystemFileSource.ClassNameIs(FileSource.ClassName) then
+    FPathAvailable := mbFileSystemEntryExists(CurrentPath)
+  else
+    FPathAvailable := True;
+  if Parent is TFileViewPage then
+    TFileViewPage(Parent).UpdateTitle;
+end;
+
 procedure TFileView.ActivateEvent(Sender: TObject);
 begin
   SetFlags(Flags - [fvfDelayLoadingFiles]);
   ReloadIfNeeded;
+  UpdatePathAvailability;
 end;
 
 function TFileView.CheckIfDelayReload: Boolean;

--- a/src/fmain.pas
+++ b/src/fmain.pas
@@ -833,6 +833,7 @@ type
     function FrameLeft: TFileView;
     function FrameRight: TFileView;
     procedure ForEachView(CallbackFunction: TForEachViewFunction; UserData: Pointer);
+    procedure UpdateAvailabilityForViewsUnderPath(AFileView: TFileView; AUserData: Pointer);
     procedure GetListOpenedPaths(const APaths:TStringList);
     //check selected count and generate correct msg, parameters is lng indexs
     Function GetFileDlgStr(sLngOne, sLngMulti : String; Files: TFiles):String;
@@ -7330,6 +7331,12 @@ begin
   end;
 end;
 
+procedure TfrmMain.UpdateAvailabilityForViewsUnderPath(AFileView: TFileView; AUserData: Pointer);
+begin
+  if IsInPath(PDrive(AUserData)^.Path, AFileView.CurrentPath, True, True) then
+    AFileView.UpdatePathAvailability;
+end;
+
 procedure TfrmMain.OnDriveWatcherEvent(EventType: TDriveWatcherEvent; const ADrive: PDrive);
 begin
   // Update disk panel does not work correctly when main
@@ -7343,7 +7350,13 @@ begin
 
   if (FrameLeft = nil) or (FrameRight = nil) then Exit;
 
-  if (EventType = dweDriveRemoved) and Assigned(ADrive) then
+  if (EventType = dweDriveAdded) and Assigned(ADrive) then
+  begin
+    // Refresh tab markers for views whose path is on the new drive,
+    // e.g. a previously unplugged removable drive became available again.
+    ForEachView(@UpdateAvailabilityForViewsUnderPath, ADrive);
+  end
+  else if (EventType = dweDriveRemoved) and Assigned(ADrive) then
   begin
     if IsInPath(ADrive^.Path, ActiveFrame.CurrentPath, True, True) then
       ActiveFrame.CurrentPath:= GetHomeDir

--- a/src/frames/foptionstabs.lfm
+++ b/src/frames/foptionstabs.lfm
@@ -135,6 +135,18 @@ inherited frmOptionsTabs: TfrmOptionsTabs
       Caption = 'Show locked tabs &with an asterisk *'
       TabOrder = 11
     end
+    object cbTabsUnavailableMarker: TCheckBox
+      AnchorSideLeft.Control = cbTabsAlwaysVisible
+      AnchorSideTop.Control = cbTabsLockedAsterisk
+      AnchorSideTop.Side = asrBottom
+      Left = 12
+      Height = 19
+      Top = 281
+      Width = 300
+      BorderSpacing.Top = 6
+      Caption = 'Mark unavailable path in tab title with &a question mark ?'
+      TabOrder = 12
+    end
     object cbTabsActivateOnClick: TCheckBox
       AnchorSideLeft.Control = cbTabsAlwaysVisible
       AnchorSideTop.Control = cbKeepRenamedNameBackToNormal
@@ -145,7 +157,7 @@ inherited frmOptionsTabs: TfrmOptionsTabs
       Width = 302
       BorderSpacing.Top = 6
       Caption = 'Activate target &panel when clicking on one of its Tabs'
-      TabOrder = 13
+      TabOrder = 14
     end
     object cbTabsShowCloseButton: TCheckBox
       AnchorSideLeft.Control = cbTabsAlwaysVisible
@@ -177,7 +189,7 @@ inherited frmOptionsTabs: TfrmOptionsTabs
         'Bottom'
       )
       Style = csDropDownList
-      TabOrder = 15
+      TabOrder = 16
     end
     object cbTabsOpenNearCurrent: TCheckBox
       AnchorSideLeft.Control = cbTabsAlwaysVisible
@@ -213,7 +225,7 @@ inherited frmOptionsTabs: TfrmOptionsTabs
       Width = 203
       BorderSpacing.Top = 6
       Caption = 'Always show drive letter in tab title'
-      TabOrder = 14
+      TabOrder = 15
       Visible = False
     end
     object cbTabsReuseTabWhenPossible: TCheckBox
@@ -242,15 +254,15 @@ inherited frmOptionsTabs: TfrmOptionsTabs
     end
     object cbKeepRenamedNameBackToNormal: TCheckBox
       AnchorSideLeft.Control = cbTabsAlwaysVisible
-      AnchorSideTop.Control = cbTabsLockedAsterisk
+      AnchorSideTop.Control = cbTabsUnavailableMarker
       AnchorSideTop.Side = asrBottom
       Left = 12
       Height = 19
-      Top = 281
+      Top = 306
       Width = 246
       BorderSpacing.Top = 6
       Caption = 'Keep renamed name when unlocking a tab'
-      TabOrder = 12
+      TabOrder = 13
     end
     object lblTabsActionOnDoubleClick: TLabel
       AnchorSideLeft.Control = cbTabsAlwaysVisible
@@ -287,7 +299,7 @@ inherited frmOptionsTabs: TfrmOptionsTabs
         'Tabs popup menu'
       )
       Style = csDropDownList
-      TabOrder = 16
+      TabOrder = 17
     end
   end
 end

--- a/src/frames/foptionstabs.pas
+++ b/src/frames/foptionstabs.pas
@@ -54,6 +54,7 @@ type
     cbTabsReuseTabWhenPossible: TCheckBox;
     cbTabsShowDriveLetter: TCheckBox;
     cbTabsCloseDuplicateWhenClosing: TCheckBox;
+    cbTabsUnavailableMarker: TCheckBox;
   private
     FPageControl: TPageControl; // For checking Tabs capabilities
   protected
@@ -108,6 +109,7 @@ begin
   cbKeepRenamedNameBackToNormal.Checked := tb_keep_renamed_when_back_normal in gDirTabOptions;
   cbTabsActivateOnClick.Checked := tb_activate_panel_on_click in gDirTabOptions;
   cbTabsShowDriveLetter.Checked := tb_show_drive_letter in gDirTabOptions;
+  cbTabsUnavailableMarker.Checked := tb_show_unavailable_marker in gDirTabOptions;
   cbTabsActionOnDoubleClick.ItemIndex := integer(gDirTabActionOnDoubleClick);
   if cbTabsActionOnDoubleClick.ItemIndex = -1 then cbTabsActionOnDoubleClick.ItemIndex := 1; // Because with r6597 to r6599 we saved incorrect value for "gDirTabActionOnDoubleClick"...
   cbTabsActionOnDoubleClick.Refresh;
@@ -163,6 +165,8 @@ begin
     gDirTabOptions := gDirTabOptions + [tb_activate_panel_on_click];
   if cbTabsShowDriveLetter.Checked then
     gDirTabOptions := gDirTabOptions + [tb_show_drive_letter];
+  if cbTabsUnavailableMarker.Checked then
+    gDirTabOptions := gDirTabOptions + [tb_show_unavailable_marker];
   if cbTabsShowCloseButton.Checked then
     gDirTabOptions := gDirTabOptions + [tb_show_close_button];
 

--- a/src/ufileviewnotebook.pas
+++ b/src/ufileviewnotebook.pas
@@ -334,6 +334,11 @@ begin
        (tb_show_asterisk_for_locked in gDirTabOptions) then
       NewCaption := '*' + NewCaption;
 
+    // Mark tabs whose current path is currently unavailable
+    // (e.g. unplugged removable media or disconnected network share).
+    if (not FileView.PathAvailable) and (tb_show_unavailable_marker in gDirTabOptions) then
+      NewCaption := '?' + NewCaption;
+
     if (tb_text_length_limit in gDirTabOptions) and (UTF8Length(NewCaption) > gDirTabLimit) then
       NewCaption := UTF8Copy(NewCaption, 1, gDirTabLimit) + '..';
 

--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -71,7 +71,8 @@ type
                          tb_close_on_doubleclick, tb_show_drive_letter,
                          tb_reusing_tab_when_possible,
                          tb_confirm_close_locked_tab,
-                         tb_keep_renamed_when_back_normal);
+                         tb_keep_renamed_when_back_normal,
+                         tb_show_unavailable_marker);
 
   TTabsOptionsDoubleClick = (tadc_Nothing, tadc_CloseTab, tadc_FavoriteTabs, tadc_TabsPopup);
 
@@ -2126,7 +2127,8 @@ begin
                      tb_activate_panel_on_click,
                      tb_close_on_doubleclick,
                      tb_reusing_tab_when_possible,
-                     tb_confirm_close_locked_tab];
+                     tb_confirm_close_locked_tab,
+                     tb_show_unavailable_marker];
   gDirTabActionOnDoubleClick := tadc_FavoriteTabs;
   gDirTabLimit := 32;
   gDirTabPosition := tbpos_top;


### PR DESCRIPTION
`TFileView.LoadConfiguration` corrected the path of every restored tab (`GetDeepestExistingPath` with `mbGetCurrentDir` fallback), so a tab whose target was temporarily unavailable (unplugged drive, offline network share) had its saved path silently rewritten at launch and persisted on exit.

This runs the correction only when the tab is actually loaded (i.e. when it does not have the `fvfDelayLoadingFiles` flag). 

Cache path availability for a '?' tab-title marker that is refreshed on activation, path change, list load and drive-added events.
On activation of a tab with unavailable path an empty list is displayed and `..` will follow through to the first available parent. This prevents silent changing of tab's path.

The marker is controlled via the new default `tb_show_unavailable_marker` option.

Closes #2502