### PR TITLE
FIX: avoid macOS FSEvents UI deadlock during stream teardown

### DIFF
--- a/src/platform/unix/darwin/udarwinfswatch.pas
+++ b/src/platform/unix/darwin/udarwinfswatch.pas
@@ -133,7 +133,7 @@ private
   procedure handleEvents( const originalSession:TDarwinFSWatchEventSession );
   procedure doCallback( const watchPath:String; const internalEvent:TInternalEvent );
 
-  procedure updateStream;
+  procedure updateStream( const watchPaths:NSArray );
   procedure closeStream;
   procedure waitPath;
   procedure notifyPath;
@@ -615,16 +615,16 @@ begin
   event.Free;
 end;
 
-procedure TDarwinFSWatcher.updateStream;
+procedure TDarwinFSWatcher.updateStream( const watchPaths:NSArray );
 begin
-  if _watchPaths.isEqualToArray(_streamPaths) then exit;
+  if watchPaths.isEqualToArray(_streamPaths) then exit;
 
   closeStream;
 
   _streamPaths.release;
-  _streamPaths:= NSArray.alloc.initWithArray( _watchPaths );
+  _streamPaths:= NSArray.alloc.initWithArray( watchPaths );
 
-  if _watchPaths.count = 0 then
+  if watchPaths.count = 0 then
   begin
     _lastEventId:= FSEventStreamEventId(kFSEventStreamEventIdSinceNow);
     exit;
@@ -633,7 +633,7 @@ begin
   _stream:= FSEventStreamCreate( nil,
               @cdeclFSEventsCallback,
               @_streamContext,
-              CFArrayRef(_watchPaths),
+              CFArrayRef(watchPaths),
               _lastEventId,
               _latency/1000,
               CREATE_FLAGS );
@@ -657,6 +657,9 @@ end;
 procedure TDarwinFSWatcher.start;
 var
   pool: NSAutoReleasePool;
+  watchPaths: NSArray;
+  keepRunning: Boolean;
+  pathsChanged: Boolean;
 begin
   _running:= true;
   _runLoop:= CFRunLoopGetCurrent();
@@ -666,21 +669,42 @@ begin
 
     pool:= NSAutoreleasePool.alloc.init;
 
-    _lockObject.Acquire;
-    try
-      updateStream;
-    finally
-      _lockObject.Release;
-    end;
+    repeat
+      // Closing an FSEvent stream may block on SMB for several seconds.
+      // Take a snapshot so updateStream can run without holding _lockObject.
+      _lockObject.Acquire;
+      try
+        watchPaths:= _watchPaths.copy;
+      finally
+        _lockObject.Release;
+      end;
 
-    if Assigned(_stream) then
-      CFRunLoopRun
-    else
-      waitPath;
+      try
+        updateStream( watchPaths );
+      finally
+        watchPaths.release;
+      end;
+
+      _lockObject.Acquire;
+      try
+        keepRunning:= _running;
+        pathsChanged:= not _watchPaths.isEqualToArray(_streamPaths);
+      finally
+        _lockObject.Release;
+      end;
+    until not keepRunning or not pathsChanged;
+
+    if keepRunning then
+    begin
+      if Assigned(_stream) then
+        CFRunLoopRun
+      else
+        waitPath;
+    end;
 
     pool.release;
 
-  until not _running;
+  until not keepRunning;
 end;
 
 procedure TDarwinFSWatcher.terminate;


### PR DESCRIPTION
Addresses #1561

Related to #1266 and commit 8494d60e8a97c0b81efef3171ce102799060a06a.

## Problem

On macOS, changing directories on an SMB share can freeze the entire Double Commander UI for 5-15 seconds even when raw SMB directory enumeration is fast.

Process samples show the FSEvents worker blocked in:

`FSEventStreamInvalidate -> __CFFileDescriptorDeallocate -> dispatch_sync -> kevent_id`

At the same time, the main thread is waiting for the watcher mutex while adding or removing a watched path.

## Root cause

`TDarwinFSWatcher.start` calls `updateStream` while holding `_lockObject`. `updateStream` may synchronously flush, stop, invalidate, and release the previous FSEvent stream. On SMB, Apple's teardown can block for many seconds, so UI-side `addPath` and `removePath` calls wait for the same mutex and the GUI beachballs.

## Fix

- Copy `_watchPaths` to an immutable `NSArray` snapshot while holding `_lockObject`.
- Release `_lockObject` before rebuilding or closing the FSEvent stream.
- Reacquire the mutex afterward and compare the current watched paths with `_streamPaths`.
- Repeat the rebuild when watched paths changed during the slow teardown.

This keeps the potentially slow Apple call on the watcher thread without holding the mutex needed by the UI. Path changes that arrive during teardown are retried rather than lost.

## Relation to #1266

The fix for #1266 filters subdirectory events unless Flat View is active, reducing unnecessary refresh traffic. This change is complementary: it removes the remaining UI lock coupling when an FSEvent stream itself is synchronously torn down.

## Tests

Environment: macOS 26.6.2 on Apple Silicon, Cocoa, FPC 3.2.2, Lazarus 4.99, TrueNAS SMB share.

- 2,640 automated SMB directory transitions across both panes on the patch-only build, with no freeze or crash.
- 74 UI responsiveness probes completed in 386-514 ms.
- Two samples caught `FSEventStreamInvalidate` blocking the watcher for 17.739 and 8.627 seconds while the main thread stayed responsive in the AppKit event loop.
- 100 concurrent SMB create/remove cycles completed during navigation.
- Auto-refresh detected a 20-file create/remove burst without manual refresh.
- Kqueue count remained exactly 2; no material FSEvents leak was detected.
- Clean shutdown after stress completed in 1.078 seconds without a crash report.
- Rebased onto current master `1c4c3ef0fcdba54d4aef7d8b6832b01e891a2a21`; ARM64 build and `git diff --check` pass.
- Focused current-master rerun: 120 additional SMB transitions, auto-refresh 0 -> 10 -> 0 files, and clean exit in 1.019 seconds.

## Current-master test note

A completely clean current-master build on macOS 26.6.2 also hits an unrelated existing AppKit exception in `NSUpdateDynamicServices` before normal startup. The focused current-master runtime rerun used a test-only skip of that existing call. It is not part of this commit; the branch contains only the `udarwinfswatch.pas` change. The 2,640-transition stress run used the patch-only build without this test workaround.

## Commit

`b141512 FIX: avoid macOS FSEvents UI deadlock`
