### PR TITLE
fix: restore main window focus after closing delete confirmation

### DIFF
--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -58,6 +58,7 @@ type
                                           State: TFileSourceOperationState);
    procedure OnCalcChecksumStateChanged(Operation: TFileSourceOperation;
                                         State: TFileSourceOperationState);
+   procedure RestoreFocusAfterDelete({%H-}Data: PtrInt);
 
   public
    constructor Create(TheOwner: TComponent; ActionList: TActionList = nil); reintroduce;
@@ -460,6 +461,16 @@ end;
 function TMainCommands.CommandsFilter(Command: String): Boolean;
 begin
   Result := Command = 'cm_ExecuteToolbarItem';
+end;
+
+procedure TMainCommands.RestoreFocusAfterDelete({%H-}Data: PtrInt);
+begin
+  if frmMain.CanSetFocus then
+  begin
+    frmMain.BringToFront;
+    if frmMain.ActiveFrame.CanSetFocus then
+      frmMain.ActiveFrame.SetFocus;
+  end;
 end;
 
 //------------------------------------------------------
@@ -2730,11 +2741,10 @@ begin
       end;
       if (bConfirmation = False) or (ShowDeleteDialog(frmMain, Message, FileSource, QueueId)) then
       begin
-        // Restore focus to main window after confirmation dialog closes
-        if bConfirmation and frmMain.ActiveFrame.CanSetFocus then
-        begin
-          frmMain.ActiveFrame.SetFocus;
-        end;
+        // Let the widgetset finish closing the modal window before restoring
+        // the main window and active panel focus (required by Qt6 in particular).
+        if bConfirmation then
+          Application.QueueAsyncCall(@RestoreFocusAfterDelete, 0);
         if FileSource.IsClass(TFileSystemFileSource) then
         begin
           if frmMain.NotActiveFrame.FileSource.IsClass(TFileSystemFileSource) then


### PR DESCRIPTION
My earlier focus fix is still present - 3f9e3d3, but it restores focus synchronously immediately after ShowModal returns. It seems that with newer Qt6/LCL versions, native modal window closing and activation events may finish processing afterward, causing the main window to lose focus again.

The solution will queue the focus restoration so it runs after the widgetset has completed closing the dialog. Bring the main window to the front first, then restore focus to the active file panel.