### PR TITLE
Add Swedish translation for Zip plugin

### DIFF
--- a/plugins/wcx/zip/language/zip.sv.po
+++ b/plugins/wcx/zip/language/zip.sv.po
@@ -1,0 +1,79 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander Zip plugin\n"
+"PO-Revision-Date: 2026-09-04 22:43+0300\n"
+"Last-Translator: Jonatan Nyberg\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: tdialogbox.caption
+msgid "Zip plugin configuration"
+msgstr "Konfiguration av ZIP-insticksmodulen"
+
+#: tdialogbox.lblAbout.caption
+msgid "Zip plugin supports PKZIP-compatible, TAR, XZ, GZip, Zstandard and BZip2 data compression and archiving."
+msgstr "ZIP-insticksmodulen stöder PKZIP-kompatibel datakomprimering och arkivering samt formaten TAR, XZ, GZip, Zstandard och BZip2."
+
+#: tdialogbox.gbCompression.caption
+msgid "Compression"
+msgstr "Komprimering"
+
+#: tdialogbox.gbCompression.lblArchiveFormat.caption
+msgid "Archive format:"
+msgstr "Arkivformat:"
+
+#: tdialogbox.gbCompression.lblCompressionMethod.caption
+msgid "Compression method:"
+msgstr "Komprimeringsmetod:"
+
+#: tdialogbox.gbCompression.lblCompressionLevel.caption
+msgid "Compression level:"
+msgstr "Komprimeringsnivå:"
+
+#: tdialogbox.chkFollowLinks.caption
+msgid "Follow Links (pack the target files)"
+msgstr "Följ länkar (arkivera målfilerna)"
+
+#: tdialogbox.chkTarAutoHandle.caption
+msgid "Open *.tar.xyz archives at one step (slowly with big archives)"
+msgstr "Öppna *.tar.xyz-arkiv i ett steg (långsamt för stora arkiv)"
+
+#: tdialogbox.btnCancel.caption
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tdialogbox.btnOK.caption
+msgid "OK"
+msgstr "OK"
+
+#: ziplng.rscompressionmethodstore
+msgid "Store"
+msgstr "Lagra"
+
+#: ziplng.rscompressionmethodoptimal
+msgid "Optimal (2x slower)"
+msgstr "Optimal (2× långsammare)"
+
+#: ziplng.rscompressionlevelfastest
+msgid "Fastest"
+msgstr "Snabbast"
+
+#: ziplng.rscompressionlevelfast
+msgid "Fast"
+msgstr "Snabb"
+
+#: ziplng.rscompressionlevelnormal
+msgid "Normal"
+msgstr "Normal"
+
+#: ziplng.rscompressionlevelmaximum
+msgid "Maximum"
+msgstr "Maximal"
+
+#: ziplng.rscompressionlevelultra
+msgid "Ultra"
+msgstr "Ultra"


### PR DESCRIPTION
## Summary

Add a Swedish translation for the WCX Zip plugin.

## Changes

- Add `plugins/wcx/zip/language/zip.sv.po`
- Translate all current Zip plugin settings into Swedish
- Use consistent Swedish terminology for archive formats, compression methods, and compression levels
- Add complete Swedish PO metadata

## Validation

- `msgfmt --check -o /dev/null plugins/wcx/zip/language/zip.sv.po` passes without warnings or errors
- Only the new Swedish translation file is added
