### PR TITLE
Add Swedish translations

### DIFF
--- a/language/doublecmd.sv.po
+++ b/language/doublecmd.sv.po
@@ -1,0 +1,14720 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander 1.1.0 alpha\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-11-15 11:15+0300\n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: fsyncdirsdlg.rscomparingpercent
+#, object-pascal-format
+msgid "Comparing... %d%% (ESC to cancel)"
+msgstr "Jämför... %d%% (ESC för att avbryta)"
+
+#: fsyncdirsdlg.rsdeleteleft
+#, object-pascal-format
+msgid "Left: Delete %d file(s)"
+msgstr "Vänster: Ta bort %d fil(er)"
+
+#: fsyncdirsdlg.rsdeleteright
+#, object-pascal-format
+msgid "Right: Delete %d file(s)"
+msgstr "Höger: Ta bort %d fil(er)"
+
+#: fsyncdirsdlg.rsfilesfound
+#, object-pascal-format
+msgid "Files found: %d  (Identical: %d, Different: %d, Unique left: %d, Unique right: %d)"
+msgstr "Filer hittades: %d  (Identiska: %d, Olika: %d, Unika vänster: %d, Unika höger: %d)"
+
+#: fsyncdirsdlg.rslefttorightcopy
+#, object-pascal-format
+msgid "Left to Right: Copy %d files, total size: %s (%s)"
+msgstr "Vänster till höger: Kopiera %d filer, total storlek: %s (%s)"
+
+#: fsyncdirsdlg.rsrighttoleftcopy
+#, object-pascal-format
+msgid "Right to Left: Copy %d files, total size: %s (%s)"
+msgstr "Höger till vänster: Kopiera %d filer, total storlek: %s (%s)"
+
+#: tfilesystemcopymoveoperationoptionsui.btnsearchtemplate.hint
+msgid "Choose template..."
+msgstr "Välj mall..."
+
+#: tfilesystemcopymoveoperationoptionsui.cbcheckfreespace.caption
+msgid "C&heck free space"
+msgstr "Kontrollera &ledigt utrymme"
+
+#: tfilesystemcopymoveoperationoptionsui.cbcopyattributes.caption
+msgid "Cop&y attributes"
+msgstr "Kopiera &attribut"
+
+#: tfilesystemcopymoveoperationoptionsui.cbcopyownership.caption
+msgid "Copy o&wnership"
+msgstr "Kopiera ä&garskap"
+
+#: tfilesystemcopymoveoperationoptionsui.cbcopypermissions.caption
+msgid "Copy &permissions"
+msgstr "Kopiera &behörigheter"
+
+#: tfilesystemcopymoveoperationoptionsui.cbcopytime.caption
+msgctxt "tfilesystemcopymoveoperationoptionsui.cbcopytime.caption"
+msgid "Copy d&ate/time"
+msgstr "Kopiera &datum/tid"
+
+#: tfilesystemcopymoveoperationoptionsui.cbcorrectlinks.caption
+msgid "Correct lin&ks"
+msgstr "Korrigera län&kar"
+
+#: tfilesystemcopymoveoperationoptionsui.cbdropreadonlyflag.caption
+msgid "Drop readonly fla&g"
+msgstr "Ta bort skrivsk&yddsflaggan"
+
+#: tfilesystemcopymoveoperationoptionsui.cbexcludeemptydirectories.caption
+msgid "E&xclude empty directories"
+msgstr "Uteslut &tomma kataloger"
+
+#: tfilesystemcopymoveoperationoptionsui.cbfollowlinks.caption
+msgctxt "tfilesystemcopymoveoperationoptionsui.cbfollowlinks.caption"
+msgid "Fo&llow links"
+msgstr "Fö&lj länkar"
+
+#: tfilesystemcopymoveoperationoptionsui.cbreservespace.caption
+msgid "&Reserve space"
+msgstr "&Reservera utrymme"
+
+#: tfilesystemcopymoveoperationoptionsui.chkcopyonwrite.caption
+msgid "Copy on write"
+msgstr "Kopiera vid skrivning"
+
+#: tfilesystemcopymoveoperationoptionsui.chkverify.caption
+msgid "&Verify"
+msgstr "&Verifiera"
+
+#: tfilesystemcopymoveoperationoptionsui.cmbsetpropertyerror.hint
+msgid "What to do when cannot set file time, attributes, etc."
+msgstr "Vad ska göras när filtid, attribut osv. inte kan ställas in"
+
+#: tfilesystemcopymoveoperationoptionsui.gbfiletemplate.caption
+msgid "Use file template"
+msgstr "Använd filmall"
+
+#: tfilesystemcopymoveoperationoptionsui.lbldirectoryexists.caption
+msgctxt "tfilesystemcopymoveoperationoptionsui.lbldirectoryexists.caption"
+msgid "When dir&ectory exists"
+msgstr "När &katalogen redan finns"
+
+#: tfilesystemcopymoveoperationoptionsui.lblfileexists.caption
+msgid "When &file exists"
+msgstr "När &filen redan finns"
+
+#: tfilesystemcopymoveoperationoptionsui.lblsetpropertyerror.caption
+msgid "When ca&nnot set property"
+msgstr "När en egenskap i&nte kan ställas in"
+
+#: tfilesystemcopymoveoperationoptionsui.lbltemplatename.caption
+msgid "<no template>"
+msgstr "<ingen mall>"
+
+#: tfrmabout.btnclose.caption
+msgctxt "tfrmabout.btnclose.caption"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmabout.btncopytoclipboard.caption
+msgid "Copy to clipboard"
+msgstr "Kopiera till urklipp"
+
+#: tfrmabout.caption
+msgctxt "tfrmabout.caption"
+msgid "About"
+msgstr "Om"
+
+#: tfrmabout.lblbuild.caption
+msgctxt "tfrmabout.lblbuild.caption"
+msgid "Build"
+msgstr "Byggversion"
+
+#: tfrmabout.lblcommit.caption
+msgctxt "tfrmabout.lblcommit.caption"
+msgid "Commit"
+msgstr "Commit"
+
+#: tfrmabout.lblfreepascalver.caption
+msgctxt "tfrmabout.lblfreepascalver.caption"
+msgid "Free Pascal"
+msgstr "Free Pascal"
+
+#: tfrmabout.lblhomepage.caption
+msgid "Home Page:"
+msgstr "Webbplats:"
+
+#: tfrmabout.lblhomepageaddress.caption
+msgid "https://doublecmd.sourceforge.io"
+msgstr "https://doublecmd.sourceforge.io"
+
+#: tfrmabout.lbllazarusver.caption
+msgctxt "tfrmabout.lbllazarusver.caption"
+msgid "Lazarus"
+msgstr "Lazarus"
+
+#: tfrmabout.lblrevision.caption
+msgctxt "tfrmabout.lblrevision.caption"
+msgid "Revision"
+msgstr "Revision"
+
+#: tfrmabout.lbltitle.caption
+msgctxt "tfrmabout.lbltitle.caption"
+msgid "Double Commander"
+msgstr "Double Commander"
+
+#: tfrmabout.lblversion.caption
+msgctxt "tfrmabout.lblversion.caption"
+msgid "Version"
+msgstr "Version"
+
+#: tfrmattributesedit.btncancel.caption
+msgctxt "tfrmattributesedit.btncancel.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmattributesedit.btnok.caption
+msgctxt "tfrmattributesedit.btnok.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmattributesedit.btnreset.caption
+msgid "&Reset"
+msgstr "&Återställ"
+
+#: tfrmattributesedit.caption
+msgid "Choose attributes"
+msgstr "Välj attribut"
+
+#: tfrmattributesedit.cbarchive.caption
+msgid "&Archive"
+msgstr "&Arkiv"
+
+#: tfrmattributesedit.cbcompressed.caption
+msgid "Co&mpressed"
+msgstr "Ko&mprimerad"
+
+#: tfrmattributesedit.cbdirectory.caption
+msgid "&Directory"
+msgstr "&Katalog"
+
+#: tfrmattributesedit.cbencrypted.caption
+msgid "&Encrypted"
+msgstr "&Krypterad"
+
+#: tfrmattributesedit.cbhidden.caption
+msgid "&Hidden"
+msgstr "&Dold"
+
+#: tfrmattributesedit.cbreadonly.caption
+msgid "Read o&nly"
+msgstr "Skrivsk&yddad"
+
+#: tfrmattributesedit.cbsgid.caption
+msgctxt "tfrmattributesedit.cbsgid.caption"
+msgid "SGID"
+msgstr "SGID"
+
+#: tfrmattributesedit.cbsparse.caption
+msgid "S&parse"
+msgstr "G&les"
+
+#: tfrmattributesedit.cbsticky.caption
+msgctxt "tfrmattributesedit.cbsticky.caption"
+msgid "Sticky"
+msgstr "Sticky"
+
+#: tfrmattributesedit.cbsuid.caption
+msgctxt "tfrmattributesedit.cbsuid.caption"
+msgid "SUID"
+msgstr "SUID"
+
+#: tfrmattributesedit.cbsymlink.caption
+msgid "&Symlink"
+msgstr "&Symbolisk länk"
+
+#: tfrmattributesedit.cbsystem.caption
+msgid "S&ystem"
+msgstr "S&ystem"
+
+#: tfrmattributesedit.cbtemporary.caption
+msgid "&Temporary"
+msgstr "&Tillfällig"
+
+#: tfrmattributesedit.gbntfsattributes.caption
+msgid "NTFS attributes"
+msgstr "NTFS-attribut"
+
+#: tfrmattributesedit.gbwingeneral.caption
+msgid "General attributes"
+msgstr "Allmänna attribut"
+
+#: tfrmattributesedit.lblattrbitsstr.caption
+msgctxt "tfrmattributesedit.lblattrbitsstr.caption"
+msgid "Bits:"
+msgstr "Bitar:"
+
+#: tfrmattributesedit.lblattrgroupstr.caption
+msgctxt "tfrmattributesedit.lblattrgroupstr.caption"
+msgid "Group"
+msgstr "Grupp"
+
+#: tfrmattributesedit.lblattrotherstr.caption
+msgctxt "tfrmattributesedit.lblattrotherstr.caption"
+msgid "Other"
+msgstr "Övriga"
+
+#: tfrmattributesedit.lblattrownerstr.caption
+msgctxt "tfrmattributesedit.lblattrownerstr.caption"
+msgid "Owner"
+msgstr "Ägare"
+
+#: tfrmattributesedit.lblexec.caption
+msgctxt "tfrmattributesedit.lblexec.caption"
+msgid "Execute"
+msgstr "Kör"
+
+#: tfrmattributesedit.lblread.caption
+msgctxt "tfrmattributesedit.lblread.caption"
+msgid "Read"
+msgstr "Läs"
+
+#: tfrmattributesedit.lbltextattrs.caption
+msgid "As te&xt:"
+msgstr "Som te&xt:"
+
+#: tfrmattributesedit.lblwrite.caption
+msgctxt "tfrmattributesedit.lblwrite.caption"
+msgid "Write"
+msgstr "Skriv"
+
+#: tfrmbenchmark.caption
+msgid "Benchmark"
+msgstr "Prestandatest"
+
+#: tfrmbenchmark.lblbenchmarksize.caption
+#, object-pascal-format
+msgid "Benchmark data size: %d MB"
+msgstr "Datastorlek för prestandatest: %d MB"
+
+#: tfrmbenchmark.stgresult.columns[0].title.caption
+msgid "Hash"
+msgstr "Hash"
+
+#: tfrmbenchmark.stgresult.columns[1].title.caption
+msgid "Time (ms)"
+msgstr "Tid (ms)"
+
+#: tfrmbenchmark.stgresult.columns[2].title.caption
+msgid "Speed (MB/s)"
+msgstr "Hastighet (MB/s)"
+
+#: tfrmchecksumcalc.caption
+msgctxt "tfrmchecksumcalc.caption"
+msgid "Calculate checksum..."
+msgstr "Beräkna kontrollsumma..."
+
+#: tfrmchecksumcalc.cbopenafterjobiscomplete.caption
+msgid "Open checksum file after job is completed"
+msgstr "Öppna kontrollsummefilen när jobbet är slutfört"
+
+#: tfrmchecksumcalc.cbseparatefile.caption
+msgid "C&reate separate checksum file for each file"
+msgstr "Skapa separat kontrollsummefil för varje &fil"
+
+#: tfrmchecksumcalc.cbseparatefolder.caption
+msgid "Create separate checksum file for each &directory"
+msgstr "Skapa separat kontrollsummefil för varje &katalog"
+
+#: tfrmchecksumcalc.lblfileformat.caption
+msgid "File &format"
+msgstr "Fil&format"
+
+#: tfrmchecksumcalc.lblsaveto.caption
+msgid "&Save checksum file(s) to:"
+msgstr "&Spara kontrollsummefil(er) i:"
+
+#: tfrmchecksumcalc.rbunix.caption
+msgid "Unix"
+msgstr "Unix"
+
+#: tfrmchecksumcalc.rbwindows.caption
+msgid "Windows"
+msgstr "Windows"
+
+#: tfrmchecksumcalc.rghashalgorithm.caption
+msgid "Algorithm"
+msgstr "Algoritm"
+
+#: tfrmchecksumverify.btnclose.caption
+msgctxt "TFRMCHECKSUMVERIFY.BTNCLOSE.CAPTION"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmchecksumverify.caption
+msgctxt "tfrmchecksumverify.caption"
+msgid "Verify checksum..."
+msgstr "Verifiera kontrollsumma..."
+
+#: tfrmchooseencoding.caption
+msgctxt "tfrmchooseencoding.caption"
+msgid "Encoding"
+msgstr "Kodning"
+
+#: tfrmconnectionmanager.btnadd.caption
+msgctxt "tfrmconnectionmanager.btnadd.caption"
+msgid "A&dd"
+msgstr "Lä&gg till"
+
+#: tfrmconnectionmanager.btncancel.caption
+msgctxt "TFRMCONNECTIONMANAGER.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmconnectionmanager.btnconnect.caption
+msgid "C&onnect"
+msgstr "A&nslut"
+
+#: tfrmconnectionmanager.btndelete.caption
+msgctxt "tfrmconnectionmanager.btndelete.caption"
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: tfrmconnectionmanager.btnedit.caption
+msgctxt "tfrmconnectionmanager.btnedit.caption"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmconnectionmanager.caption
+msgid "Connection manager"
+msgstr "Anslutningshanterare"
+
+#: tfrmconnectionmanager.gbconnectto.caption
+msgid "Connect to:"
+msgstr "Anslut till:"
+
+#: tfrmcopydlg.btnaddtoqueue.caption
+msgid "A&dd To Queue"
+msgstr "Lägg till i &kö"
+
+#: tfrmcopydlg.btncancel.caption
+msgctxt "TFRMCOPYDLG.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmcopydlg.btnoptions.caption
+msgid "O&ptions"
+msgstr "A&lternativ"
+
+#: tfrmcopydlg.btnsaveoptions.caption
+msgid "Sa&ve these options as default"
+msgstr "S&para dessa alternativ som standard"
+
+#: tfrmcopydlg.caption
+msgctxt "tfrmcopydlg.caption"
+msgid "Copy file(s)"
+msgstr "Kopiera fil(er)"
+
+#: tfrmcopydlg.mnunewqueue.caption
+msgctxt "tfrmcopydlg.mnunewqueue.caption"
+msgid "New queue"
+msgstr "Ny kö"
+
+#: tfrmcopydlg.mnuqueue1.caption
+msgctxt "tfrmcopydlg.mnuqueue1.caption"
+msgid "Queue 1"
+msgstr "Kö 1"
+
+#: tfrmcopydlg.mnuqueue2.caption
+msgctxt "tfrmcopydlg.mnuqueue2.caption"
+msgid "Queue 2"
+msgstr "Kö 2"
+
+#: tfrmcopydlg.mnuqueue3.caption
+msgctxt "tfrmcopydlg.mnuqueue3.caption"
+msgid "Queue 3"
+msgstr "Kö 3"
+
+#: tfrmcopydlg.mnuqueue4.caption
+msgctxt "tfrmcopydlg.mnuqueue4.caption"
+msgid "Queue 4"
+msgstr "Kö 4"
+
+#: tfrmcopydlg.mnuqueue5.caption
+msgctxt "tfrmcopydlg.mnuqueue5.caption"
+msgid "Queue 5"
+msgstr "Kö 5"
+
+#: tfrmdescredit.actsavedescription.caption
+msgid "Save Description"
+msgstr "Spara beskrivning"
+
+#: tfrmdescredit.btncancel.caption
+msgctxt "TFRMDESCREDIT.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmdescredit.btnok.caption
+msgctxt "TFRMDESCREDIT.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmdescredit.caption
+msgid "File/folder comment"
+msgstr "Fil-/mappkommentar"
+
+#: tfrmdescredit.lbleditcommentfor.caption
+msgid "E&dit comment for:"
+msgstr "R&edigera kommentar för:"
+
+#: tfrmdescredit.lblencoding.caption
+msgid "&Encoding:"
+msgstr "&Kodning:"
+
+#: tfrmdescredit.lblfilename.caption
+msgctxt "tfrmdescredit.lblfilename.caption"
+msgid "???"
+msgstr "???"
+
+#: tfrmdiffer.actabout.caption
+msgctxt "TFRMDIFFER.ACTABOUT.CAPTION"
+msgid "About"
+msgstr "Om"
+
+#: tfrmdiffer.actautocompare.caption
+msgid "Auto Compare"
+msgstr "Jämför automatiskt"
+
+#: tfrmdiffer.actbinarycompare.caption
+msgctxt "tfrmdiffer.actbinarycompare.caption"
+msgid "Binary Mode"
+msgstr "Binärt läge"
+
+#: tfrmdiffer.actcancelcompare.caption
+msgctxt "tfrmdiffer.actcancelcompare.caption"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmdiffer.actcancelcompare.hint
+msgctxt "TFRMDIFFER.ACTCANCELCOMPARE.HINT"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmdiffer.actcopylefttoright.caption
+msgctxt "tfrmdiffer.actcopylefttoright.caption"
+msgid "Copy Block To Right"
+msgstr "Kopiera block åt höger"
+
+#: tfrmdiffer.actcopylefttoright.hint
+msgctxt "TFRMDIFFER.ACTCOPYLEFTTORIGHT.HINT"
+msgid "Copy Block From Left To Right"
+msgstr "Kopiera block från vänster till höger"
+
+#: tfrmdiffer.actcopyrighttoleft.caption
+msgctxt "tfrmdiffer.actcopyrighttoleft.caption"
+msgid "Copy Block To Left"
+msgstr "Kopiera block åt vänster"
+
+#: tfrmdiffer.actcopyrighttoleft.hint
+msgctxt "TFRMDIFFER.ACTCOPYRIGHTTOLEFT.HINT"
+msgid "Copy Block From Right To Left"
+msgstr "Kopiera block från höger till vänster"
+
+#: tfrmdiffer.acteditcopy.caption
+msgctxt "tfrmdiffer.acteditcopy.caption"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmdiffer.acteditcut.caption
+msgctxt "tfrmdiffer.acteditcut.caption"
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: tfrmdiffer.acteditdelete.caption
+msgctxt "tfrmdiffer.acteditdelete.caption"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmdiffer.acteditpaste.caption
+msgctxt "tfrmdiffer.acteditpaste.caption"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: tfrmdiffer.acteditredo.caption
+msgctxt "tfrmdiffer.acteditredo.caption"
+msgid "Redo"
+msgstr "Gör om"
+
+#: tfrmdiffer.acteditredo.hint
+msgctxt "tfrmdiffer.acteditredo.hint"
+msgid "Redo"
+msgstr "Gör om"
+
+#: tfrmdiffer.acteditselectall.caption
+msgid "Select &All"
+msgstr "Markera &allt"
+
+#: tfrmdiffer.acteditundo.caption
+msgctxt "tfrmdiffer.acteditundo.caption"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmdiffer.acteditundo.hint
+msgctxt "tfrmdiffer.acteditundo.hint"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmdiffer.actexit.caption
+msgctxt "tfrmdiffer.actexit.caption"
+msgid "E&xit"
+msgstr "A&vsluta"
+
+#: tfrmdiffer.actfind.caption
+msgctxt "tfrmdiffer.actfind.caption"
+msgid "&Find"
+msgstr "&Sök"
+
+#: tfrmdiffer.actfind.hint
+msgctxt "tfrmdiffer.actfind.hint"
+msgid "Find"
+msgstr "Sök"
+
+#: tfrmdiffer.actfindnext.caption
+msgctxt "tfrmdiffer.actfindnext.caption"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: tfrmdiffer.actfindnext.hint
+msgctxt "tfrmdiffer.actfindnext.hint"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: tfrmdiffer.actfindprev.caption
+msgctxt "tfrmdiffer.actfindprev.caption"
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: tfrmdiffer.actfindprev.hint
+msgctxt "tfrmdiffer.actfindprev.hint"
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: tfrmdiffer.actfindreplace.caption
+msgctxt "tfrmdiffer.actfindreplace.caption"
+msgid "&Replace"
+msgstr "&Ersätt"
+
+#: tfrmdiffer.actfindreplace.hint
+msgctxt "tfrmdiffer.actfindreplace.hint"
+msgid "Replace"
+msgstr "Ersätt"
+
+#: tfrmdiffer.actfirstdifference.caption
+msgctxt "tfrmdiffer.actfirstdifference.caption"
+msgid "First Difference"
+msgstr "Första skillnaden"
+
+#: tfrmdiffer.actfirstdifference.hint
+msgctxt "TFRMDIFFER.ACTFIRSTDIFFERENCE.HINT"
+msgid "First Difference"
+msgstr "Första skillnaden"
+
+#: tfrmdiffer.actgotoline.caption
+msgctxt "tfrmdiffer.actgotoline.caption"
+msgid "Goto Line..."
+msgstr "Gå till rad..."
+
+#: tfrmdiffer.actgotoline.hint
+msgctxt "tfrmdiffer.actgotoline.hint"
+msgid "Goto Line"
+msgstr "Gå till rad"
+
+#: tfrmdiffer.actignorecase.caption
+msgid "Ignore Case"
+msgstr "Ignorera skiftläge"
+
+#: tfrmdiffer.actignorewhitespace.caption
+msgid "Ignore Blanks"
+msgstr "Ignorera blanktecken"
+
+#: tfrmdiffer.actkeepscrolling.caption
+msgid "Keep Scrolling"
+msgstr "Synkroniserad rullning"
+
+#: tfrmdiffer.actlastdifference.caption
+msgctxt "tfrmdiffer.actlastdifference.caption"
+msgid "Last Difference"
+msgstr "Sista skillnaden"
+
+#: tfrmdiffer.actlastdifference.hint
+msgctxt "TFRMDIFFER.ACTLASTDIFFERENCE.HINT"
+msgid "Last Difference"
+msgstr "Sista skillnaden"
+
+#: tfrmdiffer.actlinedifferences.caption
+msgid "Line Differences"
+msgstr "Radskillnader"
+
+#: tfrmdiffer.actnextdifference.caption
+msgctxt "tfrmdiffer.actnextdifference.caption"
+msgid "Next Difference"
+msgstr "Nästa skillnad"
+
+#: tfrmdiffer.actnextdifference.hint
+msgctxt "TFRMDIFFER.ACTNEXTDIFFERENCE.HINT"
+msgid "Next Difference"
+msgstr "Nästa skillnad"
+
+#: tfrmdiffer.actopenleft.caption
+msgid "Open Left..."
+msgstr "Öppna vänster..."
+
+#: tfrmdiffer.actopenright.caption
+msgid "Open Right..."
+msgstr "Öppna höger..."
+
+#: tfrmdiffer.actpaintbackground.caption
+msgid "Paint Background"
+msgstr "Färga bakgrunden"
+
+#: tfrmdiffer.actprevdifference.caption
+msgctxt "tfrmdiffer.actprevdifference.caption"
+msgid "Previous Difference"
+msgstr "Föregående skillnad"
+
+#: tfrmdiffer.actprevdifference.hint
+msgctxt "TFRMDIFFER.ACTPREVDIFFERENCE.HINT"
+msgid "Previous Difference"
+msgstr "Föregående skillnad"
+
+#: tfrmdiffer.actreload.caption
+msgid "&Reload"
+msgstr "&Läs om"
+
+#: tfrmdiffer.actreload.hint
+msgctxt "tfrmdiffer.actreload.hint"
+msgid "Reload"
+msgstr "Läs om"
+
+#: tfrmdiffer.actsave.caption
+msgctxt "tfrmdiffer.actsave.caption"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmdiffer.actsave.hint
+msgctxt "TFRMDIFFER.ACTSAVE.HINT"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmdiffer.actsaveas.caption
+msgctxt "tfrmdiffer.actsaveas.caption"
+msgid "Save as..."
+msgstr "Spara som..."
+
+#: tfrmdiffer.actsaveas.hint
+msgctxt "TFRMDIFFER.ACTSAVEAS.HINT"
+msgid "Save as..."
+msgstr "Spara som..."
+
+#: tfrmdiffer.actsaveleft.caption
+msgctxt "tfrmdiffer.actsaveleft.caption"
+msgid "Save Left"
+msgstr "Spara vänster"
+
+#: tfrmdiffer.actsaveleft.hint
+msgctxt "TFRMDIFFER.ACTSAVELEFT.HINT"
+msgid "Save Left"
+msgstr "Spara vänster"
+
+#: tfrmdiffer.actsaveleftas.caption
+msgctxt "tfrmdiffer.actsaveleftas.caption"
+msgid "Save Left As..."
+msgstr "Spara vänster som..."
+
+#: tfrmdiffer.actsaveleftas.hint
+msgctxt "TFRMDIFFER.ACTSAVELEFTAS.HINT"
+msgid "Save Left As..."
+msgstr "Spara vänster som..."
+
+#: tfrmdiffer.actsaveright.caption
+msgctxt "tfrmdiffer.actsaveright.caption"
+msgid "Save Right"
+msgstr "Spara höger"
+
+#: tfrmdiffer.actsaveright.hint
+msgctxt "TFRMDIFFER.ACTSAVERIGHT.HINT"
+msgid "Save Right"
+msgstr "Spara höger"
+
+#: tfrmdiffer.actsaverightas.caption
+msgctxt "tfrmdiffer.actsaverightas.caption"
+msgid "Save Right As..."
+msgstr "Spara höger som..."
+
+#: tfrmdiffer.actsaverightas.hint
+msgctxt "TFRMDIFFER.ACTSAVERIGHTAS.HINT"
+msgid "Save Right As..."
+msgstr "Spara höger som..."
+
+#: tfrmdiffer.actstartcompare.caption
+msgctxt "tfrmdiffer.actstartcompare.caption"
+msgid "Compare"
+msgstr "Jämför"
+
+#: tfrmdiffer.actstartcompare.hint
+msgctxt "TFRMDIFFER.ACTSTARTCOMPARE.HINT"
+msgid "Compare"
+msgstr "Jämför"
+
+#: tfrmdiffer.btnleftencoding.hint
+msgctxt "tfrmdiffer.btnleftencoding.hint"
+msgid "Encoding"
+msgstr "Kodning"
+
+#: tfrmdiffer.btnrightencoding.hint
+msgctxt "TFRMDIFFER.BTNRIGHTENCODING.HINT"
+msgid "Encoding"
+msgstr "Kodning"
+
+#: tfrmdiffer.caption
+msgid "Compare files"
+msgstr "Jämför filer"
+
+#: tfrmdiffer.miencodingleft.caption
+msgid "&Left"
+msgstr "&Vänster"
+
+#: tfrmdiffer.miencodingright.caption
+msgid "&Right"
+msgstr "&Höger"
+
+#: tfrmdiffer.mnuactions.caption
+msgid "&Actions"
+msgstr "&Åtgärder"
+
+#: tfrmdiffer.mnuedit.caption
+msgctxt "TFRMDIFFER.MNUEDIT.CAPTION"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmdiffer.mnuencoding.caption
+msgctxt "tfrmdiffer.mnuencoding.caption"
+msgid "En&coding"
+msgstr "Ko&dning"
+
+#: tfrmdiffer.mnufile.caption
+msgctxt "tfrmdiffer.mnufile.caption"
+msgid "&File"
+msgstr "&Fil"
+
+#: tfrmdiffer.mnuoptions.caption
+msgid "&Options"
+msgstr "&Alternativ"
+
+#: tfrmedithotkey.btnaddshortcut.hint
+msgid "Add new shortcut to sequence"
+msgstr "Lägg till nytt kortkommando i sekvensen"
+
+#: tfrmedithotkey.btncancel.caption
+msgctxt "TFRMEDITHOTKEY.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmedithotkey.btnok.caption
+msgctxt "TFRMEDITHOTKEY.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmedithotkey.btnremoveshortcut.hint
+msgid "Remove last shortcut from sequence"
+msgstr "Ta bort det sista kortkommandot från sekvensen"
+
+#: tfrmedithotkey.btnselectfromlist.hint
+msgid "Select shortcut from list of remaining free available keys"
+msgstr "Välj kortkommando från listan över återstående lediga tangenter"
+
+#: tfrmedithotkey.cghkcontrols.caption
+msgid "Only for these controls"
+msgstr "Endast för dessa kontroller"
+
+#: tfrmedithotkey.lblparameters.caption
+msgid "&Parameters (each in a separate line):"
+msgstr "&Parametrar (en per rad):"
+
+#: tfrmedithotkey.lblshortcuts.caption
+msgid "Shortcuts:"
+msgstr "Kortkommandon:"
+
+#: tfrmeditor.actabout.caption
+msgctxt "TFRMEDITOR.ACTABOUT.CAPTION"
+msgid "About"
+msgstr "Om"
+
+#: tfrmeditor.actabout.hint
+msgctxt "TFRMEDITOR.ACTABOUT.HINT"
+msgid "About"
+msgstr "Om"
+
+#: tfrmeditor.actconfhigh.caption
+msgid "&Configuration"
+msgstr "&Inställningar"
+
+#: tfrmeditor.actconfhigh.hint
+msgctxt "tfrmeditor.actconfhigh.hint"
+msgid "Configuration"
+msgstr "Inställningar"
+
+#: tfrmeditor.acteditcopy.caption
+msgctxt "TFRMEDITOR.ACTEDITCOPY.CAPTION"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmeditor.acteditcopy.hint
+msgctxt "TFRMEDITOR.ACTEDITCOPY.HINT"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmeditor.acteditcut.caption
+msgctxt "TFRMEDITOR.ACTEDITCUT.CAPTION"
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: tfrmeditor.acteditcut.hint
+msgctxt "TFRMEDITOR.ACTEDITCUT.HINT"
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: tfrmeditor.acteditdelete.caption
+msgctxt "TFRMEDITOR.ACTEDITDELETE.CAPTION"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmeditor.acteditdelete.hint
+msgctxt "TFRMEDITOR.ACTEDITDELETE.HINT"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmeditor.acteditfind.caption
+msgctxt "tfrmeditor.acteditfind.caption"
+msgid "&Find"
+msgstr "&Sök"
+
+#: tfrmeditor.acteditfind.hint
+msgctxt "tfrmeditor.acteditfind.hint"
+msgid "Find"
+msgstr "Sök"
+
+#: tfrmeditor.acteditfindnext.caption
+msgctxt "tfrmeditor.acteditfindnext.caption"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: tfrmeditor.acteditfindnext.hint
+msgctxt "TFRMEDITOR.ACTEDITFINDNEXT.HINT"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: tfrmeditor.acteditfindprevious.caption
+msgctxt "tfrmeditor.acteditfindprevious.caption"
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: tfrmeditor.acteditgotoline.caption
+msgctxt "tfrmeditor.acteditgotoline.caption"
+msgid "Goto Line..."
+msgstr "Gå till rad..."
+
+#: tfrmeditor.acteditlineendcr.caption
+msgctxt "tfrmeditor.acteditlineendcr.caption"
+msgid "Mac (CR)"
+msgstr "Mac (CR)"
+
+#: tfrmeditor.acteditlineendcr.hint
+msgctxt "TFRMEDITOR.ACTEDITLINEENDCR.HINT"
+msgid "Mac (CR)"
+msgstr "Mac (CR)"
+
+#: tfrmeditor.acteditlineendcrlf.caption
+msgctxt "tfrmeditor.acteditlineendcrlf.caption"
+msgid "Windows (CRLF)"
+msgstr "Windows (CRLF)"
+
+#: tfrmeditor.acteditlineendcrlf.hint
+msgctxt "TFRMEDITOR.ACTEDITLINEENDCRLF.HINT"
+msgid "Windows (CRLF)"
+msgstr "Windows (CRLF)"
+
+#: tfrmeditor.acteditlineendlf.caption
+msgctxt "tfrmeditor.acteditlineendlf.caption"
+msgid "Unix (LF)"
+msgstr "Unix (LF)"
+
+#: tfrmeditor.acteditlineendlf.hint
+msgctxt "TFRMEDITOR.ACTEDITLINEENDLF.HINT"
+msgid "Unix (LF)"
+msgstr "Unix (LF)"
+
+#: tfrmeditor.acteditpaste.caption
+msgctxt "TFRMEDITOR.ACTEDITPASTE.CAPTION"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: tfrmeditor.acteditpaste.hint
+msgctxt "TFRMEDITOR.ACTEDITPASTE.HINT"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: tfrmeditor.acteditredo.caption
+msgctxt "TFRMEDITOR.ACTEDITREDO.CAPTION"
+msgid "Redo"
+msgstr "Gör om"
+
+#: tfrmeditor.acteditredo.hint
+msgctxt "TFRMEDITOR.ACTEDITREDO.HINT"
+msgid "Redo"
+msgstr "Gör om"
+
+#: tfrmeditor.acteditrplc.caption
+msgctxt "tfrmeditor.acteditrplc.caption"
+msgid "&Replace"
+msgstr "&Ersätt"
+
+#: tfrmeditor.acteditrplc.hint
+msgctxt "tfrmeditor.acteditrplc.hint"
+msgid "Replace"
+msgstr "Ersätt"
+
+#: tfrmeditor.acteditselectall.caption
+msgid "Select&All"
+msgstr "Markera &allt"
+
+#: tfrmeditor.acteditselectall.hint
+msgctxt "tfrmeditor.acteditselectall.hint"
+msgid "Select All"
+msgstr "Markera allt"
+
+#: tfrmeditor.actedittimedate.caption
+msgid "Time/Date"
+msgstr "Tid/datum"
+
+#: tfrmeditor.acteditundo.caption
+msgctxt "TFRMEDITOR.ACTEDITUNDO.CAPTION"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmeditor.acteditundo.hint
+msgctxt "TFRMEDITOR.ACTEDITUNDO.HINT"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmeditor.actfileclose.caption
+msgctxt "TFRMEDITOR.ACTFILECLOSE.CAPTION"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmeditor.actfileclose.hint
+msgctxt "tfrmeditor.actfileclose.hint"
+msgid "Close"
+msgstr "Stäng"
+
+#: tfrmeditor.actfileexit.caption
+msgctxt "TFRMEDITOR.ACTFILEEXIT.CAPTION"
+msgid "E&xit"
+msgstr "A&vsluta"
+
+#: tfrmeditor.actfileexit.hint
+msgctxt "tfrmeditor.actfileexit.hint"
+msgid "Exit"
+msgstr "Avsluta"
+
+#: tfrmeditor.actfilenew.caption
+msgid "&New"
+msgstr "&Ny"
+
+#: tfrmeditor.actfilenew.hint
+msgctxt "tfrmeditor.actfilenew.hint"
+msgid "New"
+msgstr "Ny"
+
+#: tfrmeditor.actfileopen.caption
+msgid "&Open"
+msgstr "&Öppna"
+
+#: tfrmeditor.actfileopen.hint
+msgctxt "tfrmeditor.actfileopen.hint"
+msgid "Open"
+msgstr "Öppna"
+
+#: tfrmeditor.actfilereload.caption
+msgctxt "tfrmeditor.actfilereload.caption"
+msgid "Reload"
+msgstr "Läs om"
+
+#: tfrmeditor.actfilesave.caption
+msgctxt "tfrmeditor.actfilesave.caption"
+msgid "&Save"
+msgstr "&Spara"
+
+#: tfrmeditor.actfilesave.hint
+msgctxt "TFRMEDITOR.ACTFILESAVE.HINT"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmeditor.actfilesaveas.caption
+msgid "Save &As..."
+msgstr "Spara s&om..."
+
+#: tfrmeditor.actfilesaveas.hint
+msgid "Save As"
+msgstr "Spara som"
+
+#: tfrmeditor.actwordwrap.caption
+msgid "&Word wrap"
+msgstr "&Radbrytning"
+
+#: tfrmeditor.actzoomin.caption
+msgctxt "tfrmeditor.actzoomin.caption"
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: tfrmeditor.actzoomout.caption
+msgctxt "tfrmeditor.actzoomout.caption"
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: tfrmeditor.caption
+msgctxt "tfrmeditor.caption"
+msgid "Editor"
+msgstr "Redigerare"
+
+#: tfrmeditor.help1.caption
+msgctxt "tfrmeditor.help1.caption"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmeditor.miedit.caption
+msgctxt "TFRMEDITOR.MIEDIT.CAPTION"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmeditor.miencoding.caption
+msgctxt "TFRMEDITOR.MIENCODING.CAPTION"
+msgid "En&coding"
+msgstr "Ko&dning"
+
+#: tfrmeditor.miencodingin.caption
+msgid "Open as"
+msgstr "Öppna som"
+
+#: tfrmeditor.miencodingout.caption
+msgctxt "tfrmeditor.miencodingout.caption"
+msgid "Save as"
+msgstr "Spara som"
+
+#: tfrmeditor.mifile.caption
+msgctxt "TFRMEDITOR.MIFILE.CAPTION"
+msgid "&File"
+msgstr "&Fil"
+
+#: tfrmeditor.mihighlight.caption
+msgid "Syntax highlight"
+msgstr "Syntaxmarkering"
+
+#: tfrmeditor.milineendtype.caption
+msgid "End Of Line"
+msgstr "Radslut"
+
+#: tfrmeditor.miview.caption
+msgctxt "tfrmeditor.miview.caption"
+msgid "&View"
+msgstr "&Visa"
+
+#: tfrmeditsearchreplace.buttonpanel.cancelbutton.caption
+msgctxt "TFRMEDITSEARCHREPLACE.BUTTONPANEL.CANCELBUTTON.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmeditsearchreplace.buttonpanel.okbutton.caption
+msgctxt "TFRMEDITSEARCHREPLACE.BUTTONPANEL.OKBUTTON.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmeditsearchreplace.cbmultiline.caption
+msgid "&Multiline pattern"
+msgstr "&Flerradsmönster"
+
+#: tfrmeditsearchreplace.cbsearchcasesensitive.caption
+msgid "C&ase sensitivity"
+msgstr "S&kiftlägeskänslig"
+
+#: tfrmeditsearchreplace.cbsearchfromcursor.caption
+msgid "S&earch from caret"
+msgstr "Sök från &markören"
+
+#: tfrmeditsearchreplace.cbsearchregexp.caption
+msgctxt "tfrmeditsearchreplace.cbsearchregexp.caption"
+msgid "&Regular expressions"
+msgstr "&Reguljära uttryck"
+
+#: tfrmeditsearchreplace.cbsearchselectedonly.caption
+msgid "Selected &text only"
+msgstr "Endast markerad &text"
+
+#: tfrmeditsearchreplace.cbsearchwholewords.caption
+msgid "&Whole words only"
+msgstr "Endast &hela ord"
+
+#: tfrmeditsearchreplace.gbsearchoptions.caption
+msgid "Option"
+msgstr "Alternativ"
+
+#: tfrmeditsearchreplace.lblreplacewith.caption
+msgid "&Replace with:"
+msgstr "&Ersätt med:"
+
+#: tfrmeditsearchreplace.lblsearchfor.caption
+msgid "&Search for:"
+msgstr "&Sök efter:"
+
+#: tfrmeditsearchreplace.rgsearchdirection.caption
+msgid "Direction"
+msgstr "Riktning"
+
+#: tfrmelevation.chkelevateall.caption
+msgid "Do this for &all current objects"
+msgstr "Gör detta för &alla aktuella objekt"
+
+#: tfrmextractdlg.caption
+msgid "Unpack files"
+msgstr "Packa upp filer"
+
+#: tfrmextractdlg.cbextractpath.caption
+msgid "&Unpack path names if stored with files"
+msgstr "Packa upp &sökvägar om de är lagrade med filerna"
+
+#: tfrmextractdlg.cbfilemask.text
+msgctxt "tfrmextractdlg.cbfilemask.text"
+msgid "*.*"
+msgstr "*.*"
+
+#: tfrmextractdlg.cbinseparatefolder.caption
+msgid "Unpack each archive to a &separate subdir (name of the archive)"
+msgstr "Packa upp varje arkiv till en &separat underkatalog (med arkivets namn)"
+
+#: tfrmextractdlg.cboverwrite.caption
+msgid "O&verwrite existing files"
+msgstr "Skriv &över befintliga filer"
+
+#: tfrmextractdlg.lblextractto.caption
+msgid "To the &directory:"
+msgstr "Till &katalogen:"
+
+#: tfrmextractdlg.lblfilemask.caption
+msgid "&Extract files matching file mask:"
+msgstr "&Packa upp filer som matchar filmasken:"
+
+#: tfrmextractdlg.lblpassword.caption
+msgid "&Password for encrypted files:"
+msgstr "&Lösenord för krypterade filer:"
+
+#: tfrmfileexecuteyourself.btnclose.caption
+msgctxt "TFRMFILEEXECUTEYOURSELF.BTNCLOSE.CAPTION"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmfileexecuteyourself.caption
+msgid "Wait..."
+msgstr "Vänta..."
+
+#: tfrmfileexecuteyourself.lblfilename.caption
+msgid "File name:"
+msgstr "Filnamn:"
+
+#: tfrmfileexecuteyourself.lblfrompath.caption
+msgctxt "tfrmfileexecuteyourself.lblfrompath.caption"
+msgid "From:"
+msgstr "Från:"
+
+#: tfrmfileexecuteyourself.lblprompt.caption
+msgid "Click on Close when the temporary file can be deleted!"
+msgstr "Klicka på Stäng när den tillfälliga filen kan tas bort!"
+
+#: tfrmfileop.btncancel.caption
+msgctxt "TFRMFILEOP.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmfileop.btnminimizetopanel.caption
+msgid "&To panel"
+msgstr "&Till panel"
+
+#: tfrmfileop.btnviewoperations.caption
+msgid "&View all"
+msgstr "&Visa alla"
+
+#: tfrmfileop.lblcurrentoperation.caption
+msgid "Current operation:"
+msgstr "Aktuell åtgärd:"
+
+#: tfrmfileop.lblfrom.caption
+msgctxt "TFRMFILEOP.LBLFROM.CAPTION"
+msgid "From:"
+msgstr "Från:"
+
+#: tfrmfileop.lblto.caption
+msgid "To:"
+msgstr "Till:"
+
+#: tfrmfileproperties.caption
+msgctxt "tfrmfileproperties.caption"
+msgid "Properties"
+msgstr "Egenskaper"
+
+#: tfrmfileproperties.cbsgid.caption
+msgctxt "TFRMFILEPROPERTIES.CBSGID.CAPTION"
+msgid "SGID"
+msgstr "SGID"
+
+#: tfrmfileproperties.cbsticky.caption
+msgctxt "TFRMFILEPROPERTIES.CBSTICKY.CAPTION"
+msgid "Sticky"
+msgstr "Sticky"
+
+#: tfrmfileproperties.cbsuid.caption
+msgctxt "TFRMFILEPROPERTIES.CBSUID.CAPTION"
+msgid "SUID"
+msgstr "SUID"
+
+#: tfrmfileproperties.chkexecutable.caption
+msgid "Allow &executing file as program"
+msgstr "Tillåt att filen &körs som program"
+
+#: tfrmfileproperties.chkrecursive.caption
+msgid "&Recursive"
+msgstr "&Rekursivt"
+
+#: tfrmfileproperties.dividerbevel3.caption
+msgctxt "TFRMFILEPROPERTIES.DIVIDERBEVEL3.CAPTION"
+msgid "Owner"
+msgstr "Ägare"
+
+#: tfrmfileproperties.lblattrbitsstr.caption
+msgctxt "TFRMFILEPROPERTIES.LBLATTRBITSSTR.CAPTION"
+msgid "Bits:"
+msgstr "Bitar:"
+
+#: tfrmfileproperties.lblattrgroupstr.caption
+msgctxt "TFRMFILEPROPERTIES.LBLATTRGROUPSTR.CAPTION"
+msgid "Group"
+msgstr "Grupp"
+
+#: tfrmfileproperties.lblattrotherstr.caption
+msgctxt "TFRMFILEPROPERTIES.LBLATTROTHERSTR.CAPTION"
+msgid "Other"
+msgstr "Övriga"
+
+#: tfrmfileproperties.lblattrownerstr.caption
+msgctxt "TFRMFILEPROPERTIES.LBLATTROWNERSTR.CAPTION"
+msgid "Owner"
+msgstr "Ägare"
+
+#: tfrmfileproperties.lblattrtext.caption
+msgctxt "tfrmfileproperties.lblattrtext.caption"
+msgid "-----------"
+msgstr "-----------"
+
+#: tfrmfileproperties.lblattrtextstr.caption
+msgctxt "tfrmfileproperties.lblattrtextstr.caption"
+msgid "Text:"
+msgstr "Text:"
+
+#: tfrmfileproperties.lblcontainsstr.caption
+msgid "Contains:"
+msgstr "Innehåller:"
+
+#: tfrmfileproperties.lblcreatedstr.caption
+msgctxt "tfrmfileproperties.lblcreatedstr.caption"
+msgid "Created:"
+msgstr "Skapad:"
+
+#: tfrmfileproperties.lblexec.caption
+msgctxt "TFRMFILEPROPERTIES.LBLEXEC.CAPTION"
+msgid "Execute"
+msgstr "Kör"
+
+#: tfrmfileproperties.lblexecutable.caption
+msgid "Execute:"
+msgstr "Kör:"
+
+#: tfrmfileproperties.lblfile.caption
+msgctxt "TFRMFILEPROPERTIES.LBLFILE.CAPTION"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmfileproperties.lblfilename.caption
+msgctxt "TFRMFILEPROPERTIES.LBLFILENAME.CAPTION"
+msgid "???"
+msgstr "???"
+
+#: tfrmfileproperties.lblfilestr.caption
+msgctxt "tfrmfileproperties.lblfilestr.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmfileproperties.lblfolderstr.caption
+msgctxt "tfrmfileproperties.lblfolderstr.caption"
+msgid "Path:"
+msgstr "Sökväg:"
+
+#: tfrmfileproperties.lblgroupstr.caption
+msgid "&Group"
+msgstr "&Grupp"
+
+#: tfrmfileproperties.lbllastaccessstr.caption
+msgctxt "tfrmfileproperties.lbllastaccessstr.caption"
+msgid "Accessed:"
+msgstr "Åtkommen:"
+
+#: tfrmfileproperties.lbllastmodifstr.caption
+msgctxt "tfrmfileproperties.lbllastmodifstr.caption"
+msgid "Modified:"
+msgstr "Ändrad:"
+
+#: tfrmfileproperties.lbllaststchangestr.caption
+msgid "Status changed:"
+msgstr "Status ändrad:"
+
+#: tfrmfileproperties.lbllinksstr.caption
+msgid "Links:"
+msgstr "Länkar:"
+
+#: tfrmfileproperties.lblmediatypestr.caption
+msgid "Media type:"
+msgstr "Medietyp:"
+
+#: tfrmfileproperties.lbloctal.caption
+msgctxt "tfrmfileproperties.lbloctal.caption"
+msgid "Octal:"
+msgstr "Oktalt:"
+
+#: tfrmfileproperties.lblownerstr.caption
+msgid "O&wner"
+msgstr "Ä&gare"
+
+#: tfrmfileproperties.lblread.caption
+msgctxt "TFRMFILEPROPERTIES.LBLREAD.CAPTION"
+msgid "Read"
+msgstr "Läs"
+
+#: tfrmfileproperties.lblsizeondiskstr.caption
+msgid "Size on disk:"
+msgstr "Storlek på disk:"
+
+#: tfrmfileproperties.lblsizestr.caption
+msgctxt "tfrmfileproperties.lblsizestr.caption"
+msgid "Size:"
+msgstr "Storlek:"
+
+#: tfrmfileproperties.lblsymlinkstr.caption
+msgid "Symlink to:"
+msgstr "Symbolisk länk till:"
+
+#: tfrmfileproperties.lbltypestr.caption
+msgid "Type:"
+msgstr "Typ:"
+
+#: tfrmfileproperties.lblwrite.caption
+msgctxt "TFRMFILEPROPERTIES.LBLWRITE.CAPTION"
+msgid "Write"
+msgstr "Skriv"
+
+#: tfrmfileproperties.sgplugins.columns[0].title.caption
+msgctxt "tfrmfileproperties.sgplugins.columns[0].title.caption"
+msgid "Name"
+msgstr "Namn"
+
+#: tfrmfileproperties.sgplugins.columns[1].title.caption
+msgctxt "tfrmfileproperties.sgplugins.columns[1].title.caption"
+msgid "Value"
+msgstr "Värde"
+
+#: tfrmfileproperties.tsattributes.caption
+msgctxt "tfrmfileproperties.tsattributes.caption"
+msgid "Attributes"
+msgstr "Attribut"
+
+#: tfrmfileproperties.tsplugins.caption
+msgctxt "tfrmfileproperties.tsplugins.caption"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmfileproperties.tsproperties.caption
+msgctxt "TFRMFILEPROPERTIES.TSPROPERTIES.CAPTION"
+msgid "Properties"
+msgstr "Egenskaper"
+
+#: tfrmfileunlock.btnclose.caption
+msgctxt "tfrmfileunlock.btnclose.caption"
+msgid "Close"
+msgstr "Stäng"
+
+#: tfrmfileunlock.btnterminate.caption
+msgid "Terminate"
+msgstr "Avsluta"
+
+#: tfrmfileunlock.btnunlock.caption
+msgctxt "tfrmfileunlock.btnunlock.caption"
+msgid "Unlock"
+msgstr "Lås upp"
+
+#: tfrmfileunlock.btnunlockall.caption
+msgid "Unlock All"
+msgstr "Lås upp alla"
+
+#: tfrmfileunlock.caption
+msgctxt "tfrmfileunlock.caption"
+msgid "Unlock"
+msgstr "Lås upp"
+
+#: tfrmfileunlock.stgfilehandles.columns[0].title.caption
+msgid "File Handle"
+msgstr "Filhandtag"
+
+#: tfrmfileunlock.stgfilehandles.columns[1].title.caption
+msgid "Process ID"
+msgstr "Process-ID"
+
+#: tfrmfileunlock.stgfilehandles.columns[2].title.caption
+msgid "Executable Path"
+msgstr "Sökväg till körbar fil"
+
+#: tfrmfinddlg.actcancel.caption
+msgctxt "TFRMFINDDLG.ACTCANCEL.CAPTION"
+msgid "C&ancel"
+msgstr "A&vbryt"
+
+#: tfrmfinddlg.actcancelclose.caption
+msgid "Cancel search and close window"
+msgstr "Avbryt sökningen och stäng fönstret"
+
+#: tfrmfinddlg.actclose.caption
+msgctxt "TFRMFINDDLG.ACTCLOSE.CAPTION"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmfinddlg.actconfigfilesearchhotkeys.caption
+msgctxt "TFRMFINDDLG.ACTCONFIGFILESEARCHHOTKEYS.CAPTION"
+msgid "Configuration of hot keys"
+msgstr "Konfiguration av kortkommandon"
+
+#: tfrmfinddlg.actedit.caption
+msgctxt "tfrmfinddlg.actedit.caption"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmfinddlg.actfeedtolistbox.caption
+msgid "Feed to &listbox"
+msgstr "Skicka till &listan"
+
+#: tfrmfinddlg.actfreefrommem.caption
+msgid "Cancel search, close and free from memory"
+msgstr "Avbryt sökningen, stäng och frigör minne"
+
+#: tfrmfinddlg.actfreefrommemallothers.caption
+msgid "For all other \"Find files\", cancel, close and free from memory"
+msgstr "För alla andra ”Sök filer”: avbryt, stäng och frigör minne"
+
+#: tfrmfinddlg.actgotofile.caption
+msgid "&Go to file"
+msgstr "&Gå till fil"
+
+#: tfrmfinddlg.actintellifocus.caption
+msgctxt "TFRMFINDDLG.ACTINTELLIFOCUS.CAPTION"
+msgid "Find Data"
+msgstr "Sökdata"
+
+#: tfrmfinddlg.actlastsearch.caption
+msgid "&Last search"
+msgstr "&Senaste sökning"
+
+#: tfrmfinddlg.actnewsearch.caption
+msgid "&New search"
+msgstr "&Ny sökning"
+
+#: tfrmfinddlg.actnewsearchclearfilters.caption
+msgid "New search (clear filters)"
+msgstr "Ny sökning (rensa filter)"
+
+#: tfrmfinddlg.actpageadvanced.caption
+msgid "Go to page \"Advanced\""
+msgstr "Gå till sidan ”Avancerat”"
+
+#: tfrmfinddlg.actpageloadsave.caption
+msgid "Go to page \"Load/Save\""
+msgstr "Gå till sidan ”Läs in/spara”"
+
+#: tfrmfinddlg.actpagenext.caption
+msgid "Switch to Nex&t Page"
+msgstr "Växla till &nästa sida"
+
+#: tfrmfinddlg.actpageplugins.caption
+msgid "Go to page \"Plugins\""
+msgstr "Gå till sidan ”Insticksmoduler”"
+
+#: tfrmfinddlg.actpageprev.caption
+msgid "Switch to &Previous Page"
+msgstr "Växla till &föregående sida"
+
+#: tfrmfinddlg.actpageresults.caption
+msgid "Go to page \"Results\""
+msgstr "Gå till sidan ”Resultat”"
+
+#: tfrmfinddlg.actpagestandard.caption
+msgid "Go to page \"Standard\""
+msgstr "Gå till sidan ”Standard”"
+
+#: tfrmfinddlg.actstart.caption
+msgctxt "tfrmfinddlg.actstart.caption"
+msgid "&Start"
+msgstr "&Starta"
+
+#: tfrmfinddlg.actview.caption
+msgctxt "tfrmfinddlg.actview.caption"
+msgid "&View"
+msgstr "&Visa"
+
+#: tfrmfinddlg.btnaddattribute.caption
+msgctxt "tfrmfinddlg.btnaddattribute.caption"
+msgid "&Add"
+msgstr "&Lägg till"
+
+#: tfrmfinddlg.btnattrshelp.caption
+msgctxt "TFRMFINDDLG.BTNATTRSHELP.CAPTION"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmfinddlg.btndrives.caption
+msgid "Drives"
+msgstr "Enheter"
+
+#: tfrmfinddlg.btnsavetemplate.caption
+msgctxt "TFRMFINDDLG.BTNSAVETEMPLATE.CAPTION"
+msgid "&Save"
+msgstr "&Spara"
+
+#: tfrmfinddlg.btnsearchdelete.caption
+msgctxt "TFRMFINDDLG.BTNSEARCHDELETE.CAPTION"
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: tfrmfinddlg.btnsearchload.caption
+msgid "L&oad"
+msgstr "L&äs in"
+
+#: tfrmfinddlg.btnsearchsave.caption
+msgid "S&ave"
+msgstr "S&para"
+
+#: tfrmfinddlg.btnsearchsavewithstartingpath.caption
+msgid "Sa&ve with \"Start in directory\""
+msgstr "Spa&ra med ”Starta i katalog”"
+
+#: tfrmfinddlg.btnsearchsavewithstartingpath.hint
+msgid ""
+"If saved then \"Start in directory\" will be restored when loading template. Use it if you want "
+"to fix searching to a certain directory"
+msgstr ""
+"Om ”Starta i katalog” sparas återställs det när mallen läses in. Använd detta om du vill begränsa"
+" sökningen till en viss katalog"
+
+#: tfrmfinddlg.btnusetemplate.caption
+msgid "Use template"
+msgstr "Använd mall"
+
+#: tfrmfinddlg.caption
+msgctxt "tfrmfinddlg.caption"
+msgid "Find files"
+msgstr "Sök filer"
+
+#: tfrmfinddlg.cbcasesens.caption
+msgid "Case sens&itive"
+msgstr "Skiftläges&känslig"
+
+#: tfrmfinddlg.cbdatefrom.caption
+msgid "&Date from:"
+msgstr "&Datum från:"
+
+#: tfrmfinddlg.cbdateto.caption
+msgid "Dat&e to:"
+msgstr "Dat&um till:"
+
+#: tfrmfinddlg.cbfilesizefrom.caption
+msgid "S&ize from:"
+msgstr "S&torlek från:"
+
+#: tfrmfinddlg.cbfilesizeto.caption
+msgid "Si&ze to:"
+msgstr "Sto&rlek till:"
+
+#: tfrmfinddlg.cbfindinarchive.caption
+msgid "Search in &archives"
+msgstr "Sök i &arkiv"
+
+#: tfrmfinddlg.cbfindtext.caption
+msgid "Find &text in file"
+msgstr "Sök &text i fil"
+
+#: tfrmfinddlg.cbfollowsymlinks.caption
+msgid "Follow s&ymlinks"
+msgstr "Följ s&ymboliska länkar"
+
+#: tfrmfinddlg.cbnotcontainingtext.caption
+msgid "Find files N&OT containing the text"
+msgstr "Sök filer som I&NTE innehåller texten"
+
+#: tfrmfinddlg.cbnotolderthan.caption
+msgid "N&ot older than:"
+msgstr "I&nte äldre än:"
+
+#: tfrmfinddlg.cbofficexml.caption
+msgid "Offi&ce XML"
+msgstr "Offi&ce XML"
+
+#: tfrmfinddlg.cbopenedtabs.caption
+msgid "Opened tabs"
+msgstr "Öppna flikar"
+
+#: tfrmfinddlg.cbpartialnamesearch.caption
+msgid "Searc&h for part of file name"
+msgstr "Sök efter en de&l av filnamnet"
+
+#: tfrmfinddlg.cbregexp.caption
+msgid "&Regular expression"
+msgstr "&Reguljärt uttryck"
+
+#: tfrmfinddlg.cbreplacetext.caption
+msgid "Re&place by"
+msgstr "E&rsätt med"
+
+#: tfrmfinddlg.cbselectedfiles.caption
+msgid "Selected directories and files"
+msgstr "Markerade kataloger och filer"
+
+#: tfrmfinddlg.cbtextregexp.caption
+msgid "Reg&ular expression"
+msgstr "Reg&uljärt uttryck"
+
+#: tfrmfinddlg.cbtimefrom.caption
+msgid "&Time from:"
+msgstr "&Tid från:"
+
+#: tfrmfinddlg.cbtimeto.caption
+msgid "Ti&me to:"
+msgstr "Ti&d till:"
+
+#: tfrmfinddlg.cbuseplugin.caption
+msgid "&Use search plugin:"
+msgstr "&Använd sökinsticksmodul:"
+
+#: tfrmfinddlg.chkduplicatecontent.caption
+msgid "same content"
+msgstr "samma innehåll"
+
+#: tfrmfinddlg.chkduplicatehash.caption
+msgid "same hash"
+msgstr "samma hash"
+
+#: tfrmfinddlg.chkduplicatename.caption
+msgid "same name"
+msgstr "samma namn"
+
+#: tfrmfinddlg.chkduplicates.caption
+msgid "Find du&plicate files:"
+msgstr "Sök d&ubblettfiler:"
+
+#: tfrmfinddlg.chkduplicatesize.caption
+msgid "same size"
+msgstr "samma storlek"
+
+#: tfrmfinddlg.chkhex.caption
+msgctxt "tfrmfinddlg.chkhex.caption"
+msgid "Hexadeci&mal"
+msgstr "Hexadeci&malt"
+
+#: tfrmfinddlg.cmbexcludedirectories.hint
+msgid "Enter directories names that should be excluded from search separated with \";\""
+msgstr "Ange katalognamn som ska uteslutas från sökningen, avgränsade med ”;”"
+
+#: tfrmfinddlg.cmbexcludefiles.hint
+msgid "Enter files names that should be excluded from search separated with \";\""
+msgstr "Ange filnamn som ska uteslutas från sökningen, avgränsade med ”;”"
+
+#: tfrmfinddlg.cmbfindfilemask.hint
+msgid "Enter files names separated with \";\""
+msgstr "Ange filnamn avgränsade med ”;”"
+
+#: tfrmfinddlg.gbdirectories.caption
+msgctxt "tfrmfinddlg.gbdirectories.caption"
+msgid "Directories"
+msgstr "Kataloger"
+
+#: tfrmfinddlg.gbfiles.caption
+msgctxt "tfrmfinddlg.gbfiles.caption"
+msgid "Files"
+msgstr "Filer"
+
+#: tfrmfinddlg.gbfinddata.caption
+msgctxt "tfrmfinddlg.gbfinddata.caption"
+msgid "Find Data"
+msgstr "Sökdata"
+
+#: tfrmfinddlg.lblattributes.caption
+msgid "Attri&butes"
+msgstr "Attri&but"
+
+#: tfrmfinddlg.lblencoding.caption
+msgid "Encodin&g:"
+msgstr "Kodnin&g:"
+
+#: tfrmfinddlg.lblexcludedirectories.caption
+msgid "E&xclude subdirectories"
+msgstr "Uteslut &underkataloger"
+
+#: tfrmfinddlg.lblexcludefiles.caption
+msgid "&Exclude files"
+msgstr "&Uteslut filer"
+
+#: tfrmfinddlg.lblfindfilemask.caption
+msgid "&File mask"
+msgstr "&Filmask"
+
+#: tfrmfinddlg.lblfindpathstart.caption
+msgid "Start in &directory"
+msgstr "Starta i &katalog"
+
+#: tfrmfinddlg.lblsearchdepth.caption
+msgid "Search su&bdirectories:"
+msgstr "Sök i u&nderkataloger:"
+
+#: tfrmfinddlg.lbltemplateheader.caption
+msgid "&Previous searches:"
+msgstr "&Tidigare sökningar:"
+
+#: tfrmfinddlg.miaction.caption
+msgid "&Action"
+msgstr "&Åtgärd"
+
+#: tfrmfinddlg.mifreefrommemallothers.caption
+msgid "For all others, cancel, close and free from memory"
+msgstr "För alla andra: avbryt, stäng och frigör minne"
+
+#: tfrmfinddlg.miopeninnewtab.caption
+msgid "Open In New Tab(s)"
+msgstr "Öppna i nya flikar"
+
+#: tfrmfinddlg.mioptions.caption
+msgctxt "TFRMFINDDLG.MIOPTIONS.CAPTION"
+msgid "Options"
+msgstr "Alternativ"
+
+#: tfrmfinddlg.miremovefromllist.caption
+msgid "Remove from list"
+msgstr "Ta bort från listan"
+
+#: tfrmfinddlg.miresult.caption
+msgid "&Result"
+msgstr "&Resultat"
+
+#: tfrmfinddlg.mishowallfound.caption
+msgid "Show all found items"
+msgstr "Visa alla hittade objekt"
+
+#: tfrmfinddlg.mishowineditor.caption
+msgid "Show In Editor"
+msgstr "Visa i redigeraren"
+
+#: tfrmfinddlg.mishowinviewer.caption
+msgid "Show In Viewer"
+msgstr "Visa i visaren"
+
+#: tfrmfinddlg.miviewtab.caption
+msgctxt "TFRMFINDDLG.MIVIEWTAB.CAPTION"
+msgid "&View"
+msgstr "&Visa"
+
+#: tfrmfinddlg.tsadvanced.caption
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: tfrmfinddlg.tsloadsave.caption
+msgid "Load/Save"
+msgstr "Läs in/spara"
+
+#: tfrmfinddlg.tsplugins.caption
+msgctxt "tfrmfinddlg.tsplugins.caption"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmfinddlg.tsresults.caption
+msgid "Results"
+msgstr "Resultat"
+
+#: tfrmfinddlg.tsstandard.caption
+msgid "Standard"
+msgstr "Standard"
+
+#: tfrmfindview.btnclose.caption
+msgctxt "TFRMFINDVIEW.BTNCLOSE.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmfindview.btnfind.caption
+msgctxt "TFRMFINDVIEW.BTNFIND.CAPTION"
+msgid "&Find"
+msgstr "&Sök"
+
+#: tfrmfindview.caption
+msgctxt "TFRMFINDVIEW.CAPTION"
+msgid "Find"
+msgstr "Sök"
+
+#: tfrmfindview.cbbackwards.caption
+msgid "&Backwards"
+msgstr "&Bakåt"
+
+#: tfrmfindview.cbcasesens.caption
+msgid "C&ase sensitive"
+msgstr "S&kiftlägeskänslig"
+
+#: tfrmfindview.cbregexp.caption
+msgctxt "tfrmfindview.cbregexp.caption"
+msgid "&Regular expressions"
+msgstr "&Reguljära uttryck"
+
+#: tfrmfindview.chkhex.caption
+msgctxt "tfrmfindview.chkhex.caption"
+msgid "Hexadecimal"
+msgstr "Hexadecimalt"
+
+#: tfrmgioauthdialog.lbldomain.caption
+msgid "Domain:"
+msgstr "Domän:"
+
+#: tfrmgioauthdialog.lblpassword.caption
+msgctxt "tfrmgioauthdialog.lblpassword.caption"
+msgid "Password:"
+msgstr "Lösenord:"
+
+#: tfrmgioauthdialog.lblusername.caption
+msgctxt "tfrmgioauthdialog.lblusername.caption"
+msgid "User name:"
+msgstr "Användarnamn:"
+
+#: tfrmgioauthdialog.rbanonymous.caption
+msgid "Connect anonymously"
+msgstr "Anslut anonymt"
+
+#: tfrmgioauthdialog.rbconnetas.caption
+msgid "Connect as user:"
+msgstr "Anslut som användare:"
+
+#: tfrmhardlink.btncancel.caption
+msgctxt "TFRMHARDLINK.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmhardlink.btnok.caption
+msgctxt "TFRMHARDLINK.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmhardlink.caption
+msgid "Create hard link"
+msgstr "Skapa hård länk"
+
+#: tfrmhardlink.lblexistingfile.caption
+msgctxt "tfrmhardlink.lblexistingfile.caption"
+msgid "&Destination that the link will point to"
+msgstr "&Mål som länken ska peka på"
+
+#: tfrmhardlink.lbllinktocreate.caption
+msgctxt "tfrmhardlink.lbllinktocreate.caption"
+msgid "&Link name"
+msgstr "&Länknamn"
+
+#: tfrmhotdirexportimport.btnselectall.caption
+msgctxt "tfrmhotdirexportimport.btnselectall.caption"
+msgid "Import all!"
+msgstr "Importera alla!"
+
+#: tfrmhotdirexportimport.btnselectiondone.caption
+msgctxt "tfrmhotdirexportimport.btnselectiondone.caption"
+msgid "Import selected"
+msgstr "Importera markerade"
+
+#: tfrmhotdirexportimport.caption
+msgid "Select the entries your want to import"
+msgstr "Markera de poster du vill importera"
+
+#: tfrmhotdirexportimport.lbhint.caption
+msgid "When clicking a sub-menu, it will select the whole menu"
+msgstr "När du klickar på en undermeny markeras hela menyn"
+
+#: tfrmhotdirexportimport.lblhintholdcontrol.caption
+msgid "Hold CTRL and click entries to select multiple ones"
+msgstr "Håll ned CTRL och klicka på poster för att markera flera"
+
+#: tfrmlinker.btnsave.caption
+msgctxt "tfrmlinker.btnsave.caption"
+msgid "..."
+msgstr "..."
+
+#: tfrmlinker.caption
+msgid "Linker"
+msgstr "Sammanfogare"
+
+#: tfrmlinker.gbsaveto.caption
+msgid "Save to..."
+msgstr "Spara till..."
+
+#: tfrmlinker.grbxcontrol.caption
+msgid "Item"
+msgstr "Objekt"
+
+#: tfrmlinker.lblfilename.caption
+msgid "&File name"
+msgstr "&Filnamn"
+
+#: tfrmlinker.spbtndown.caption
+msgctxt "tfrmlinker.spbtndown.caption"
+msgid "Do&wn"
+msgstr "&Ned"
+
+#: tfrmlinker.spbtndown.hint
+msgid "Down"
+msgstr "Ned"
+
+#: tfrmlinker.spbtnrem.caption
+msgctxt "tfrmlinker.spbtnrem.caption"
+msgid "&Remove"
+msgstr "&Ta bort"
+
+#: tfrmlinker.spbtnrem.hint
+msgctxt "TFRMLINKER.SPBTNREM.HINT"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmlinker.spbtnup.caption
+msgctxt "tfrmlinker.spbtnup.caption"
+msgid "&Up"
+msgstr "&Upp"
+
+#: tfrmlinker.spbtnup.hint
+msgid "Up"
+msgstr "Upp"
+
+#: tfrmmain.actabout.caption
+msgid "&About"
+msgstr "&Om"
+
+#: tfrmmain.actactivatetabbyindex.caption
+msgid "Activate Tab By Index"
+msgstr "Aktivera flik efter index"
+
+#: tfrmmain.actaddfilenametocmdline.caption
+msgid "Add file name to command line"
+msgstr "Lägg till filnamn på kommandoraden"
+
+#: tfrmmain.actaddnewsearch.caption
+msgid "New search instance..."
+msgstr "Ny sökinstans..."
+
+#: tfrmmain.actaddpathandfilenametocmdline.caption
+msgid "Add path and file name to command line"
+msgstr "Lägg till sökväg och filnamn på kommandoraden"
+
+#: tfrmmain.actaddpathtocmdline.caption
+msgid "Copy path to command line"
+msgstr "Kopiera sökväg till kommandoraden"
+
+#: tfrmmain.actaddplugin.caption
+msgid "Add Plugin"
+msgstr "Lägg till insticksmodul"
+
+#: tfrmmain.actaddtostash.caption
+msgid "Add to Stash"
+msgstr "Lägg till i stash"
+
+#: tfrmmain.actbenchmark.caption
+msgid "&Benchmark"
+msgstr "&Prestandatest"
+
+#: tfrmmain.actbriefview.caption
+msgid "Brief view"
+msgstr "Kompakt vy"
+
+#: tfrmmain.actbriefview.hint
+msgid "Brief View"
+msgstr "Kompakt vy"
+
+#: tfrmmain.actcalculatespace.caption
+msgid "Calculate &Occupied Space"
+msgstr "Beräkna &upptaget utrymme"
+
+#: tfrmmain.actcallplatformfunctions.caption
+msgid "Call platform functions"
+msgstr "Anropa plattformsfunktioner"
+
+#: tfrmmain.actcallplatformfunctions.hint
+msgid "Call platform functions (the function to be called is specified by the parameter 'func')"
+msgstr "Anropa plattformsfunktioner (funktionen som ska anropas anges med parametern 'func')"
+
+#: tfrmmain.actchangedir.caption
+msgid "Change directory"
+msgstr "Byt katalog"
+
+#: tfrmmain.actchangedirtohome.caption
+msgid "Change directory to home"
+msgstr "Byt till hemkatalogen"
+
+#: tfrmmain.actchangedirtoparent.caption
+msgid "Change Directory To Parent"
+msgstr "Byt till överordnad katalog"
+
+#: tfrmmain.actchangedirtoroot.caption
+msgid "Change directory to root"
+msgstr "Byt till rotkatalogen"
+
+#: tfrmmain.actchecksumcalc.caption
+msgid "Calculate Check&sum..."
+msgstr "Beräkna &kontrollsumma..."
+
+#: tfrmmain.actchecksumverify.caption
+msgid "&Verify Checksum..."
+msgstr "&Verifiera kontrollsumma..."
+
+#: tfrmmain.actclearlogfile.caption
+msgid "Clear log file"
+msgstr "Rensa loggfil"
+
+#: tfrmmain.actclearlogwindow.caption
+msgid "Clear log window"
+msgstr "Rensa loggfönster"
+
+#: tfrmmain.actclosealltabs.caption
+msgid "Close &All Tabs"
+msgstr "Stäng &alla flikar"
+
+#: tfrmmain.actcloseduplicatetabs.caption
+msgid "Close Duplicate Tabs"
+msgstr "Stäng dubblettflikar"
+
+#: tfrmmain.actclosetab.caption
+msgid "&Close Tab"
+msgstr "&Stäng flik"
+
+#: tfrmmain.actcmdlinenext.caption
+msgid "Next Command Line"
+msgstr "Nästa kommandorad"
+
+#: tfrmmain.actcmdlinenext.hint
+msgid "Set command line to next command in history"
+msgstr "Ställ in kommandoraden till nästa kommando i historiken"
+
+#: tfrmmain.actcmdlineprev.caption
+msgid "Previous Command Line"
+msgstr "Föregående kommandorad"
+
+#: tfrmmain.actcmdlineprev.hint
+msgid "Set command line to previous command in history"
+msgstr "Ställ in kommandoraden till föregående kommando i historiken"
+
+#: tfrmmain.actcolumnsview.caption
+msgid "Full"
+msgstr "Detaljerad"
+
+#: tfrmmain.actcolumnsview.hint
+msgid "Columns View"
+msgstr "Kolumnvy"
+
+#: tfrmmain.actcomparecontents.caption
+msgid "Compare by &Contents"
+msgstr "Jämför efter &innehåll"
+
+#: tfrmmain.actcomparedirectories.caption
+msgctxt "tfrmmain.actcomparedirectories.caption"
+msgid "Compare Directories"
+msgstr "Jämför kataloger"
+
+#: tfrmmain.actcomparedirectories.hint
+msgctxt "TFRMMAIN.ACTCOMPAREDIRECTORIES.HINT"
+msgid "Compare Directories"
+msgstr "Jämför kataloger"
+
+#: tfrmmain.actconfigarchivers.caption
+msgid "Configuration of Archivers"
+msgstr "Konfiguration av arkiverare"
+
+#: tfrmmain.actconfigdirhotlist.caption
+msgctxt "tfrmmain.actconfigdirhotlist.caption"
+msgid "Configuration of Directory Hotlist"
+msgstr "Konfiguration av katalogfavoriter"
+
+#: tfrmmain.actconfigfavoritetabs.caption
+msgid "Configuration of Favorite Tabs"
+msgstr "Konfiguration av favoritflikar"
+
+#: tfrmmain.actconfigfoldertabs.caption
+msgid "Configuration of folder tabs"
+msgstr "Konfiguration av mappflikar"
+
+#: tfrmmain.actconfighotkeys.caption
+msgctxt "tfrmmain.actconfighotkeys.caption"
+msgid "Configuration of hot keys"
+msgstr "Konfiguration av kortkommandon"
+
+#: tfrmmain.actconfigplugins.caption
+msgid "Configuration of Plugins"
+msgstr "Konfiguration av insticksmoduler"
+
+#: tfrmmain.actconfigsavepos.caption
+msgid "Save Position"
+msgstr "Spara position"
+
+#: tfrmmain.actconfigsavesettings.caption
+msgid "Save Settings"
+msgstr "Spara inställningar"
+
+#: tfrmmain.actconfigsearches.caption
+msgid "Configuration of searches"
+msgstr "Konfiguration av sökningar"
+
+#: tfrmmain.actconfigtoolbars.caption
+msgid "Toolbar..."
+msgstr "Verktygsfält..."
+
+#: tfrmmain.actconfigtooltips.caption
+msgid "Configuration of tooltips"
+msgstr "Konfiguration av verktygstips"
+
+#: tfrmmain.actconfigtreeviewmenus.caption
+msgctxt "tfrmmain.actconfigtreeviewmenus.caption"
+msgid "Configuration of Tree View Menu"
+msgstr "Konfiguration av trädvyns meny"
+
+#: tfrmmain.actconfigtreeviewmenuscolors.caption
+msgctxt "tfrmmain.actconfigtreeviewmenuscolors.caption"
+msgid "Configuration of Tree View Menu Colors"
+msgstr "Konfiguration av färger för trädvyns meny"
+
+#: tfrmmain.actcontextmenu.caption
+msgid "Show context menu"
+msgstr "Visa snabbmeny"
+
+#: tfrmmain.actcopy.caption
+msgctxt "TFRMMAIN.ACTCOPY.CAPTION"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmmain.actcopyalltabstoopposite.caption
+msgid "Copy all tabs to opposite side"
+msgstr "Kopiera alla flikar till motsatt sida"
+
+#: tfrmmain.actcopyfiledetailstoclip.caption
+msgid "Copy all shown &columns"
+msgstr "Kopiera alla visade &kolumner"
+
+#: tfrmmain.actcopyfullnamestoclip.caption
+msgid "Copy Filename(s) with Full &Path"
+msgstr "Kopiera filnamn med fullständig &sökväg"
+
+#: tfrmmain.actcopynamestoclip.caption
+msgid "Copy &Filename(s) to Clipboard"
+msgstr "Kopiera &filnamn till urklipp"
+
+#: tfrmmain.actcopynetnamestoclip.caption
+msgid "Copy names with UNC path"
+msgstr "Kopiera namn med UNC-sökväg"
+
+#: tfrmmain.actcopynoask.caption
+msgid "Copy files without asking for confirmation"
+msgstr "Kopiera filer utan att fråga efter bekräftelse"
+
+#: tfrmmain.actcopypathnosepoffilestoclip.caption
+msgid "Copy Full Path of selected file(s) with no ending dir separator"
+msgstr "Kopiera fullständig sökväg för markerad(e) fil(er) utan avslutande katalogavgränsare"
+
+#: tfrmmain.actcopypathoffilestoclip.caption
+msgid "Copy Full Path of selected file(s)"
+msgstr "Kopiera fullständig sökväg för markerad(e) fil(er)"
+
+#: tfrmmain.actcopysamepanel.caption
+msgid "Copy to same panel"
+msgstr "Kopiera till samma panel"
+
+#: tfrmmain.actcopytoclipboard.caption
+msgid "&Copy"
+msgstr "&Kopiera"
+
+#: tfrmmain.actcountdircontent.caption
+msgid "Sho&w Occupied Space"
+msgstr "Visa &upptaget utrymme"
+
+#: tfrmmain.actcuttoclipboard.caption
+msgid "Cu&t"
+msgstr "Klipp &ut"
+
+#: tfrmmain.actdebugshowcommandparameters.caption
+msgid "Show Command Parameters"
+msgstr "Visa kommandoparametrar"
+
+#: tfrmmain.actdelete.caption
+msgctxt "TFRMMAIN.ACTDELETE.CAPTION"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmmain.actdeletesearches.caption
+msgid "For all searches, cancel, close and free memory"
+msgstr "För alla sökningar: avbryt, stäng och frigör minne"
+
+#: tfrmmain.actdirhistory.caption
+msgid "Directory history"
+msgstr "Kataloghistorik"
+
+#: tfrmmain.actdirhotlist.caption
+msgid "Directory &Hotlist"
+msgstr "Katalog&favoriter"
+
+#: tfrmmain.actdoanycmcommand.caption
+msgid "Execute &internal command..."
+msgstr "Kör &internt kommando..."
+
+#: tfrmmain.actdoanycmcommand.hint
+msgid "Select any command and execute it"
+msgstr "Välj ett kommando och kör det"
+
+#: tfrmmain.actedit.caption
+msgctxt "TFRMMAIN.ACTEDIT.CAPTION"
+msgid "Edit"
+msgstr "Redigera"
+
+#: tfrmmain.acteditcomment.caption
+msgid "Edit Co&mment..."
+msgstr "Redigera ko&mmentar..."
+
+#: tfrmmain.acteditnew.caption
+msgid "Edit new file"
+msgstr "Redigera ny fil"
+
+#: tfrmmain.acteditpath.caption
+msgid "Edit path field above file list"
+msgstr "Redigera sökvägsfältet ovanför fillistan"
+
+#: tfrmmain.actemptystash.caption
+msgid "Empty Stash"
+msgstr "Töm stash"
+
+#: tfrmmain.actexchange.caption
+msgid "Swap &Panels"
+msgstr "Byt &paneler"
+
+#: tfrmmain.actexecutescript.caption
+msgid "Execute Script"
+msgstr "Kör skript"
+
+#: tfrmmain.actexit.caption
+msgctxt "TFRMMAIN.ACTEXIT.CAPTION"
+msgid "E&xit"
+msgstr "A&vsluta"
+
+#: tfrmmain.actextractfiles.caption
+msgid "&Extract Files..."
+msgstr "&Packa upp filer..."
+
+#: tfrmmain.actfileassoc.caption
+msgid "Configuration of File &Associations"
+msgstr "Konfiguration av &filassociationer"
+
+#: tfrmmain.actfilelinker.caption
+msgid "Com&bine Files..."
+msgstr "Sa&mmanfoga filer..."
+
+#: tfrmmain.actfileproperties.caption
+msgid "Show &File Properties"
+msgstr "Visa &filegenskaper"
+
+#: tfrmmain.actfilespliter.caption
+msgid "Spl&it File..."
+msgstr "D&ela fil..."
+
+#: tfrmmain.actflatview.caption
+msgid "&Flat view"
+msgstr "&Platt vy"
+
+#: tfrmmain.actflatviewsel.caption
+msgid "&Flat view, only selected"
+msgstr "&Platt vy, endast markerade"
+
+#: tfrmmain.actfocuscmdline.caption
+msgid "Focus command line"
+msgstr "Fokusera kommandoraden"
+
+#: tfrmmain.actfocusswap.caption
+msgid "Swap focus"
+msgstr "Byt fokus"
+
+#: tfrmmain.actfocusswap.hint
+msgid "Switch between left and right file list"
+msgstr "Växla mellan vänster och höger fillista"
+
+#: tfrmmain.actfocustreeview.caption
+msgid "Focus on tree view"
+msgstr "Fokusera trädvyn"
+
+#: tfrmmain.actfocustreeview.hint
+msgid "Switch between current file list and tree view (if enabled)"
+msgstr "Växla mellan aktuell fillista och trädvy (om aktiverad)"
+
+#: tfrmmain.actgotofirstentry.caption
+msgid "Place cursor on first folder or file"
+msgstr "Placera markören på första mappen eller filen"
+
+#: tfrmmain.actgotofirstfile.caption
+msgid "Place cursor on first file in list"
+msgstr "Placera markören på första filen i listan"
+
+#: tfrmmain.actgotolastentry.caption
+msgid "Place cursor on last folder or file"
+msgstr "Placera markören på sista mappen eller filen"
+
+#: tfrmmain.actgotolastfile.caption
+msgid "Place cursor on last file in list"
+msgstr "Placera markören på sista filen i listan"
+
+#: tfrmmain.actgotonextentry.caption
+msgid "Place cursor on next folder or file"
+msgstr "Placera markören på nästa mapp eller fil"
+
+#: tfrmmain.actgotopreventry.caption
+msgid "Place cursor on previous folder or file"
+msgstr "Placera markören på föregående mapp eller fil"
+
+#: tfrmmain.acthardlink.caption
+msgid "Create &Hard Link..."
+msgstr "Skapa &hård länk..."
+
+#: tfrmmain.acthelpindex.caption
+msgid "&Contents"
+msgstr "&Innehåll"
+
+#: tfrmmain.acthorizontalfilepanels.caption
+msgid "&Horizontal Panels Mode"
+msgstr "&Horisontellt panelläge"
+
+#: tfrmmain.actkeyboard.caption
+msgid "&Keyboard"
+msgstr "&Tangentbord"
+
+#: tfrmmain.actleftbriefview.caption
+msgid "Brief view on left panel"
+msgstr "Kompakt vy i vänster panel"
+
+#: tfrmmain.actleftcolumnsview.caption
+msgid "Columns view on left panel"
+msgstr "Kolumnvy i vänster panel"
+
+#: tfrmmain.actleftequalright.caption
+msgid "Left &= Right"
+msgstr "Vänster &= höger"
+
+#: tfrmmain.actleftflatview.caption
+msgid "&Flat view on left panel"
+msgstr "&Platt vy i vänster panel"
+
+#: tfrmmain.actleftopendrives.caption
+msgid "Open left drive list"
+msgstr "Öppna vänster enhetslista"
+
+#: tfrmmain.actleftreverseorder.caption
+msgid "Re&verse order on left panel"
+msgstr "Om&vänd ordning i vänster panel"
+
+#: tfrmmain.actleftsortbyattr.caption
+msgid "Sort left panel by &Attributes"
+msgstr "Sortera vänster panel efter &attribut"
+
+#: tfrmmain.actleftsortbydate.caption
+msgid "Sort left panel by &Date"
+msgstr "Sortera vänster panel efter &datum"
+
+#: tfrmmain.actleftsortbyext.caption
+msgid "Sort left panel by &Extension"
+msgstr "Sortera vänster panel efter &filändelse"
+
+#: tfrmmain.actleftsortbyname.caption
+msgid "Sort left panel by &Name"
+msgstr "Sortera vänster panel efter &namn"
+
+#: tfrmmain.actleftsortbysize.caption
+msgid "Sort left panel by &Size"
+msgstr "Sortera vänster panel efter &storlek"
+
+#: tfrmmain.actleftthumbview.caption
+msgid "Thumbnails view on left panel"
+msgstr "Miniatyrvy i vänster panel"
+
+#: tfrmmain.actloadfavoritetabs.caption
+msgid "Load tabs from Favorite Tabs"
+msgstr "Läs in flikar från favoritflikar"
+
+#: tfrmmain.actloadlist.caption
+msgid "Load List"
+msgstr "Läs in lista"
+
+#: tfrmmain.actloadlist.hint
+msgid "Load list of files/folders from the specified text file"
+msgstr "Läs in lista med filer/mappar från angiven textfil"
+
+#: tfrmmain.actloadselectionfromclip.caption
+msgid "Load Selection from Clip&board"
+msgstr "Läs in markering från &urklipp"
+
+#: tfrmmain.actloadselectionfromfile.caption
+msgid "&Load Selection from File..."
+msgstr "&Läs in markering från fil..."
+
+#: tfrmmain.actloadtabs.caption
+msgid "&Load Tabs from File"
+msgstr "&Läs in flikar från fil"
+
+#: tfrmmain.actmainfontzoomin.caption
+msgctxt "tfrmmain.actmainfontzoomin.caption"
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: tfrmmain.actmainfontzoomout.caption
+msgctxt "tfrmmain.actmainfontzoomout.caption"
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: tfrmmain.actmakedir.caption
+msgid "Create &Directory"
+msgstr "Skapa &katalog"
+
+#: tfrmmain.actmapnetworkdrive.caption
+msgid "Map Network Drive..."
+msgstr "Anslut nätverksenhet..."
+
+#: tfrmmain.actmarkcurrentextension.caption
+msgid "Select All with the Same E&xtension"
+msgstr "Markera alla med samma filä&ndelse"
+
+#: tfrmmain.actmarkcurrentname.caption
+msgid "Select all files with same name"
+msgstr "Markera alla filer med samma namn"
+
+#: tfrmmain.actmarkcurrentnameext.caption
+msgid "Select all files with same name and extension"
+msgstr "Markera alla filer med samma namn och filändelse"
+
+#: tfrmmain.actmarkcurrentpath.caption
+msgid "Select all in same path"
+msgstr "Markera alla i samma sökväg"
+
+#: tfrmmain.actmarkinvert.caption
+msgid "&Invert Selection"
+msgstr "&Invertera markering"
+
+#: tfrmmain.actmarkmarkall.caption
+msgid "&Select All"
+msgstr "Markera &allt"
+
+#: tfrmmain.actmarkminus.caption
+msgid "Unselect a Gro&up..."
+msgstr "Avmarkera en gr&upp..."
+
+#: tfrmmain.actmarkplus.caption
+msgid "Select a &Group..."
+msgstr "Markera en &grupp..."
+
+#: tfrmmain.actmarkunmarkall.caption
+msgid "&Unselect All"
+msgstr "&Avmarkera allt"
+
+#: tfrmmain.actminimize.caption
+msgid "Minimize window"
+msgstr "Minimera fönstret"
+
+#: tfrmmain.actmovetableft.caption
+msgid "Move current tab to the left"
+msgstr "Flytta aktuell flik åt vänster"
+
+#: tfrmmain.actmovetabright.caption
+msgid "Move current tab to the right"
+msgstr "Flytta aktuell flik åt höger"
+
+#: tfrmmain.actmultirename.caption
+msgid "Multi-&Rename Tool"
+msgstr "Verktyg för mass&omdöpning"
+
+#: tfrmmain.actnetworkconnect.caption
+msgid "Network &Connect..."
+msgstr "&Anslut nätverksenhet..."
+
+#: tfrmmain.actnetworkdisconnect.caption
+msgid "Network &Disconnect"
+msgstr "&Koppla från nätverksenhet"
+
+#: tfrmmain.actnetworkquickconnect.caption
+msgid "Network &Quick Connect..."
+msgstr "&Snabbanslut nätverk..."
+
+#: tfrmmain.actnewtab.caption
+msgid "&New Tab"
+msgstr "&Ny flik"
+
+#: tfrmmain.actnextfavoritetabs.caption
+msgid "Load the Next Favorite Tabs in the list"
+msgstr "Läs in nästa favoritflik i listan"
+
+#: tfrmmain.actnexttab.caption
+msgid "Switch to Nex&t Tab"
+msgstr "Växla till &nästa flik"
+
+#: tfrmmain.actopen.caption
+msgctxt "TFRMMAIN.ACTOPEN.CAPTION"
+msgid "Open"
+msgstr "Öppna"
+
+#: tfrmmain.actopenarchive.caption
+msgid "Try open archive"
+msgstr "Försök öppna arkiv"
+
+#: tfrmmain.actopenbar.caption
+msgid "Open bar file"
+msgstr "Öppna knappfältsfil"
+
+#: tfrmmain.actopendirinnewtab.caption
+msgid "Open &Folder in a New Tab"
+msgstr "Öppna &mapp i ny flik"
+
+#: tfrmmain.actopendrivebyindex.caption
+msgid "Open Drive by Index"
+msgstr "Öppna enhet efter index"
+
+#: tfrmmain.actopenvirtualfilesystemlist.caption
+msgid "Open &VFS List"
+msgstr "Öppna &VFS-lista"
+
+#: tfrmmain.actoperationsviewer.caption
+msgid "Operations &Viewer"
+msgstr "&Åtgärdsvisare"
+
+#: tfrmmain.actoptions.caption
+msgid "&Options..."
+msgstr "&Alternativ..."
+
+#: tfrmmain.actpackfiles.caption
+msgid "&Pack Files..."
+msgstr "&Packa filer..."
+
+#: tfrmmain.actpanelssplitterperpos.caption
+msgid "Set splitter position"
+msgstr "Ställ in delningslistens position"
+
+#: tfrmmain.actpastefromclipboard.caption
+msgid "&Paste"
+msgstr "&Klistra in"
+
+#: tfrmmain.actpreviousfavoritetabs.caption
+msgid "Load the Previous Favorite Tabs in the list"
+msgstr "Läs in föregående favoritflik i listan"
+
+#: tfrmmain.actprevtab.caption
+msgid "Switch to &Previous Tab"
+msgstr "Växla till &föregående flik"
+
+#: tfrmmain.actquickfilter.caption
+msgid "Quick filter"
+msgstr "Snabbfilter"
+
+#: tfrmmain.actquicksearch.caption
+msgid "Quick search"
+msgstr "Snabbsökning"
+
+#: tfrmmain.actquickview.caption
+msgid "&Quick View Panel"
+msgstr "&Snabbvisningspanel"
+
+#: tfrmmain.actrefresh.caption
+msgid "&Refresh"
+msgstr "&Uppdatera"
+
+#: tfrmmain.actreloadfavoritetabs.caption
+msgid "Reload the last Favorite Tabs loaded"
+msgstr "Läs om de senast inlästa favoritflikarna"
+
+#: tfrmmain.actremovefromstash.caption
+msgid "Remove Stash Items"
+msgstr "Ta bort objekt från stash"
+
+#: tfrmmain.actrename.caption
+msgctxt "tfrmmain.actrename.caption"
+msgid "Move"
+msgstr "Flytta"
+
+#: tfrmmain.actrenamenoask.caption
+msgid "Move/Rename files without asking for confirmation"
+msgstr "Flytta/byt namn på filer utan att fråga efter bekräftelse"
+
+#: tfrmmain.actrenameonly.caption
+msgctxt "tfrmmain.actrenameonly.caption"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmmain.actrenametab.caption
+msgid "&Rename Tab"
+msgstr "&Byt namn på flik"
+
+#: tfrmmain.actresavefavoritetabs.caption
+msgid "Resave on the last Favorite Tabs loaded"
+msgstr "Spara om de senast inlästa favoritflikarna"
+
+#: tfrmmain.actrestoreselection.caption
+msgid "&Restore Selection"
+msgstr "&Återställ markering"
+
+#: tfrmmain.actreverseorder.caption
+msgid "Re&verse Order"
+msgstr "Om&vänd ordning"
+
+#: tfrmmain.actrightbriefview.caption
+msgid "Brief view on right panel"
+msgstr "Kompakt vy i höger panel"
+
+#: tfrmmain.actrightcolumnsview.caption
+msgid "Columns view on right panel"
+msgstr "Kolumnvy i höger panel"
+
+#: tfrmmain.actrightequalleft.caption
+msgid "Right &= Left"
+msgstr "Höger &= vänster"
+
+#: tfrmmain.actrightflatview.caption
+msgid "&Flat view on right panel"
+msgstr "&Platt vy i höger panel"
+
+#: tfrmmain.actrightopendrives.caption
+msgid "Open right drive list"
+msgstr "Öppna höger enhetslista"
+
+#: tfrmmain.actrightreverseorder.caption
+msgid "Re&verse order on right panel"
+msgstr "Om&vänd ordning i höger panel"
+
+#: tfrmmain.actrightsortbyattr.caption
+msgid "Sort right panel by &Attributes"
+msgstr "Sortera höger panel efter &attribut"
+
+#: tfrmmain.actrightsortbydate.caption
+msgid "Sort right panel by &Date"
+msgstr "Sortera höger panel efter &datum"
+
+#: tfrmmain.actrightsortbyext.caption
+msgid "Sort right panel by &Extension"
+msgstr "Sortera höger panel efter &filändelse"
+
+#: tfrmmain.actrightsortbyname.caption
+msgid "Sort right panel by &Name"
+msgstr "Sortera höger panel efter &namn"
+
+#: tfrmmain.actrightsortbysize.caption
+msgid "Sort right panel by &Size"
+msgstr "Sortera höger panel efter &storlek"
+
+#: tfrmmain.actrightthumbview.caption
+msgid "Thumbnails view on right panel"
+msgstr "Miniatyrvy i höger panel"
+
+#: tfrmmain.actrunterm.caption
+msgid "Run &Terminal"
+msgstr "Kör &terminal"
+
+#: tfrmmain.actsavefavoritetabs.caption
+msgid "Save current tabs to a New Favorite Tabs"
+msgstr "Spara aktuella flikar som nya favoritflikar"
+
+#: tfrmmain.actsavefiledetailstofile.caption
+msgid "Save all shown columns to file"
+msgstr "Spara alla visade kolumner till fil"
+
+#: tfrmmain.actsaveselection.caption
+msgid "Sa&ve Selection"
+msgstr "S&para markering"
+
+#: tfrmmain.actsaveselectiontofile.caption
+msgid "Save S&election to File..."
+msgstr "Spara m&arkering till fil..."
+
+#: tfrmmain.actsavetabs.caption
+msgid "&Save Tabs to File"
+msgstr "&Spara flikar till fil"
+
+#: tfrmmain.actsearch.caption
+msgid "&Search..."
+msgstr "&Sök..."
+
+#: tfrmmain.actsetalltabsoptiondirsinnewtab.caption
+msgid "All tabs Locked with Dir Opened in New Tabs"
+msgstr "Alla flikar låsta med kataloger öppnade i nya flikar"
+
+#: tfrmmain.actsetalltabsoptionnormal.caption
+msgid "Set all tabs to Normal"
+msgstr "Ställ in alla flikar som normala"
+
+#: tfrmmain.actsetalltabsoptionpathlocked.caption
+msgid "Set all tabs to Locked"
+msgstr "Lås alla flikar"
+
+#: tfrmmain.actsetalltabsoptionpathresets.caption
+msgid "All tabs Locked with Dir Changes Allowed"
+msgstr "Alla flikar låsta med tillåtna katalogbyten"
+
+#: tfrmmain.actsetfileproperties.caption
+msgid "Change &Attributes..."
+msgstr "Ändra &attribut..."
+
+#: tfrmmain.actsetsortmode.caption
+msgid "Set Sort Mode"
+msgstr "Ställ in sorteringsläge"
+
+#: tfrmmain.actsettaboptiondirsinnewtab.caption
+msgid "Locked with Directories Opened in New &Tabs"
+msgstr "Låst med kataloger öppnade i nya &flikar"
+
+#: tfrmmain.actsettaboptionnormal.caption
+msgid "&Normal"
+msgstr "&Normal"
+
+#: tfrmmain.actsettaboptionpathlocked.caption
+msgid "&Locked"
+msgstr "&Låst"
+
+#: tfrmmain.actsettaboptionpathresets.caption
+msgid "Locked with &Directory Changes Allowed"
+msgstr "Låst med &tillåtna katalogbyten"
+
+#: tfrmmain.actshellexecute.caption
+msgctxt "TFRMMAIN.ACTSHELLEXECUTE.CAPTION"
+msgid "Open"
+msgstr "Öppna"
+
+#: tfrmmain.actshellexecute.hint
+msgid "Open using system associations"
+msgstr "Öppna med systemets filassociationer"
+
+#: tfrmmain.actshowbuttonmenu.caption
+msgid "Show button menu"
+msgstr "Visa knappmeny"
+
+#: tfrmmain.actshowcmdlinehistory.caption
+msgid "Show command line history"
+msgstr "Visa kommandoradshistorik"
+
+#: tfrmmain.actshowmainmenu.caption
+msgid "Menu"
+msgstr "Meny"
+
+#: tfrmmain.actshowsysfiles.caption
+msgid "Show &Hidden/System Files"
+msgstr "Visa &dolda/systemfiler"
+
+#: tfrmmain.actshowtabslist.caption
+msgid "Show Tabs List"
+msgstr "Visa fliklista"
+
+#: tfrmmain.actshowtabslist.hint
+msgid "Show list of all open tabs"
+msgstr "Visa lista över alla öppna flikar"
+
+#: tfrmmain.actsortbyattr.caption
+msgid "Sort by &Attributes"
+msgstr "Sortera efter &attribut"
+
+#: tfrmmain.actsortbydate.caption
+msgid "Sort by &Date"
+msgstr "Sortera efter &datum"
+
+#: tfrmmain.actsortbyext.caption
+msgid "Sort by &Extension"
+msgstr "Sortera efter &filändelse"
+
+#: tfrmmain.actsortbyname.caption
+msgid "Sort by &Name"
+msgstr "Sortera efter &namn"
+
+#: tfrmmain.actsortbysize.caption
+msgid "Sort by &Size"
+msgstr "Sortera efter &storlek"
+
+#: tfrmmain.actsrcopendrives.caption
+msgid "Open drive list"
+msgstr "Öppna enhetslista"
+
+#: tfrmmain.actswitchignorelist.caption
+msgid "Enable/disable ignore list file to not show file names"
+msgstr "Aktivera/inaktivera ignoreringslista för filnamn som inte ska visas"
+
+#: tfrmmain.actsymlink.caption
+msgid "Create Symbolic &Link..."
+msgstr "Skapa &symbolisk länk..."
+
+#: tfrmmain.actsyncchangedir.caption
+msgid "Synchronous navigation"
+msgstr "Synkroniserad navigering"
+
+#: tfrmmain.actsyncchangedir.hint
+msgid "Synchronous directory changing in both panels"
+msgstr "Synkroniserat katalogbyte i båda panelerna"
+
+#: tfrmmain.actsyncdirs.caption
+msgid "Syn&chronize dirs..."
+msgstr "Syn&kronisera kataloger..."
+
+#: tfrmmain.acttargetequalsource.caption
+msgid "Target &= Source"
+msgstr "Mål &= källa"
+
+#: tfrmmain.acttestarchive.caption
+msgid "&Test Archive(s)"
+msgstr "&Testa arkiv"
+
+#: tfrmmain.actthumbnailsview.caption
+msgctxt "tfrmmain.actthumbnailsview.caption"
+msgid "Thumbnails"
+msgstr "Miniatyrer"
+
+#: tfrmmain.actthumbnailsview.hint
+msgid "Thumbnails View"
+msgstr "Miniatyrvy"
+
+#: tfrmmain.acttogglefullscreenconsole.caption
+msgid "Toggle fullscreen mode console"
+msgstr "Växla helskärmsläge för konsolen"
+
+#: tfrmmain.acttransferleft.caption
+msgid "Transfer dir under cursor to left window"
+msgstr "Överför katalogen under markören till vänster panel"
+
+#: tfrmmain.acttransferright.caption
+msgid "Transfer dir under cursor to right window"
+msgstr "Överför katalogen under markören till höger panel"
+
+#: tfrmmain.acttreeview.caption
+msgid "&Tree View Panel"
+msgstr "&Trädvypanel"
+
+#: tfrmmain.actuniversalsingledirectsort.caption
+msgid "Sort according to parameters"
+msgstr "Sortera enligt parametrar"
+
+#: tfrmmain.actunmarkcurrentextension.caption
+msgid "Unselect All with the Same Ex&tension"
+msgstr "Avmarkera alla med samma filä&ndelse"
+
+#: tfrmmain.actunmarkcurrentname.caption
+msgid "Unselect all files with same name"
+msgstr "Avmarkera alla filer med samma namn"
+
+#: tfrmmain.actunmarkcurrentnameext.caption
+msgid "Unselect all files with same name and extension"
+msgstr "Avmarkera alla filer med samma namn och filändelse"
+
+#: tfrmmain.actunmarkcurrentpath.caption
+msgid "Unselect all in same path"
+msgstr "Avmarkera alla i samma sökväg"
+
+#: tfrmmain.actview.caption
+msgctxt "TFRMMAIN.ACTVIEW.CAPTION"
+msgid "View"
+msgstr "Visa"
+
+#: tfrmmain.actviewhistory.caption
+msgid "Show history of visited paths for active view"
+msgstr "Visa historik över besökta sökvägar för aktiv vy"
+
+#: tfrmmain.actviewhistorynext.caption
+msgid "Go to next entry in history"
+msgstr "Gå till nästa post i historiken"
+
+#: tfrmmain.actviewhistoryprev.caption
+msgid "Go to previous entry in history"
+msgstr "Gå till föregående post i historiken"
+
+#: tfrmmain.actviewlogfile.caption
+msgid "View log file"
+msgstr "Visa loggfil"
+
+#: tfrmmain.actviewsearches.caption
+msgid "View current search instances"
+msgstr "Visa aktuella sökinstanser"
+
+#: tfrmmain.actvisithomepage.caption
+msgid "&Visit Double Commander Website"
+msgstr "&Besök Double Commanders webbplats"
+
+#: tfrmmain.actwipe.caption
+msgid "Wipe"
+msgstr "Säker radering"
+
+#: tfrmmain.actworkwithdirectoryhotlist.caption
+msgid "Work with Directory Hotlist and parameters"
+msgstr "Arbeta med katalogfavoriter och parametrar"
+
+#: tfrmmain.btnf10.caption
+msgctxt "TFRMMAIN.BTNF10.CAPTION"
+msgid "Exit"
+msgstr "Avsluta"
+
+#: tfrmmain.btnf7.caption
+msgctxt "tfrmmain.btnf7.caption"
+msgid "Directory"
+msgstr "Katalog"
+
+#: tfrmmain.btnf8.caption
+msgctxt "TFRMMAIN.BTNF8.CAPTION"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmmain.btnf9.caption
+msgctxt "tfrmmain.btnf9.caption"
+msgid "Terminal"
+msgstr "Terminal"
+
+#: tfrmmain.btnleftdirectoryhotlist.caption
+msgctxt "TFRMMAIN.BTNLEFTDIRECTORYHOTLIST.CAPTION"
+msgid "*"
+msgstr "*"
+
+#: tfrmmain.btnleftdirectoryhotlist.hint
+msgctxt "tfrmmain.btnleftdirectoryhotlist.hint"
+msgid "Directory Hotlist"
+msgstr "Katalogfavoriter"
+
+#: tfrmmain.btnleftequalright.caption
+msgctxt "tfrmmain.btnleftequalright.caption"
+msgid "<"
+msgstr "<"
+
+#: tfrmmain.btnleftequalright.hint
+msgid "Show current directory of the right panel in the left panel"
+msgstr "Visa aktuell katalog i höger panel i vänster panel"
+
+#: tfrmmain.btnlefthome.caption
+msgctxt "tfrmmain.btnlefthome.caption"
+msgid "~"
+msgstr "~"
+
+#: tfrmmain.btnlefthome.hint
+msgid "Go to home directory"
+msgstr "Gå till hemkatalogen"
+
+#: tfrmmain.btnleftroot.caption
+msgctxt "tfrmmain.btnleftroot.caption"
+msgid "/"
+msgstr "/"
+
+#: tfrmmain.btnleftroot.hint
+msgid "Go to root directory"
+msgstr "Gå till rotkatalogen"
+
+#: tfrmmain.btnleftup.hint
+msgid "Go to parent directory"
+msgstr "Gå till överordnad katalog"
+
+#: tfrmmain.btnrightdirectoryhotlist.caption
+msgctxt "TFRMMAIN.BTNRIGHTDIRECTORYHOTLIST.CAPTION"
+msgid "*"
+msgstr "*"
+
+#: tfrmmain.btnrightdirectoryhotlist.hint
+msgctxt "TFRMMAIN.BTNRIGHTDIRECTORYHOTLIST.HINT"
+msgid "Directory Hotlist"
+msgstr "Katalogfavoriter"
+
+#: tfrmmain.btnrightequalleft.caption
+msgctxt "tfrmmain.btnrightequalleft.caption"
+msgid ">"
+msgstr ">"
+
+#: tfrmmain.btnrightequalleft.hint
+msgid "Show current directory of the left panel in the right panel"
+msgstr "Visa aktuell katalog i vänster panel i höger panel"
+
+#: tfrmmain.btnrighthome.caption
+msgctxt "TFRMMAIN.BTNRIGHTHOME.CAPTION"
+msgid "~"
+msgstr "~"
+
+#: tfrmmain.btnrightroot.caption
+msgctxt "TFRMMAIN.BTNRIGHTROOT.CAPTION"
+msgid "/"
+msgstr "/"
+
+#: tfrmmain.caption
+msgctxt "TFRMMAIN.CAPTION"
+msgid "Double Commander"
+msgstr "Double Commander"
+
+#: tfrmmain.lblcommandpath.caption
+msgctxt "tfrmmain.lblcommandpath.caption"
+msgid "Path"
+msgstr "Sökväg"
+
+#: tfrmmain.mi2080.caption
+msgid "&20/80"
+msgstr "&20/80"
+
+#: tfrmmain.mi3070.caption
+msgid "&30/70"
+msgstr "&30/70"
+
+#: tfrmmain.mi4060.caption
+msgid "&40/60"
+msgstr "&40/60"
+
+#: tfrmmain.mi5050.caption
+msgid "&50/50"
+msgstr "&50/50"
+
+#: tfrmmain.mi6040.caption
+msgid "&60/40"
+msgstr "&60/40"
+
+#: tfrmmain.mi7030.caption
+msgid "&70/30"
+msgstr "&70/30"
+
+#: tfrmmain.mi8020.caption
+msgid "&80/20"
+msgstr "&80/20"
+
+#: tfrmmain.micancel.caption
+msgctxt "TFRMMAIN.MICANCEL.CAPTION"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmmain.micopy.caption
+msgid "Copy..."
+msgstr "Kopiera..."
+
+#: tfrmmain.mihardlink.caption
+msgid "Create link..."
+msgstr "Skapa länk..."
+
+#: tfrmmain.milogclear.caption
+msgctxt "tfrmmain.milogclear.caption"
+msgid "Clear"
+msgstr "Rensa"
+
+#: tfrmmain.milogcopy.caption
+msgctxt "TFRMMAIN.MILOGCOPY.CAPTION"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmmain.miloghide.caption
+msgid "Hide"
+msgstr "Dölj"
+
+#: tfrmmain.milogselectall.caption
+msgctxt "TFRMMAIN.MILOGSELECTALL.CAPTION"
+msgid "Select All"
+msgstr "Markera allt"
+
+#: tfrmmain.mimove.caption
+msgid "Move..."
+msgstr "Flytta..."
+
+#: tfrmmain.misymlink.caption
+msgid "Create symlink..."
+msgstr "Skapa symbolisk länk..."
+
+#: tfrmmain.mitaboptions.caption
+msgid "Tab options"
+msgstr "Flikalternativ"
+
+#: tfrmmain.mitrayiconexit.caption
+msgctxt "TFRMMAIN.MITRAYICONEXIT.CAPTION"
+msgid "E&xit"
+msgstr "A&vsluta"
+
+#: tfrmmain.mitrayiconrestore.caption
+msgctxt "tfrmmain.mitrayiconrestore.caption"
+msgid "Restore"
+msgstr "Återställ"
+
+#: tfrmmain.mnualloperpause.caption
+msgctxt "tfrmmain.mnualloperpause.caption"
+msgid "||"
+msgstr "||"
+
+#: tfrmmain.mnualloperstart.caption
+msgctxt "TFRMMAIN.MNUALLOPERSTART.CAPTION"
+msgid "Start"
+msgstr "Starta"
+
+#: tfrmmain.mnualloperstop.caption
+msgctxt "TFRMMAIN.MNUALLOPERSTOP.CAPTION"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmmain.mnucmd.caption
+msgid "&Commands"
+msgstr "&Kommandon"
+
+#: tfrmmain.mnuconfig.caption
+msgid "C&onfiguration"
+msgstr "&Inställningar"
+
+#: tfrmmain.mnufavoritetabs.caption
+msgid "F&avorites"
+msgstr "F&avoriter"
+
+#: tfrmmain.mnufiles.caption
+msgid "&Files"
+msgstr "&Filer"
+
+#: tfrmmain.mnuhelp.caption
+msgctxt "TFRMMAIN.MNUHELP.CAPTION"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmmain.mnumark.caption
+msgid "&Mark"
+msgstr "&Markera"
+
+#: tfrmmain.mnunetwork.caption
+msgctxt "tfrmmain.mnunetwork.caption"
+msgid "&Network"
+msgstr "&Nätverk"
+
+#: tfrmmain.mnuopenstash.caption
+msgctxt "tfrmmain.mnuopenstash.caption"
+msgid "Open Stash"
+msgstr "Öppna stash"
+
+#: tfrmmain.mnushow.caption
+msgctxt "tfrmmain.mnushow.caption"
+msgid "&Show"
+msgstr "&Visa"
+
+#: tfrmmain.mnutaboptions.caption
+msgid "Tab &Options"
+msgstr "Flik&alternativ"
+
+#: tfrmmain.mnutabs.caption
+msgid "&Tabs"
+msgstr "&Flikar"
+
+#: tfrmmain.tbchangedir.caption
+msgid "CD"
+msgstr "CD"
+
+#: tfrmmain.tbcopy.caption
+msgctxt "TFRMMAIN.TBCOPY.CAPTION"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmmain.tbcut.caption
+msgctxt "TFRMMAIN.TBCUT.CAPTION"
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: tfrmmain.tbdelete.caption
+msgctxt "TFRMMAIN.TBDELETE.CAPTION"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmmain.tbedit.caption
+msgctxt "TFRMMAIN.TBEDIT.CAPTION"
+msgid "Edit"
+msgstr "Redigera"
+
+#: tfrmmain.tbpaste.caption
+msgctxt "TFRMMAIN.TBPASTE.CAPTION"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: tfrmmaincommandsdlg.btncancel.caption
+msgctxt "TFRMMAINCOMMANDSDLG.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmmaincommandsdlg.btnok.caption
+msgctxt "TFRMMAINCOMMANDSDLG.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmmaincommandsdlg.caption
+msgctxt "tfrmmaincommandsdlg.caption"
+msgid "Select your internal command"
+msgstr "Välj internt kommando"
+
+#: tfrmmaincommandsdlg.cbcategorysortornot.text
+msgctxt "tfrmmaincommandsdlg.cbcategorysortornot.text"
+msgid "Legacy sorted"
+msgstr "Äldre sortering"
+
+#: tfrmmaincommandsdlg.cbcommandssortornot.text
+msgctxt "TFRMMAINCOMMANDSDLG.CBCOMMANDSSORTORNOT.TEXT"
+msgid "Legacy sorted"
+msgstr "Äldre sortering"
+
+#: tfrmmaincommandsdlg.cbselectallcategorydefault.caption
+msgid "Select all categories by default"
+msgstr "Markera alla kategorier som standard"
+
+#: tfrmmaincommandsdlg.gbselection.caption
+msgctxt "tfrmmaincommandsdlg.gbselection.caption"
+msgid "Selection:"
+msgstr "Markering:"
+
+#: tfrmmaincommandsdlg.lblcategory.caption
+msgid "&Categories:"
+msgstr "&Kategorier:"
+
+#: tfrmmaincommandsdlg.lblcommandname.caption
+msgid "Command &name:"
+msgstr "Kommando&namn:"
+
+#: tfrmmaincommandsdlg.lbledtfilter.editlabel.caption
+msgid "&Filter:"
+msgstr "&Filter:"
+
+#: tfrmmaincommandsdlg.lblhint.caption
+msgid "Hint:"
+msgstr "Tips:"
+
+#: tfrmmaincommandsdlg.lblhotkey.caption
+msgid "Hotkey:"
+msgstr "Kortkommando:"
+
+#: tfrmmaincommandsdlg.lblselectedcommand.caption
+msgid "cm_name"
+msgstr "cm_name"
+
+#: tfrmmaincommandsdlg.lblselectedcommandcategory.caption
+msgctxt "tfrmmaincommandsdlg.lblselectedcommandcategory.caption"
+msgid "Category"
+msgstr "Kategori"
+
+#: tfrmmaincommandsdlg.lblselectedcommandhelp.caption
+msgctxt "tfrmmaincommandsdlg.lblselectedcommandhelp.caption"
+msgid "Help"
+msgstr "Hjälp"
+
+#: tfrmmaincommandsdlg.lblselectedcommandhint.caption
+msgid "Hint"
+msgstr "Tips"
+
+#: tfrmmaincommandsdlg.lblselectedcommandhotkey.caption
+msgctxt "tfrmmaincommandsdlg.lblselectedcommandhotkey.caption"
+msgid "Hotkey"
+msgstr "Kortkommando"
+
+#: tfrmmaskinputdlg.btnaddattribute.caption
+msgctxt "TFRMMASKINPUTDLG.BTNADDATTRIBUTE.CAPTION"
+msgid "&Add"
+msgstr "&Lägg till"
+
+#: tfrmmaskinputdlg.btnattrshelp.caption
+msgctxt "TFRMMASKINPUTDLG.BTNATTRSHELP.CAPTION"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmmaskinputdlg.btncancel.caption
+msgctxt "TFRMMASKINPUTDLG.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmmaskinputdlg.btndefinetemplate.caption
+msgid "&Define..."
+msgstr "&Definiera..."
+
+#: tfrmmaskinputdlg.btnok.caption
+msgctxt "TFRMMASKINPUTDLG.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmmaskinputdlg.chkcasesensitive.caption
+msgctxt "tfrmmaskinputdlg.chkcasesensitive.caption"
+msgid "Case sensitive"
+msgstr "Skiftlägeskänslig"
+
+#: tfrmmaskinputdlg.chkignoreaccentsandligatures.caption
+msgid "Ignore accents and ligatures"
+msgstr "Ignorera accenter och ligaturer"
+
+#: tfrmmaskinputdlg.lblattributes.caption
+msgid "Attri&butes:"
+msgstr "Attri&but:"
+
+#: tfrmmaskinputdlg.lblprompt.caption
+msgid "Input Mask:"
+msgstr "Indatamask:"
+
+#: tfrmmaskinputdlg.lblsearchtemplate.caption
+msgid "O&r select predefined selection type:"
+msgstr "E&ller välj en fördefinierad markeringstyp:"
+
+#: tfrmmasterkey.btntest.caption
+msgid "Test"
+msgstr "Testa"
+
+#: tfrmmasterkey.caption
+msgid "Create Key"
+msgstr "Skapa nyckel"
+
+#: tfrmmasterkey.gbkeytransform.caption
+msgid "Key transformation"
+msgstr "Nyckeltransformering"
+
+#: tfrmmasterkey.gbmasterkey.caption
+msgctxt "tfrmmasterkey.gbmasterkey.caption"
+msgid "Main Password"
+msgstr "Huvudlösenord"
+
+#: tfrmmasterkey.lblfooter.caption
+msgid ""
+"The more iterations, the harder are dictionary and guessing attacks, but also password store "
+"loading/saving takes more time."
+msgstr ""
+"Ju fler iterationer, desto svårare blir ordboks- och gissningsattacker, men inläsning och lagring"
+" av lösenordsförrådet tar också längre tid."
+
+#: tfrmmasterkey.lblfunction.caption
+msgid "&Key derivation function:"
+msgstr "&Nyckelhärledningsfunktion:"
+
+#: tfrmmasterkey.lblheader.caption
+msgid ""
+"The key is transformed using a key derivation function. This adds a work factor and makes "
+"dictionary and guessing attacks harder."
+msgstr ""
+"Nyckeln transformeras med en nyckelhärledningsfunktion. Det ökar arbetsfaktorn och gör ordboks- "
+"och gissningsattacker svårare."
+
+#: tfrmmasterkey.lbliterations.caption
+msgid "&Iterations:"
+msgstr "&Iterationer:"
+
+#: tfrmmasterkey.lblmemory.caption
+msgid "&Memory:"
+msgstr "&Minne:"
+
+#: tfrmmasterkey.lblparallelism.caption
+msgid "&Parallelism:"
+msgstr "&Parallellism:"
+
+#: tfrmmasterkey.lblpassword.caption
+msgid "Pass&word:"
+msgstr "L&ösenord:"
+
+#: tfrmmasterkey.lblrepeat.caption
+msgid "&Repeat password:"
+msgstr "&Upprepa lösenord:"
+
+#: tfrmmasterkey.lbltext.caption
+msgid "Specify a new key, which will be used to encrypt the password store."
+msgstr "Ange en ny nyckel som ska användas för att kryptera lösenordsförrådet."
+
+#: tfrmmasterkey.lblunit.caption
+msgctxt "tfrmmasterkey.lblunit.caption"
+msgid "MB"
+msgstr "MB"
+
+#: tfrmmkdir.caption
+msgid "Create new directory"
+msgstr "Skapa ny katalog"
+
+#: tfrmmkdir.cbextended.caption
+msgid "&Extended syntax"
+msgstr "&Utökad syntax"
+
+#: tfrmmkdir.lblmakedir.caption
+msgid "&Input new directory name:"
+msgstr "&Ange nytt katalognamn:"
+
+#: tfrmmodview.btnpath1.caption
+msgctxt "TFRMMODVIEW.BTNPATH1.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmmodview.btnpath2.caption
+msgctxt "TFRMMODVIEW.BTNPATH2.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmmodview.btnpath3.caption
+msgctxt "TFRMMODVIEW.BTNPATH3.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmmodview.btnpath4.caption
+msgctxt "TFRMMODVIEW.BTNPATH4.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmmodview.btnpath5.caption
+msgctxt "TFRMMODVIEW.BTNPATH5.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmmodview.caption
+msgctxt "tfrmmodview.caption"
+msgid "New Size"
+msgstr "Ny storlek"
+
+#: tfrmmodview.lblheight.caption
+msgid "Height :"
+msgstr "Höjd:"
+
+#: tfrmmodview.lblpath1.caption
+msgctxt "tfrmmodview.lblpath1.caption"
+msgid "1"
+msgstr "1"
+
+#: tfrmmodview.lblpath2.caption
+msgid "2"
+msgstr "2"
+
+#: tfrmmodview.lblpath3.caption
+msgid "3"
+msgstr "3"
+
+#: tfrmmodview.lblpath4.caption
+msgid "4"
+msgstr "4"
+
+#: tfrmmodview.lblpath5.caption
+msgid "5"
+msgstr "5"
+
+#: tfrmmodview.lblquality.caption
+msgid "Quality of compress to Jpg"
+msgstr "Kvalitet för JPG-komprimering"
+
+#: tfrmmodview.lblwidth.caption
+msgid "Width :"
+msgstr "Bredd:"
+
+#: tfrmmodview.teheight.text
+msgctxt "tfrmmodview.teheight.text"
+msgid "Height"
+msgstr "Höjd"
+
+#: tfrmmodview.tewidth.text
+msgctxt "tfrmmodview.tewidth.text"
+msgid "Width"
+msgstr "Bredd"
+
+#: tfrmmsg.lblmsg.caption
+msgid "456456465465465"
+msgstr "456456465465465"
+
+#: tfrmmultirename.actanyextmask.caption
+msgctxt "tfrmmultirename.actanyextmask.caption"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: tfrmmultirename.actanynamemask.caption
+msgctxt "tfrmmultirename.actanynamemask.caption"
+msgid "Filename"
+msgstr "Filnamn"
+
+#: tfrmmultirename.actclearextmask.caption
+msgctxt "tfrmmultirename.actclearextmask.caption"
+msgid "Clear"
+msgstr "Rensa"
+
+#: tfrmmultirename.actclearnamemask.caption
+msgctxt "tfrmmultirename.actclearnamemask.caption"
+msgid "Clear"
+msgstr "Rensa"
+
+#: tfrmmultirename.actclose.caption
+msgctxt "tfrmmultirename.actclose.caption"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmmultirename.actconfig.caption
+msgid "Confi&guration"
+msgstr "Inst&ällningar"
+
+#: tfrmmultirename.actctrextmask.caption
+msgctxt "tfrmmultirename.actctrextmask.caption"
+msgid "Counter"
+msgstr "Räknare"
+
+#: tfrmmultirename.actctrnamemask.caption
+msgctxt "tfrmmultirename.actctrnamemask.caption"
+msgid "Counter"
+msgstr "Räknare"
+
+#: tfrmmultirename.actdateextmask.caption
+msgctxt "tfrmmultirename.actdateextmask.caption"
+msgid "Date"
+msgstr "Datum"
+
+#: tfrmmultirename.actdatenamemask.caption
+msgctxt "tfrmmultirename.actdatenamemask.caption"
+msgid "Date"
+msgstr "Datum"
+
+#: tfrmmultirename.actdeletepreset.caption
+msgctxt "tfrmmultirename.actdeletepreset.caption"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmmultirename.actdropdownpresetlist.caption
+msgid "Drop Down Presets List"
+msgstr "Visa lista med förinställningar"
+
+#: tfrmmultirename.acteditnames.caption
+msgid "Edit Names..."
+msgstr "Redigera namn..."
+
+#: tfrmmultirename.acteditnewnames.caption
+msgid "Edit Current New Names..."
+msgstr "Redigera aktuella nya namn..."
+
+#: tfrmmultirename.actextextmask.caption
+msgctxt "tfrmmultirename.actextextmask.caption"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: tfrmmultirename.actextnamemask.caption
+msgctxt "tfrmmultirename.actextnamemask.caption"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: tfrmmultirename.actinvokeeditor.caption
+msgctxt "tfrmmultirename.actinvokeeditor.caption"
+msgid "Edit&or"
+msgstr "Rediger&are"
+
+#: tfrmmultirename.actinvokerelativepath.caption
+msgid "Invoke Relative Path Menu"
+msgstr "Öppna meny för relativ sökväg"
+
+#: tfrmmultirename.actloadlastpreset.caption
+msgid "Load Last Preset"
+msgstr "Läs in senaste förinställningen"
+
+#: tfrmmultirename.actloadnamesfromclipboard.caption
+msgid "Load Names from Clipboard"
+msgstr "Läs in namn från urklipp"
+
+#: tfrmmultirename.actloadnamesfromfile.caption
+msgid "Load Names from File..."
+msgstr "Läs in namn från fil..."
+
+#: tfrmmultirename.actloadpreset.caption
+msgid "Load Preset by Name or Index"
+msgstr "Läs in förinställning efter namn eller index"
+
+#: tfrmmultirename.actloadpreset1.caption
+msgid "Load Preset 1"
+msgstr "Läs in förinställning 1"
+
+#: tfrmmultirename.actloadpreset2.caption
+msgid "Load Preset 2"
+msgstr "Läs in förinställning 2"
+
+#: tfrmmultirename.actloadpreset3.caption
+msgid "Load Preset 3"
+msgstr "Läs in förinställning 3"
+
+#: tfrmmultirename.actloadpreset4.caption
+msgid "Load Preset 4"
+msgstr "Läs in förinställning 4"
+
+#: tfrmmultirename.actloadpreset5.caption
+msgid "Load Preset 5"
+msgstr "Läs in förinställning 5"
+
+#: tfrmmultirename.actloadpreset6.caption
+msgid "Load Preset 6"
+msgstr "Läs in förinställning 6"
+
+#: tfrmmultirename.actloadpreset7.caption
+msgid "Load Preset 7"
+msgstr "Läs in förinställning 7"
+
+#: tfrmmultirename.actloadpreset8.caption
+msgid "Load Preset 8"
+msgstr "Läs in förinställning 8"
+
+#: tfrmmultirename.actloadpreset9.caption
+msgid "Load Preset 9"
+msgstr "Läs in förinställning 9"
+
+#: tfrmmultirename.actnameextmask.caption
+msgctxt "tfrmmultirename.actnameextmask.caption"
+msgid "Filename"
+msgstr "Filnamn"
+
+#: tfrmmultirename.actnamenamemask.caption
+msgctxt "tfrmmultirename.actnamenamemask.caption"
+msgid "Filename"
+msgstr "Filnamn"
+
+#: tfrmmultirename.actplgnextmask.caption
+msgctxt "tfrmmultirename.actplgnextmask.caption"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmmultirename.actplgnnamemask.caption
+msgctxt "tfrmmultirename.actplgnnamemask.caption"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmmultirename.actrename.caption
+msgctxt "tfrmmultirename.actrename.caption"
+msgid "&Rename"
+msgstr "&Byt namn"
+
+#: tfrmmultirename.actrenamepreset.caption
+msgctxt "tfrmmultirename.actrenamepreset.caption"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmmultirename.actresetall.caption
+msgctxt "tfrmmultirename.actresetall.caption"
+msgid "Reset &All"
+msgstr "Återställ &allt"
+
+#: tfrmmultirename.actsavepreset.caption
+msgctxt "tfrmmultirename.actsavepreset.caption"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmmultirename.actsavepresetas.caption
+msgctxt "tfrmmultirename.actsavepresetas.caption"
+msgid "Save As..."
+msgstr "Spara som..."
+
+#: tfrmmultirename.actshowpresetsmenu.caption
+msgid "Show Preset Menu"
+msgstr "Visa meny med förinställningar"
+
+#: tfrmmultirename.actsortpresets.caption
+msgid "Sort"
+msgstr "Sortera"
+
+#: tfrmmultirename.acttimeextmask.caption
+msgctxt "tfrmmultirename.acttimeextmask.caption"
+msgid "Time"
+msgstr "Tid"
+
+#: tfrmmultirename.acttimenamemask.caption
+msgctxt "tfrmmultirename.acttimenamemask.caption"
+msgid "Time"
+msgstr "Tid"
+
+#: tfrmmultirename.actviewrenamelogfile.caption
+msgid "View Rename Log File"
+msgstr "Visa loggfil för namnbyten"
+
+#: tfrmmultirename.caption
+msgctxt "tfrmmultirename.caption"
+msgid "Multi-Rename Tool"
+msgstr "Verktyg för massomdöpning"
+
+#: tfrmmultirename.cbcasesens.caption
+msgid "A≠a"
+msgstr "A≠a"
+
+#: tfrmmultirename.cbcasesens.hint
+msgctxt "tfrmmultirename.cbcasesens.hint"
+msgid "Case sensitive"
+msgstr "Skiftlägeskänslig"
+
+#: tfrmmultirename.cblog.caption
+msgid "&Log result"
+msgstr "&Logga resultat"
+
+#: tfrmmultirename.cblogappend.caption
+msgid "Append"
+msgstr "Lägg till"
+
+#: tfrmmultirename.cbonlyfirst.caption
+msgid "1x"
+msgstr "1x"
+
+#: tfrmmultirename.cbonlyfirst.hint
+msgid "Replace only once per file"
+msgstr "Ersätt endast en gång per fil"
+
+#: tfrmmultirename.cbregexp.caption
+msgid "Regular e&xpressions"
+msgstr "Reguljära u&ttryck"
+
+#: tfrmmultirename.cbrepext.caption
+msgid "E"
+msgstr "E"
+
+#: tfrmmultirename.cbrepext.hint
+msgid "Replace also in file extensions"
+msgstr "Ersätt även i filändelser"
+
+#: tfrmmultirename.cbusesubs.caption
+msgid "&Use substitution"
+msgstr "&Använd substitution"
+
+#: tfrmmultirename.cmbxwidth.text
+msgid "01"
+msgstr "01"
+
+#: tfrmmultirename.edinterval.text
+msgctxt "TFRMMULTIRENAME.EDINTERVAL.TEXT"
+msgid "1"
+msgstr "1"
+
+#: tfrmmultirename.edpoc.text
+msgctxt "TFRMMULTIRENAME.EDPOC.TEXT"
+msgid "1"
+msgstr "1"
+
+#: tfrmmultirename.gbcounter.caption
+msgctxt "tfrmmultirename.gbcounter.caption"
+msgid "Counter"
+msgstr "Räknare"
+
+#: tfrmmultirename.gbfindreplace.caption
+msgid "Find && Replace"
+msgstr "Sök && ersätt"
+
+#: tfrmmultirename.gbmaska.caption
+msgid "Mask"
+msgstr "Mask"
+
+#: tfrmmultirename.gbpresets.caption
+msgid "Presets"
+msgstr "Förinställningar"
+
+#: tfrmmultirename.lbext.caption
+msgid "&Extension"
+msgstr "&Filändelse"
+
+#: tfrmmultirename.lbfind.caption
+msgid "&Find..."
+msgstr "&Sök..."
+
+#: tfrmmultirename.lbinterval.caption
+msgid "&Interval"
+msgstr "&Intervall"
+
+#: tfrmmultirename.lbname.caption
+msgid "File &Name"
+msgstr "Fil&namn"
+
+#: tfrmmultirename.lbreplace.caption
+msgid "Re&place..."
+msgstr "E&rsätt..."
+
+#: tfrmmultirename.lbstnb.caption
+msgid "S&tart Number"
+msgstr "S&tartnummer"
+
+#: tfrmmultirename.lbwidth.caption
+msgid "&Width"
+msgstr "&Bredd"
+
+#: tfrmmultirename.miactions.caption
+msgctxt "tfrmmultirename.miactions.caption"
+msgid "Actions"
+msgstr "Åtgärder"
+
+#: tfrmmultirename.mieditor.caption
+msgctxt "tfrmmultirename.mieditor.caption"
+msgid "Editor"
+msgstr "Redigerare"
+
+#: tfrmmultirename.stringgrid.columns[0].title.caption
+msgid "Old File Name"
+msgstr "Gammalt filnamn"
+
+#: tfrmmultirename.stringgrid.columns[1].title.caption
+msgid "New File Name"
+msgstr "Nytt filnamn"
+
+#: tfrmmultirename.stringgrid.columns[2].title.caption
+msgid "File Path"
+msgstr "Filsökväg"
+
+#: tfrmmultirenamewait.caption
+msgctxt "TFRMMULTIRENAMEWAIT.CAPTION"
+msgid "Double Commander"
+msgstr "Double Commander"
+
+#: tfrmmultirenamewait.lblmessage.caption
+msgid "Click OK when you have closed the editor to load the changed names!"
+msgstr "Klicka på OK när du har stängt redigeraren för att läsa in de ändrade namnen!"
+
+#: tfrmopenwith.caption
+msgid "Choose an application"
+msgstr "Välj ett program"
+
+#: tfrmopenwith.chkcustomcommand.caption
+msgid "Custom command"
+msgstr "Anpassat kommando"
+
+#: tfrmopenwith.chksaveassociation.caption
+msgid "Save association"
+msgstr "Spara association"
+
+#: tfrmopenwith.chkuseasdefault.caption
+msgid "Set selected application as default action"
+msgstr "Använd det markerade programmet som standardåtgärd"
+
+#: tfrmopenwith.lblmimetype.caption
+#, object-pascal-format
+msgid "File type to be opened: %s"
+msgstr "Filtyp som ska öppnas: %s"
+
+#: tfrmopenwith.milistoffiles.caption
+msgid "Multiple file names"
+msgstr "Flera filnamn"
+
+#: tfrmopenwith.milistoffiles.hint
+#, object-pascal-format
+msgid "%F"
+msgstr "%F"
+
+#: tfrmopenwith.milistofurls.caption
+msgid "Multiple URIs"
+msgstr "Flera URI:er"
+
+#: tfrmopenwith.milistofurls.hint
+#, object-pascal-format
+msgid "%U"
+msgstr "%U"
+
+#: tfrmopenwith.misinglefilename.caption
+msgid "Single file name"
+msgstr "Ett filnamn"
+
+#: tfrmopenwith.misinglefilename.hint
+#, object-pascal-format
+msgid "%f"
+msgstr "%f"
+
+#: tfrmopenwith.misingleurl.caption
+msgid "Single URI"
+msgstr "En URI"
+
+#: tfrmopenwith.misingleurl.hint
+#, object-pascal-format
+msgid "%u"
+msgstr "%u"
+
+#: tfrmoptions.btnapply.caption
+msgctxt "tfrmoptions.btnapply.caption"
+msgid "&Apply"
+msgstr "&Verkställ"
+
+#: tfrmoptions.btncancel.caption
+msgctxt "TFRMOPTIONS.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmoptions.btnhelp.caption
+msgctxt "tfrmoptions.btnhelp.caption"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmoptions.btnok.caption
+msgctxt "TFRMOPTIONS.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmoptions.caption
+msgctxt "tfrmoptions.caption"
+msgid "Options"
+msgstr "Alternativ"
+
+#: tfrmoptions.lblemptyeditor.caption
+msgid "Please select one of the subpages, this page does not contain any settings."
+msgstr "Välj en av undersidorna. Den här sidan innehåller inga inställningar."
+
+#: tfrmoptionsarchivers.btnarchiveradd.caption
+msgctxt "tfrmoptionsarchivers.btnarchiveradd.caption"
+msgid "A&dd"
+msgstr "Lä&gg till"
+
+#: tfrmoptionsarchivers.btnarchiveraddhelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiveraddhelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchiverapply.caption
+msgctxt "tfrmoptionsarchivers.btnarchiverapply.caption"
+msgid "A&pply"
+msgstr "V&erkställ"
+
+#: tfrmoptionsarchivers.btnarchivercopy.caption
+msgctxt "tfrmoptionsarchivers.btnarchivercopy.caption"
+msgid "Cop&y"
+msgstr "Kop&iera"
+
+#: tfrmoptionsarchivers.btnarchiverdelete.caption
+msgctxt "tfrmoptionsarchivers.btnarchiverdelete.caption"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmoptionsarchivers.btnarchiverdeletehelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverdeletehelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchiverextracthelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverextracthelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchiverextractwithoutpathhelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverextractwithoutpathhelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchiverlisthelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverlisthelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchiverother.caption
+msgctxt "tfrmoptionsarchivers.btnarchiverother.caption"
+msgid "Oth&er..."
+msgstr "A&nnat..."
+
+#: tfrmoptionsarchivers.btnarchiverrelativer.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverrelativer.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsarchivers.btnarchiverrename.caption
+msgctxt "tfrmoptionsarchivers.btnarchiverrename.caption"
+msgid "&Rename"
+msgstr "&Byt namn"
+
+#: tfrmoptionsarchivers.btnarchiverselfextracthelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchiverselfextracthelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.btnarchivertesthelper.hint
+msgctxt "tfrmoptionsarchivers.btnarchivertesthelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsarchivers.bvlarchiverids.caption
+msgctxt "tfrmoptionsarchivers.bvlarchiverids.caption"
+msgid ""
+"ID's used with cm_OpenArchive to recognize archive by detecting its content and not via file "
+"extension:"
+msgstr ""
+"ID:n som används med cm_OpenArchive för att känna igen arkiv genom deras innehåll i stället för "
+"filändelsen:"
+
+#: tfrmoptionsarchivers.bvlarchiveroptions.caption
+msgctxt "tfrmoptionsarchivers.bvlarchiveroptions.caption"
+msgid "Options:"
+msgstr "Alternativ:"
+
+#: tfrmoptionsarchivers.bvlarchiverparsingmode.caption
+msgctxt "tfrmoptionsarchivers.bvlarchiverparsingmode.caption"
+msgid "Format parsing mode:"
+msgstr "Läge för formatparsning:"
+
+#: tfrmoptionsarchivers.chkarchiverenabled.caption
+msgctxt "tfrmoptionsarchivers.chkarchiverenabled.caption"
+msgid "E&nabled"
+msgstr "A&ktiverad"
+
+#: tfrmoptionsarchivers.chkarchivermultiarcdebug.caption
+msgid "De&bug mode"
+msgstr "Felsöknings&läge"
+
+#: tfrmoptionsarchivers.chkarchivermultiarcoutput.caption
+msgctxt "tfrmoptionsarchivers.chkarchivermultiarcoutput.caption"
+msgid "S&how console output"
+msgstr "V&isa konsolutdata"
+
+#: tfrmoptionsarchivers.chkfilenameonlylist.caption
+msgid "Use archive name without extension as list"
+msgstr "Använd arkivnamn utan filändelse som lista"
+
+#: tfrmoptionsarchivers.chkhide.caption
+msgid "Show as normal files"
+msgstr "Visa som vanliga filer"
+
+#: tfrmoptionsarchivers.ckbarchiverunixfileattributes.caption
+msgid "Uni&x file attributes"
+msgstr "Uni&x-filattribut"
+
+#: tfrmoptionsarchivers.ckbarchiverunixpath.caption
+msgid "&Unix path delimiter \"/\""
+msgstr "&Unix-sökvägsavgränsare \"/\""
+
+#: tfrmoptionsarchivers.ckbarchiverwindowsfileattributes.caption
+msgid "Windows &file attributes"
+msgstr "Windows-&filattribut"
+
+#: tfrmoptionsarchivers.ckbarchiverwindowspath.caption
+msgid "Windows path deli&miter \"\\\""
+msgstr "Windows-sökvägsavgrän&sare \"\\\""
+
+#: tfrmoptionsarchivers.lblarchiveradd.caption
+msgctxt "tfrmoptionsarchivers.lblarchiveradd.caption"
+msgid "Add&ing:"
+msgstr "Lä&gga till:"
+
+#: tfrmoptionsarchivers.lblarchiverarchiver.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverarchiver.caption"
+msgid "Arc&hiver:"
+msgstr "Ar&kiverare:"
+
+#: tfrmoptionsarchivers.lblarchiverdelete.caption
+msgid "De&lete:"
+msgstr "Ta &bort:"
+
+#: tfrmoptionsarchivers.lblarchiverdescription.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverdescription.caption"
+msgid "De&scription:"
+msgstr "Bes&krivning:"
+
+#: tfrmoptionsarchivers.lblarchiverextension.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverextension.caption"
+msgid "E&xtension:"
+msgstr "Filä&ndelse:"
+
+#: tfrmoptionsarchivers.lblarchiverextract.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverextract.caption"
+msgid "Ex&tract:"
+msgstr "Pac&ka upp:"
+
+#: tfrmoptionsarchivers.lblarchiverextractwithoutpath.caption
+msgid "Extract &without path:"
+msgstr "Packa upp &utan sökväg:"
+
+#: tfrmoptionsarchivers.lblarchiveridposition.caption
+msgid "ID Po&sition:"
+msgstr "ID-po&sition:"
+
+#: tfrmoptionsarchivers.lblarchiverids.caption
+msgid "&ID:"
+msgstr "&ID:"
+
+#: tfrmoptionsarchivers.lblarchiveridseekrange.caption
+msgid "ID See&k Range:"
+msgstr "ID-sök&intervall:"
+
+#: tfrmoptionsarchivers.lblarchiverlist.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverlist.caption"
+msgid "&List:"
+msgstr "&Lista:"
+
+#: tfrmoptionsarchivers.lblarchiverlistbox.caption
+msgid "Archi&vers:"
+msgstr "Arki&verare:"
+
+#: tfrmoptionsarchivers.lblarchiverlistend.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverlistend.caption"
+msgid "Listing &finish (optional):"
+msgstr "Slut på &listning (valfritt):"
+
+#: tfrmoptionsarchivers.lblarchiverlistformat.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverlistformat.caption"
+msgid "Listing for&mat:"
+msgstr "Listningsfor&mat:"
+
+#: tfrmoptionsarchivers.lblarchiverliststart.caption
+msgctxt "tfrmoptionsarchivers.lblarchiverliststart.caption"
+msgid "Listin&g start (optional):"
+msgstr "Start på listnin&g (valfritt):"
+
+#: tfrmoptionsarchivers.lblarchiverpasswordquery.caption
+msgid "Password &query string:"
+msgstr "Frågesträng för &lösenord:"
+
+#: tfrmoptionsarchivers.lblarchiverselfextract.caption
+msgid "Create self extractin&g archive:"
+msgstr "Skapa självuppackande arki&v:"
+
+#: tfrmoptionsarchivers.lblarchivertest.caption
+msgid "Tes&t:"
+msgstr "Tes&ta:"
+
+#: tfrmoptionsarchivers.miarchiverautoconfigure.caption
+msgid "Auto Configure"
+msgstr "Automatisk konfiguration"
+
+#: tfrmoptionsarchivers.miarchiverdisableall.caption
+msgid "Disable all"
+msgstr "Inaktivera alla"
+
+#: tfrmoptionsarchivers.miarchiverdiscardmodification.caption
+msgid "Discard modifications"
+msgstr "Förkasta ändringar"
+
+#: tfrmoptionsarchivers.miarchiverenableall.caption
+msgid "Enable all"
+msgstr "Aktivera alla"
+
+#: tfrmoptionsarchivers.miarchiverexport.caption
+msgctxt "tfrmoptionsarchivers.miarchiverexport.caption"
+msgid "Export..."
+msgstr "Exportera..."
+
+#: tfrmoptionsarchivers.miarchiverimport.caption
+msgctxt "tfrmoptionsarchivers.miarchiverimport.caption"
+msgid "Import..."
+msgstr "Importera..."
+
+#: tfrmoptionsarchivers.miarchiversortarchivers.caption
+msgid "Sort archivers"
+msgstr "Sortera arkiverare"
+
+#: tfrmoptionsarchivers.tbarchiveradditional.caption
+msgid "Additional"
+msgstr "Ytterligare"
+
+#: tfrmoptionsarchivers.tbarchivergeneral.caption
+msgctxt "tfrmoptionsarchivers.tbarchivergeneral.caption"
+msgid "General"
+msgstr "Allmänt"
+
+#: tfrmoptionsautorefresh.cbwatchattributeschange.caption
+msgid "When &size, date or attributes change"
+msgstr "När &storlek, datum eller attribut ändras"
+
+#: tfrmoptionsautorefresh.cbwatchexcludedirs.caption
+msgctxt "tfrmoptionsautorefresh.cbwatchexcludedirs.caption"
+msgid "For the following &paths and their subdirectories:"
+msgstr "För följande &sökvägar och deras underkataloger:"
+
+#: tfrmoptionsautorefresh.cbwatchfilenamechange.caption
+msgid "When &files are created, deleted or renamed"
+msgstr "När &filer skapas, tas bort eller byter namn"
+
+#: tfrmoptionsautorefresh.cbwatchonlyforeground.caption
+msgid "When application is in the &background"
+msgstr "När programmet är i &bakgrunden"
+
+#: tfrmoptionsautorefresh.gbautorefreshdisable.caption
+msgid "Disable auto-refresh"
+msgstr "Inaktivera automatisk uppdatering"
+
+#: tfrmoptionsautorefresh.gbautorefreshenable.caption
+msgid "Refresh file list"
+msgstr "Uppdatera fillista"
+
+#: tfrmoptionsbehavior.cbalwaysshowtrayicon.caption
+msgid "Al&ways show tray icon"
+msgstr "Visa &alltid ikon i systemfältet"
+
+#: tfrmoptionsbehavior.cbblacklistunmounteddevices.caption
+msgid "Automatically &hide unmounted devices"
+msgstr "Dölj automatiskt &avmonterade enheter"
+
+#: tfrmoptionsbehavior.cbminimizetotray.caption
+msgid "Mo&ve icon to system tray when minimized"
+msgstr "Flytta iko&nen till systemfältet när programmet minimeras"
+
+#: tfrmoptionsbehavior.cbonlyonce.caption
+msgid "A&llow only one copy of DC at a time"
+msgstr "Tillåt endast en &instans av DC åt gången"
+
+#: tfrmoptionsbehavior.edtdrivesblacklist.hint
+msgid "Here you can enter one or more drives or mount points, separated by \";\"."
+msgstr "Här kan du ange en eller flera enheter eller monteringspunkter, avgränsade med ”;”."
+
+#: tfrmoptionsbehavior.lbldrivesblacklist.caption
+msgid "Drives &blacklist"
+msgstr "Svartlista över &enheter"
+
+#: tfrmoptionsbriefview.gbcolumns.caption
+msgid "Columns size"
+msgstr "Kolumnstorlek"
+
+#: tfrmoptionsbriefview.gbshowfileext.caption
+msgid "Show file extensions"
+msgstr "Visa filändelser"
+
+#: tfrmoptionsbriefview.rbaligned.caption
+msgid "ali&gned (with Tab)"
+msgstr "j&usterat (med Tab)"
+
+#: tfrmoptionsbriefview.rbdirectly.caption
+msgid "di&rectly after filename"
+msgstr "di&rekt efter filnamnet"
+
+#: tfrmoptionsbriefview.rbuseautosize.caption
+msgid "Auto"
+msgstr "Automatiskt"
+
+#: tfrmoptionsbriefview.rbusefixedcount.caption
+msgid "Fixed columns count"
+msgstr "Fast antal kolumner"
+
+#: tfrmoptionsbriefview.rbusefixedwidth.caption
+msgid "Fixed columns width"
+msgstr "Fast kolumnbredd"
+
+#: tfrmoptionscolors.cbbusegradientind.caption
+msgid "Use &Gradient Indicator"
+msgstr "Använd &gradientindikator"
+
+#: tfrmoptionscolors.dbbinarymode.caption
+msgctxt "tfrmoptionscolors.dbbinarymode.caption"
+msgid "Binary Mode"
+msgstr "Binärt läge"
+
+#: tfrmoptionscolors.dbbookmode.caption
+msgid "Book Mode"
+msgstr "Bokläge"
+
+#: tfrmoptionscolors.dbimagemode.caption
+msgid "Image Mode"
+msgstr "Bildläge"
+
+#: tfrmoptionscolors.dbtextmode.caption
+msgid "Text Mode"
+msgstr "Textläge"
+
+#: tfrmoptionscolors.lbladded.caption
+msgid "Added:"
+msgstr "Tillagd:"
+
+#: tfrmoptionscolors.lblbookbackground.caption
+msgctxt "tfrmoptionscolors.lblbookbackground.caption"
+msgid "Background:"
+msgstr "Bakgrund:"
+
+#: tfrmoptionscolors.lblbooktext.caption
+msgctxt "tfrmoptionscolors.lblbooktext.caption"
+msgid "Text:"
+msgstr "Text:"
+
+#: tfrmoptionscolors.lblcategory.caption
+msgid "Category:"
+msgstr "Kategori:"
+
+#: tfrmoptionscolors.lbldeleted.caption
+msgid "Deleted:"
+msgstr "Borttagen:"
+
+#: tfrmoptionscolors.lblerror.caption
+msgid "Error:"
+msgstr "Fel:"
+
+#: tfrmoptionscolors.lblimagebackground1.caption
+msgid "Background 1:"
+msgstr "Bakgrund 1:"
+
+#: tfrmoptionscolors.lblimagebackground2.caption
+msgctxt "tfrmoptionscolors.lblimagebackground2.caption"
+msgid "Background 2:"
+msgstr "Bakgrund 2:"
+
+#: tfrmoptionscolors.lblindbackcolor.caption
+msgid "In&dicator Back Color:"
+msgstr "Indikatorns &bakgrundsfärg:"
+
+#: tfrmoptionscolors.lblindcolor.caption
+msgid "&Indicator Fore Color:"
+msgstr "Indikatorns &förgrundsfärg:"
+
+#: tfrmoptionscolors.lblindthresholdcolor.caption
+msgid "Indicator &Threshold Color:"
+msgstr "Indikatorns &tröskelfärg:"
+
+#: tfrmoptionscolors.lblinformation.caption
+msgid "Information:"
+msgstr "Information:"
+
+#: tfrmoptionscolors.lblleft.caption
+msgid "Left:"
+msgstr "Vänster:"
+
+#: tfrmoptionscolors.lblmodified.caption
+msgctxt "tfrmoptionscolors.lblmodified.caption"
+msgid "Modified:"
+msgstr "Ändrad:"
+
+#: tfrmoptionscolors.lblmodifiedbinary.caption
+msgctxt "tfrmoptionscolors.lblmodifiedbinary.caption"
+msgid "Modified:"
+msgstr "Ändrad:"
+
+#: tfrmoptionscolors.lblright.caption
+msgid "Right:"
+msgstr "Höger:"
+
+#: tfrmoptionscolors.lblselection.caption
+msgctxt "tfrmoptionscolors.lblselection.caption"
+msgid "Selection:"
+msgstr "Markering:"
+
+#: tfrmoptionscolors.lblsuccess.caption
+msgctxt "tfrmoptionscolors.lblsuccess.caption"
+msgid "Success:"
+msgstr "Lyckades:"
+
+#: tfrmoptionscolors.lblunknown.caption
+msgid "Unknown:"
+msgstr "Okänd:"
+
+#: tfrmoptionscolors.rgdarkmode.caption
+msgid "State"
+msgstr "Tillstånd"
+
+#: tfrmoptionscolumnsview.cbcolumnstitlelikevalues.caption
+msgid "Column titles alignment &like values"
+msgstr "Justera kolumnrubriker &som värden"
+
+#: tfrmoptionscolumnsview.cbcuttexttocolwidth.caption
+msgid "Cut &text to column width"
+msgstr "Klipp &text till kolumnbredd"
+
+#: tfrmoptionscolumnsview.cbextendcellwidth.caption
+msgid "&Extend cell width if text is not fitting into column"
+msgstr "&Utöka cellbredden om texten inte ryms i kolumnen"
+
+#: tfrmoptionscolumnsview.cbgridhorzline.caption
+msgid "&Horizontal lines"
+msgstr "&Horisontella linjer"
+
+#: tfrmoptionscolumnsview.cbgridvertline.caption
+msgid "&Vertical lines"
+msgstr "&Vertikala linjer"
+
+#: tfrmoptionscolumnsview.chkautofillcolumns.caption
+msgid "A&uto fill columns"
+msgstr "F&yll kolumner automatiskt"
+
+#: tfrmoptionscolumnsview.gbshowgrid.caption
+msgid "Show grid"
+msgstr "Visa rutnät"
+
+#: tfrmoptionscolumnsview.grpautosizecolumns.caption
+msgid "Auto-size columns"
+msgstr "Anpassa kolumnstorlek automatiskt"
+
+#: tfrmoptionscolumnsview.lblautosizecolumn.caption
+msgid "Auto si&ze column:"
+msgstr "Anpassa kolumn&storlek automatiskt:"
+
+#: tfrmoptionsconfiguration.btnconfigapply.caption
+msgctxt "TFRMOPTIONSCONFIGURATION.BTNCONFIGAPPLY.CAPTION"
+msgid "A&pply"
+msgstr "V&erkställ"
+
+#: tfrmoptionsconfiguration.btnconfigedit.caption
+msgctxt "TFRMOPTIONSCONFIGURATION.BTNCONFIGEDIT.CAPTION"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmoptionsconfiguration.cbcmdlinehistory.caption
+msgid "Co&mmand line history"
+msgstr "Ko&mmandoradshistorik"
+
+#: tfrmoptionsconfiguration.cbdirhistory.caption
+msgid "&Directory history"
+msgstr "&Kataloghistorik"
+
+#: tfrmoptionsconfiguration.cbfilemaskhistory.caption
+msgid "&File mask history"
+msgstr "&Historik över filmmasker"
+
+#: tfrmoptionsconfiguration.chkfoldertabs.caption
+msgctxt "tfrmoptionsconfiguration.chkfoldertabs.caption"
+msgid "Folder tabs"
+msgstr "Mappflikar"
+
+#: tfrmoptionsconfiguration.chksaveconfiguration.caption
+msgid "Sa&ve configuration"
+msgstr "S&para konfiguration"
+
+#: tfrmoptionsconfiguration.chksearchreplacehistory.caption
+msgid "Searc&h/Replace history"
+msgstr "Sök-/ersättnings&historik"
+
+#: tfrmoptionsconfiguration.chkwindowstate.caption
+msgid "Main window state"
+msgstr "Huvudfönstrets tillstånd"
+
+#: tfrmoptionsconfiguration.gbdirectories.caption
+msgctxt "TFRMOPTIONSCONFIGURATION.GBDIRECTORIES.CAPTION"
+msgid "Directories"
+msgstr "Kataloger"
+
+#: tfrmoptionsconfiguration.gblocconfigfiles.caption
+msgid "Location of configuration files"
+msgstr "Plats för konfigurationsfiler"
+
+#: tfrmoptionsconfiguration.gbsaveonexit.caption
+msgid "Save on exit"
+msgstr "Spara vid avslut"
+
+#: tfrmoptionsconfiguration.gbsortorderconfigurationoption.caption
+msgid "Sort order of configuration order in left tree"
+msgstr "Sorteringsordning för konfigurationen i vänstra trädet"
+
+#: tfrmoptionsconfiguration.gpconfigurationtreestate.caption
+msgid "Tree state when entering in configuration page"
+msgstr "Trädets tillstånd när konfigurationssidan öppnas"
+
+#: tfrmoptionsconfiguration.lblcmdlineconfigdir.caption
+msgid "Set on command line"
+msgstr "Ställ in på kommandoraden"
+
+#: tfrmoptionsconfiguration.lblhighlighters.caption
+msgid "Highlighters:"
+msgstr "Syntaxmarkeringar:"
+
+#: tfrmoptionsconfiguration.lbliconthemes.caption
+msgid "Icon themes:"
+msgstr "Ikonteman:"
+
+#: tfrmoptionsconfiguration.lblthumbcache.caption
+msgid "Thumbnails cache:"
+msgstr "Miniatyrcache:"
+
+#: tfrmoptionsconfiguration.rbprogramdir.caption
+msgid "P&rogram directory (portable version)"
+msgstr "P&rogramkatalog (portabel version)"
+
+#: tfrmoptionsconfiguration.rbuserhomedir.caption
+msgid "&User home directory"
+msgstr "&Användarens hemkatalog"
+
+#: tfrmoptionscustomcolumns.btnallallowovercolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLALLOWOVERCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallallowovercolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLALLOWOVERCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallbackcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLBACKCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallbackcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLBACKCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallbackcolor2.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLBACKCOLOR2.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallbackcolor2.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLBACKCOLOR2.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallcursorcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLCURSORCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallcursorcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLCURSORCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallcursortext.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLCURSORTEXT.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallcursortext.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLCURSORTEXT.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallfont.caption
+msgctxt "tfrmoptionscustomcolumns.btnallfont.caption"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallfont.hint
+msgctxt "tfrmoptionscustomcolumns.btnallfont.hint"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallforecolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLFORECOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallforecolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLFORECOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallinactivecursorcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLINACTIVECURSORCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallinactivecursorcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLINACTIVECURSORCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallinactivemarkcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLINACTIVEMARKCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallinactivemarkcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLINACTIVEMARKCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnallmarkcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLMARKCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnallmarkcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLMARKCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnalluseinactiveselcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLUSEINACTIVESELCOLOR.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnalluseinactiveselcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLUSEINACTIVESELCOLOR.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btnalluseinvertedselection.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLUSEINVERTEDSELECTION.CAPTION"
+msgid "All"
+msgstr "Alla"
+
+#: tfrmoptionscustomcolumns.btnalluseinvertedselection.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNALLUSEINVERTEDSELECTION.HINT"
+msgid "Apply modification to all columns"
+msgstr "Verkställ ändringen på alla kolumner"
+
+#: tfrmoptionscustomcolumns.btndeleteconfigcolumns.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNDELETECONFIGCOLUMNS.CAPTION"
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: tfrmoptionscustomcolumns.btnfont.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNFONT.CAPTION"
+msgid "..."
+msgstr "..."
+
+#: tfrmoptionscustomcolumns.btngotosetdefault.caption
+msgid "Go to set default"
+msgstr "Gå till standardinställning"
+
+#: tfrmoptionscustomcolumns.btnnewconfig.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNNEWCONFIG.CAPTION"
+msgid "New"
+msgstr "Ny"
+
+#: tfrmoptionscustomcolumns.btnnext.caption
+msgid "Next"
+msgstr "Nästa"
+
+#: tfrmoptionscustomcolumns.btnprev.caption
+msgid "Previous"
+msgstr "Föregående"
+
+#: tfrmoptionscustomcolumns.btnrenameconfigcolumns.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRENAMECONFIGCOLUMNS.CAPTION"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmoptionscustomcolumns.btnresetallowovercolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETALLOWOVERCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetallowovercolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETALLOWOVERCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetbackcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETBACKCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetbackcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETBACKCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetbackcolor2.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETBACKCOLOR2.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetbackcolor2.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETBACKCOLOR2.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetcursorborder.caption
+msgctxt "tfrmoptionscustomcolumns.btnresetcursorborder.caption"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetcursorborder.hint
+msgctxt "tfrmoptionscustomcolumns.btnresetcursorborder.hint"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetcursorcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETCURSORCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetcursorcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETCURSORCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetcursortext.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETCURSORTEXT.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetcursortext.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETCURSORTEXT.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetfont.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFONT.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetfont.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFONT.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetforecolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFORECOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetforecolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFORECOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetframecursor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFRAMECURSOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetframecursor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETFRAMECURSOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetinactivecursorcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETINACTIVECURSORCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetinactivecursorcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETINACTIVECURSORCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetinactivemarkcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETINACTIVEMARKCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetinactivemarkcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETINACTIVEMARKCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetmarkcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETMARKCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetmarkcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETMARKCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetuseinactiveselcolor.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETUSEINACTIVESELCOLOR.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetuseinactiveselcolor.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETUSEINACTIVESELCOLOR.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnresetuseinvertedselection.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETUSEINVERTEDSELECTION.CAPTION"
+msgid "R"
+msgstr "R"
+
+#: tfrmoptionscustomcolumns.btnresetuseinvertedselection.hint
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNRESETUSEINVERTEDSELECTION.HINT"
+msgid "Reset to default"
+msgstr "Återställ standardvärde"
+
+#: tfrmoptionscustomcolumns.btnsaveasconfigcolumns.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNSAVEASCONFIGCOLUMNS.CAPTION"
+msgid "Save as"
+msgstr "Spara som"
+
+#: tfrmoptionscustomcolumns.btnsaveconfigcolumns.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.BTNSAVECONFIGCOLUMNS.CAPTION"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmoptionscustomcolumns.cballowovercolor.caption
+msgctxt "tfrmoptionscustomcolumns.cballowovercolor.caption"
+msgid "Allow Overcolor"
+msgstr "Tillåt överfärgning"
+
+#: tfrmoptionscustomcolumns.cbapplychangeforallcolumns.caption
+msgid "When clicking to change something, change for all columns"
+msgstr "När du klickar för att ändra något, ändra för alla kolumner"
+
+#: tfrmoptionscustomcolumns.cbconfigcolumns.text
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.CBCONFIGCOLUMNS.TEXT"
+msgid "General"
+msgstr "Allmänt"
+
+#: tfrmoptionscustomcolumns.cbcursorborder.caption
+msgctxt "tfrmoptionscustomcolumns.cbcursorborder.caption"
+msgid "Cursor border"
+msgstr "Markörram"
+
+#: tfrmoptionscustomcolumns.cbuseframecursor.caption
+msgid "Use Frame Cursor"
+msgstr "Använd rammarkör"
+
+#: tfrmoptionscustomcolumns.cbuseinactiveselcolor.caption
+msgid "Use Inactive Selection Color"
+msgstr "Använd färg för inaktiv markering"
+
+#: tfrmoptionscustomcolumns.cbuseinvertedselection.caption
+msgid "Use Inverted Selection"
+msgstr "Använd inverterad markering"
+
+#: tfrmoptionscustomcolumns.chkusecustomview.caption
+msgid "Use custom font and color for this view"
+msgstr "Använd anpassat teckensnitt och färg för den här vyn"
+
+#: tfrmoptionscustomcolumns.lblbackcolor.caption
+msgid "BackGround:"
+msgstr "Bakgrund:"
+
+#: tfrmoptionscustomcolumns.lblbackcolor2.caption
+msgctxt "tfrmoptionscustomcolumns.lblbackcolor2.caption"
+msgid "Background 2:"
+msgstr "Bakgrund 2:"
+
+#: tfrmoptionscustomcolumns.lblconfigcolumns.caption
+msgid "&Columns view:"
+msgstr "&Kolumnvy:"
+
+#: tfrmoptionscustomcolumns.lblcurrentcolumn.caption
+msgid "[Current Column Name]"
+msgstr "[Aktuellt kolumnnamn]"
+
+#: tfrmoptionscustomcolumns.lblcursorcolor.caption
+msgid "Cursor Color:"
+msgstr "Markörfärg:"
+
+#: tfrmoptionscustomcolumns.lblcursortext.caption
+msgid "Cursor Text:"
+msgstr "Markörtext:"
+
+#: tfrmoptionscustomcolumns.lblfilesystem.caption
+msgid "&File system:"
+msgstr "&Filsystem:"
+
+#: tfrmoptionscustomcolumns.lblfontname.caption
+msgid "Font:"
+msgstr "Teckensnitt:"
+
+#: tfrmoptionscustomcolumns.lblfontsize.caption
+msgctxt "TFRMOPTIONSCUSTOMCOLUMNS.LBLFONTSIZE.CAPTION"
+msgid "Size:"
+msgstr "Storlek:"
+
+#: tfrmoptionscustomcolumns.lblforecolor.caption
+msgctxt "tfrmoptionscustomcolumns.lblforecolor.caption"
+msgid "Text Color:"
+msgstr "Textfärg:"
+
+#: tfrmoptionscustomcolumns.lblinactivecursorcolor.caption
+msgctxt "tfrmoptionscustomcolumns.lblinactivecursorcolor.caption"
+msgid "Inactive Cursor Color:"
+msgstr "Färg för inaktiv markör:"
+
+#: tfrmoptionscustomcolumns.lblinactivemarkcolor.caption
+msgctxt "tfrmoptionscustomcolumns.lblinactivemarkcolor.caption"
+msgid "Inactive Mark Color:"
+msgstr "Färg för inaktiv markering:"
+
+#: tfrmoptionscustomcolumns.lblmarkcolor.caption
+msgid "Mark Color:"
+msgstr "Markeringsfärg:"
+
+#: tfrmoptionscustomcolumns.lblpreviewtop.caption
+msgctxt "tfrmoptionscustomcolumns.lblpreviewtop.caption"
+msgid ""
+"Below is a preview. You may move cursor and select files to get immediately an actual look and "
+"feel of the various settings."
+msgstr ""
+"Nedan visas en förhandsgranskning. Du kan flytta markören och markera filer för att omedelbart se"
+" hur de olika inställningarna ser ut och fungerar."
+
+#: tfrmoptionscustomcolumns.lblworkingcolumn.caption
+msgid "Settings for column:"
+msgstr "Inställningar för kolumn:"
+
+#: tfrmoptionscustomcolumns.miaddcolumn.caption
+msgid "Add column"
+msgstr "Lägg till kolumn"
+
+#: tfrmoptionsdiffer.rgresultingframepositionaftercompare.caption
+msgid "Position of frame panel after the comparison:"
+msgstr "Panelens position efter jämförelsen:"
+
+#: tfrmoptionsdirectoryhotlist.actaddactiveframedir.caption
+msgid "Add directory of the &active frame"
+msgstr "Lägg till katalogen från den &aktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actaddbothframedir.caption
+msgid "Add &directories of the active && inactive frames"
+msgstr "Lägg till &katalogerna från den aktiva && inaktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actaddbrowseddir.caption
+msgid "Add directory I will bro&wse to"
+msgstr "Lägg till katalog som jag &bläddrar till"
+
+#: tfrmoptionsdirectoryhotlist.actaddcopyofentry.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actaddcopyofentry.caption"
+msgid "Add a copy of the selected entry"
+msgstr "Lägg till en kopia av den markerade posten"
+
+#: tfrmoptionsdirectoryhotlist.actaddselectionsfromframe.caption
+msgid "Add current &selected or active directories of active frame"
+msgstr "Lägg till aktuella &markerade eller aktiva kataloger från den aktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actaddseparator.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actaddseparator.caption"
+msgid "Add a separator"
+msgstr "Lägg till en avgränsare"
+
+#: tfrmoptionsdirectoryhotlist.actaddsubmenu.caption
+msgid "Add a sub menu"
+msgstr "Lägg till en undermeny"
+
+#: tfrmoptionsdirectoryhotlist.actaddtypeddir.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actaddtypeddir.caption"
+msgid "Add directory I will type"
+msgstr "Lägg till katalog som jag skriver in"
+
+#: tfrmoptionsdirectoryhotlist.actcollapseall.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actcollapseall.caption"
+msgid "Collapse all"
+msgstr "Fäll ihop alla"
+
+#: tfrmoptionsdirectoryhotlist.actcollapseitem.caption
+msgid "Collapse item"
+msgstr "Fäll ihop objekt"
+
+#: tfrmoptionsdirectoryhotlist.actcut.caption
+msgid "Cut selection of entries"
+msgstr "Klipp ut markerade poster"
+
+#: tfrmoptionsdirectoryhotlist.actdeleteall.caption
+msgid "Delete all!"
+msgstr "Ta bort alla!"
+
+#: tfrmoptionsdirectoryhotlist.actdeleteselecteditem.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actdeleteselecteditem.caption"
+msgid "Delete selected item"
+msgstr "Ta bort markerat objekt"
+
+#: tfrmoptionsdirectoryhotlist.actdeletesubmenuandelem.caption
+msgid "Delete sub-menu and all its elements"
+msgstr "Ta bort undermeny och alla dess objekt"
+
+#: tfrmoptionsdirectoryhotlist.actdeletesubmenukeepelem.caption
+msgid "Delete just sub-menu but keep elements"
+msgstr "Ta bara bort undermenyn men behåll objekten"
+
+#: tfrmoptionsdirectoryhotlist.actexpanditem.caption
+msgid "Expand item"
+msgstr "Fäll ut objekt"
+
+#: tfrmoptionsdirectoryhotlist.actfocustreewindow.caption
+msgid "Focus tree window"
+msgstr "Fokusera trädfönstret"
+
+#: tfrmoptionsdirectoryhotlist.actgotofirstitem.caption
+msgid "Goto first item"
+msgstr "Gå till första objektet"
+
+#: tfrmoptionsdirectoryhotlist.actgotolastitem.caption
+msgid "Goto last item"
+msgstr "Gå till sista objektet"
+
+#: tfrmoptionsdirectoryhotlist.actgotonextitem.caption
+msgid "Go to next item"
+msgstr "Gå till nästa objekt"
+
+#: tfrmoptionsdirectoryhotlist.actgotopreviousitem.caption
+msgid "Go to previous item"
+msgstr "Gå till föregående objekt"
+
+#: tfrmoptionsdirectoryhotlist.actinsertactiveframedir.caption
+msgid "Insert directory of the &active frame"
+msgstr "Infoga katalogen från den &aktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actinsertbothframedir.caption
+msgid "Insert &directories of the active && inactive frames"
+msgstr "Infoga &katalogerna från den aktiva && inaktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actinsertbrowseddir.caption
+msgid "Insert directory I will bro&wse to"
+msgstr "Infoga katalog som jag &bläddrar till"
+
+#: tfrmoptionsdirectoryhotlist.actinsertcopyofentry.caption
+msgid "Insert a copy of the selected entry"
+msgstr "Infoga en kopia av den markerade posten"
+
+#: tfrmoptionsdirectoryhotlist.actinsertselectionsfromframe.caption
+msgid "Insert current &selected or active directories of active frame"
+msgstr "Infoga aktuella &markerade eller aktiva kataloger från den aktiva panelen"
+
+#: tfrmoptionsdirectoryhotlist.actinsertseparator.caption
+msgid "Insert a separator"
+msgstr "Infoga en avgränsare"
+
+#: tfrmoptionsdirectoryhotlist.actinsertsubmenu.caption
+msgid "Insert sub menu"
+msgstr "Infoga undermeny"
+
+#: tfrmoptionsdirectoryhotlist.actinserttypeddir.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actinserttypeddir.caption"
+msgid "Insert directory I will type"
+msgstr "Infoga katalog som jag skriver in"
+
+#: tfrmoptionsdirectoryhotlist.actmovetonext.caption
+msgid "Move to next"
+msgstr "Flytta till nästa"
+
+#: tfrmoptionsdirectoryhotlist.actmovetoprevious.caption
+msgid "Move to previous"
+msgstr "Flytta till föregående"
+
+#: tfrmoptionsdirectoryhotlist.actopenallbranches.caption
+msgctxt "tfrmoptionsdirectoryhotlist.actopenallbranches.caption"
+msgid "Open all branches"
+msgstr "Öppna alla grenar"
+
+#: tfrmoptionsdirectoryhotlist.actpaste.caption
+msgid "Paste what was cut"
+msgstr "Klistra in det som klipptes ut"
+
+#: tfrmoptionsdirectoryhotlist.actsearchandreplaceinpath.caption
+msgid "Search && replace in &path"
+msgstr "Sök && ersätt i &sökväg"
+
+#: tfrmoptionsdirectoryhotlist.actsearchandreplaceinpathandtarget.caption
+msgid "Search && replace in both path and target"
+msgstr "Sök && ersätt i både sökväg och mål"
+
+#: tfrmoptionsdirectoryhotlist.actsearchandreplaceintargetpath.caption
+msgid "Search && replace in &target path"
+msgstr "Sök && ersätt i &målsökväg"
+
+#: tfrmoptionsdirectoryhotlist.acttweakpath.caption
+msgid "Tweak path"
+msgstr "Justera sökväg"
+
+#: tfrmoptionsdirectoryhotlist.acttweaktargetpath.caption
+msgid "Tweak target path"
+msgstr "Justera målsökväg"
+
+#: tfrmoptionsdirectoryhotlist.btnadd.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btnadd.caption"
+msgid "A&dd..."
+msgstr "Lä&gg till..."
+
+#: tfrmoptionsdirectoryhotlist.btnbackup.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btnbackup.caption"
+msgid "Bac&kup..."
+msgstr "Säker&hetskopiera..."
+
+#: tfrmoptionsdirectoryhotlist.btndelete.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btndelete.caption"
+msgid "De&lete..."
+msgstr "Ta &bort..."
+
+#: tfrmoptionsdirectoryhotlist.btnexport.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btnexport.caption"
+msgid "E&xport..."
+msgstr "E&xportera..."
+
+#: tfrmoptionsdirectoryhotlist.btnimport.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btnimport.caption"
+msgid "Impo&rt..."
+msgstr "Impo&rtera..."
+
+#: tfrmoptionsdirectoryhotlist.btninsert.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btninsert.caption"
+msgid "&Insert..."
+msgstr "&Infoga..."
+
+#: tfrmoptionsdirectoryhotlist.btnmiscellaneous.caption
+msgid "&Miscellaneous..."
+msgstr "&Övrigt..."
+
+#: tfrmoptionsdirectoryhotlist.btnrelativepath.hint
+msgctxt "TFRMOPTIONSDIRECTORYHOTLIST.BTNRELATIVEPATH.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsdirectoryhotlist.btnrelativetarget.hint
+msgid "Some functions to select appropriate target"
+msgstr "Funktioner för att välja lämpligt mål"
+
+#: tfrmoptionsdirectoryhotlist.btnsort.caption
+msgctxt "tfrmoptionsdirectoryhotlist.btnsort.caption"
+msgid "&Sort..."
+msgstr "&Sortera..."
+
+#: tfrmoptionsdirectoryhotlist.cbaddtarget.caption
+msgid "&When adding directory, add also target"
+msgstr "&Lägg även till mål när en katalog läggs till"
+
+#: tfrmoptionsdirectoryhotlist.cbfullexpandtree.caption
+msgctxt "tfrmoptionsdirectoryhotlist.cbfullexpandtree.caption"
+msgid "Alwa&ys expand tree"
+msgstr "Fäll allti&d ut trädet"
+
+#: tfrmoptionsdirectoryhotlist.cbshowonlyvalidenv.caption
+msgid "Show only &valid environment variables"
+msgstr "Visa endast &giltiga miljövariabler"
+
+#: tfrmoptionsdirectoryhotlist.cbshowpathinpopup.caption
+msgid "In pop&up, show [path also]"
+msgstr "Visa [även sökväg] i pop&up-fönster"
+
+#: tfrmoptionsdirectoryhotlist.cbsorthotdirpath.text
+msgctxt "tfrmoptionsdirectoryhotlist.cbsorthotdirpath.text"
+msgid "Name, a-z"
+msgstr "Namn, a–ö"
+
+#: tfrmoptionsdirectoryhotlist.cbsorthotdirtarget.text
+msgctxt "TFRMOPTIONSDIRECTORYHOTLIST.CBSORTHOTDIRTARGET.TEXT"
+msgid "Name, a-z"
+msgstr "Namn, a–ö"
+
+#: tfrmoptionsdirectoryhotlist.gbdirectoryhotlist.caption
+msgid "Directory Hotlist (reorder by drag && drop)"
+msgstr "Katalogfavoriter (ordna om med dra && släpp)"
+
+#: tfrmoptionsdirectoryhotlist.gbhotlistotheroptions.caption
+msgctxt "tfrmoptionsdirectoryhotlist.gbhotlistotheroptions.caption"
+msgid "Other options"
+msgstr "Övriga alternativ"
+
+#: tfrmoptionsdirectoryhotlist.lbledithotdirname.editlabel.caption
+msgctxt "TFRMOPTIONSDIRECTORYHOTLIST.LBLEDITHOTDIRNAME.EDITLABEL.CAPTION"
+msgid "Name:"
+msgstr "Namn:"
+
+#: tfrmoptionsdirectoryhotlist.lbledithotdirpath.editlabel.caption
+msgctxt "TFRMOPTIONSDIRECTORYHOTLIST.LBLEDITHOTDIRPATH.EDITLABEL.CAPTION"
+msgid "Path:"
+msgstr "Sökväg:"
+
+#: tfrmoptionsdirectoryhotlist.lbledithotdirtarget.editlabel.caption
+msgid "&Target:"
+msgstr "&Mål:"
+
+#: tfrmoptionsdirectoryhotlist.micurrentlevelofitemonly.caption
+msgctxt "tfrmoptionsdirectoryhotlist.micurrentlevelofitemonly.caption"
+msgid "...current le&vel of item(s) selected only"
+msgstr "...endast aktuell ni&vå för markerade objekt"
+
+#: tfrmoptionsdirectoryhotlist.midetectifpathexist.caption
+msgid "Scan all &hotdir's path to validate the ones that actually exist"
+msgstr "Sök igenom alla &katalogfavoriters sökvägar och kontrollera vilka som faktiskt finns"
+
+#: tfrmoptionsdirectoryhotlist.midetectifpathtargetexist.caption
+msgid "&Scan all hotdir's path && target to validate the ones that actually exist"
+msgstr "&Kontrollera alla sökvägar && mål i katalogfavoriter för att validera dem som faktiskt finns"
+
+#: tfrmoptionsdirectoryhotlist.miexporttohotlistfile.caption
+msgid "to a Directory &Hotlist file (.hotlist)"
+msgstr "till en &katalogfavoritfil (.hotlist)"
+
+#: tfrmoptionsdirectoryhotlist.miexporttototalcommanderk.caption
+msgctxt "tfrmoptionsdirectoryhotlist.miexporttototalcommanderk.caption"
+msgid "to a \"wincmd.ini\" of TC (&keep existing)"
+msgstr "till TC:s ”wincmd.ini” (&behåll befintliga)"
+
+#: tfrmoptionsdirectoryhotlist.miexporttototalcommandernk.caption
+msgctxt "tfrmoptionsdirectoryhotlist.miexporttototalcommandernk.caption"
+msgid "to a \"wincmd.ini\" of TC (&erase existing)"
+msgstr "till TC:s ”wincmd.ini” (&radera befintliga)"
+
+#: tfrmoptionsdirectoryhotlist.migotoconfiguretcinfo1.caption
+msgctxt "tfrmoptionsdirectoryhotlist.migotoconfiguretcinfo1.caption"
+msgid "Go to &configure TC related info"
+msgstr "Gå till &konfiguration av TC-relaterad information"
+
+#: tfrmoptionsdirectoryhotlist.migotoconfiguretcinfo2.caption
+msgctxt "TFRMOPTIONSDIRECTORYHOTLIST.MIGOTOCONFIGURETCINFO2.CAPTION"
+msgid "Go to &configure TC related info"
+msgstr "Gå till &konfiguration av TC-relaterad information"
+
+#: tfrmoptionsdirectoryhotlist.mihotdirtestmenu.caption
+msgid "HotDirTestMenu"
+msgstr "Testmeny för katalogfavoriter"
+
+#: tfrmoptionsdirectoryhotlist.miimportfromhotlistfile.caption
+msgid "from a Directory &Hotlist file (.hotlist)"
+msgstr "från en &katalogfavoritfil (.hotlist)"
+
+#: tfrmoptionsdirectoryhotlist.miimporttotalcommander.caption
+msgid "from \"&wincmd.ini\" of TC"
+msgstr "från TC:s ”&wincmd.ini”"
+
+#: tfrmoptionsdirectoryhotlist.minavigate.caption
+msgid "&Navigate..."
+msgstr "&Navigera..."
+
+#: tfrmoptionsdirectoryhotlist.mirestorebackuphotlist.caption
+msgid "&Restore a backup of Directory Hotlist"
+msgstr "&Återställ en säkerhetskopia av katalogfavoriter"
+
+#: tfrmoptionsdirectoryhotlist.misavebackuphotlist.caption
+msgid "&Save a backup of current Directory Hotlist"
+msgstr "&Spara en säkerhetskopia av aktuella katalogfavoriter"
+
+#: tfrmoptionsdirectoryhotlist.misearchandreplace.caption
+msgctxt "tfrmoptionsdirectoryhotlist.misearchandreplace.caption"
+msgid "Search and &replace..."
+msgstr "Sök och &ersätt..."
+
+#: tfrmoptionsdirectoryhotlist.misorteverything.caption
+msgctxt "tfrmoptionsdirectoryhotlist.misorteverything.caption"
+msgid "...everything, from A to &Z!"
+msgstr "...allt, från A till &Ö!"
+
+#: tfrmoptionsdirectoryhotlist.misortsinglegroup.caption
+msgctxt "tfrmoptionsdirectoryhotlist.misortsinglegroup.caption"
+msgid "...single &group of item(s) only"
+msgstr "...endast en &grupp med objekt"
+
+#: tfrmoptionsdirectoryhotlist.misortsinglesubmenu.caption
+msgctxt "tfrmoptionsdirectoryhotlist.misortsinglesubmenu.caption"
+msgid "...&content of submenu(s) selected, no sublevel"
+msgstr "...&innehållet i markerade undermenyer, inga undernivåer"
+
+#: tfrmoptionsdirectoryhotlist.misortsubmenuandsublevel.caption
+msgctxt "tfrmoptionsdirectoryhotlist.misortsubmenuandsublevel.caption"
+msgid "...content of submenu(s) selected and &all sublevels"
+msgstr "...innehållet i markerade undermenyer och &alla undernivåer"
+
+#: tfrmoptionsdirectoryhotlist.mitestresultinghotlistmenu.caption
+msgctxt "tfrmoptionsdirectoryhotlist.mitestresultinghotlistmenu.caption"
+msgid "Test resultin&g menu"
+msgstr "Testa resulterande &meny"
+
+#: tfrmoptionsdirectoryhotlist.mitweakpath.caption
+msgid "Tweak &path"
+msgstr "Justera &sökväg"
+
+#: tfrmoptionsdirectoryhotlist.mitweaktargetpath.caption
+msgid "Tweak &target path"
+msgstr "Justera &målsökväg"
+
+#: tfrmoptionsdirectoryhotlist.rgwheretoadd.caption
+msgid "Addition from main panel"
+msgstr "Tillägg från huvudpanelen"
+
+#: tfrmoptionsdirectoryhotlistextra.btnpathtoberelativetoall.caption
+msgid "Apply current settings to directory hotlist"
+msgstr "Verkställ aktuella inställningar på katalogfavoriter"
+
+#: tfrmoptionsdirectoryhotlistextra.ckbdirectoryhotlistsource.caption
+msgid "Source"
+msgstr "Källa"
+
+#: tfrmoptionsdirectoryhotlistextra.ckbdirectoryhotlisttarget.caption
+msgid "Target"
+msgstr "Mål"
+
+#: tfrmoptionsdirectoryhotlistextra.gbdirectoryhotlistoptionsextra.caption
+msgctxt "tfrmoptionsdirectoryhotlistextra.gbdirectoryhotlistoptionsextra.caption"
+msgid "Paths"
+msgstr "Sökvägar"
+
+#: tfrmoptionsdirectoryhotlistextra.lbdirectoryhotlistfilenamestyle.caption
+msgid "Way to set paths when adding them:"
+msgstr "Sätt att ange sökvägar när de läggs till:"
+
+#: tfrmoptionsdirectoryhotlistextra.lblapplysettingsfor.caption
+msgctxt "tfrmoptionsdirectoryhotlistextra.lblapplysettingsfor.caption"
+msgid "Do this for paths of:"
+msgstr "Gör detta för sökvägar från:"
+
+#: tfrmoptionsdirectoryhotlistextra.lbpathtoberelativeto.caption
+msgctxt "tfrmoptionsdirectoryhotlistextra.lbpathtoberelativeto.caption"
+msgid "Path to be relative to:"
+msgstr "Sökvägen ska vara relativ till:"
+
+#: tfrmoptionsdragdrop.cbdraganddropaskformateachtime.caption
+msgid "From all the supported formats, ask which one to use every time"
+msgstr "Fråga varje gång vilket av de format som stöds som ska användas"
+
+#: tfrmoptionsdragdrop.cbdraganddropsaveunicodetextinuft8.caption
+msgid "When saving Unicode text, save it in UTF8 format (will be UTF16 otherwise)"
+msgstr "När Unicode-text sparas, spara den i UTF-8-format (annars används UTF-16)"
+
+#: tfrmoptionsdragdrop.cbdraganddroptextautofilename.caption
+msgid "When dropping text, generate filename automatically (otherwise will prompt the user)"
+msgstr "När text släpps, generera filnamn automatiskt (annars tillfrågas användaren)"
+
+#: tfrmoptionsdragdrop.cbshowconfirmationdialog.caption
+msgid "&Show confirmation dialog after drop"
+msgstr "Visa &bekräftelsedialog efter släpp"
+
+#: tfrmoptionsdragdrop.gbtextdraganddroprelatedoptions.caption
+msgid "When drag && dropping text into panels:"
+msgstr "När text dras && släpps i paneler:"
+
+#: tfrmoptionsdragdrop.lblmostdesiredtextformat1.caption
+msgid "Place the most desired format on top of list (use dag && drop):"
+msgstr "Placera det mest önskade formatet överst i listan (använd dra && släpp):"
+
+#: tfrmoptionsdragdrop.lblmostdesiredtextformat2.caption
+msgid "(if the most desired is not present, we'll take second one and so on)"
+msgstr "(om det mest önskade inte finns används det andra, och så vidare)"
+
+#: tfrmoptionsdragdrop.lblwarningforaskformat.caption
+msgid "(will not work with some source application, so try to uncheck if problem)"
+msgstr "(fungerar inte med vissa källprogram, så prova att avmarkera vid problem)"
+
+#: tfrmoptionsdriveslistbutton.cbshowfilesystem.caption
+msgid "Show &file system"
+msgstr "Visa &filsystem"
+
+#: tfrmoptionsdriveslistbutton.cbshowfreespace.caption
+msgid "Show fr&ee space"
+msgstr "Visa &ledigt utrymme"
+
+#: tfrmoptionsdriveslistbutton.cbshowlabel.caption
+msgid "Show &label"
+msgstr "Visa &etikett"
+
+#: tfrmoptionsdriveslistbutton.gbdriveslist.caption
+msgid "Drives list"
+msgstr "Enhetslista"
+
+#: tfrmoptionseditor.chkautoindent.caption
+msgid "Auto Indent"
+msgstr "Automatiskt indrag"
+
+#: tfrmoptionseditor.chkautoindent.hint
+msgid ""
+"Allows to indent the caret, when new line is created with <Enter>, with the same amount of "
+"leading white space as the preceding line"
+msgstr ""
+"Tillåter att markören på en ny rad, skapad med <Enter>, får samma inledande blanksteg som "
+"föregående rad"
+
+#: tfrmoptionseditor.chkgroupundo.caption
+msgid "Group Undo"
+msgstr "Grupperad ångring"
+
+#: tfrmoptionseditor.chkgroupundo.hint
+msgid ""
+"All continuous changes of the same type will be processed in one call instead of undoing/redoing "
+"each one"
+msgstr ""
+"Alla sammanhängande ändringar av samma typ behandlas i ett anrop i stället för att varje ändring "
+"ångras/görs om separat"
+
+#: tfrmoptionseditor.chkrightedge.caption
+msgid "Right margin:"
+msgstr "Högermarginal:"
+
+#: tfrmoptionseditor.chkscrollpastendline.caption
+msgid "Caret past end of line"
+msgstr "Markör efter radslut"
+
+#: tfrmoptionseditor.chkscrollpastendline.hint
+msgid "Allows caret to go into empty space beyond end-of-line position"
+msgstr "Tillåter att markören placeras i tomt utrymme bortom radslutet"
+
+#: tfrmoptionseditor.chkshowspecialchars.caption
+msgid "Show special characters"
+msgstr "Visa specialtecken"
+
+#: tfrmoptionseditor.chkshowspecialchars.hint
+msgid "Shows special characters for spaces and tabulations"
+msgstr "Visar specialtecken för blanksteg och tabbar"
+
+#: tfrmoptionseditor.chksmarttabs.caption
+msgid "Smart Tabs"
+msgstr "Smarta tabbar"
+
+#: tfrmoptionseditor.chksmarttabs.hint
+msgid "When using <Tab> key, caret will go to the next non-space character of the previous line"
+msgstr "När <Tab> används flyttas markören till nästa tecken som inte är ett blanksteg på föregående rad"
+
+#: tfrmoptionseditor.chktabindent.caption
+msgid "Tab indents blocks"
+msgstr "Tabb gör blockindrag"
+
+#: tfrmoptionseditor.chktabindent.hint
+msgid "When active <Tab> and <Shift+Tab> act as block indent, unindent when text is selected"
+msgstr "När detta är aktiverat fungerar <Tab> och <Shift+Tab> som blockindrag/utdrag när text är markerad"
+
+#: tfrmoptionseditor.chktabstospaces.caption
+msgid "Use spaces instead tab characters"
+msgstr "Använd blanksteg i stället för tabbtecken"
+
+#: tfrmoptionseditor.chktabstospaces.hint
+msgid "Converts tab characters to a specified number of space characters (when entering)"
+msgstr "Konverterar tabbtecken till ett angivet antal blanksteg vid inmatning"
+
+#: tfrmoptionseditor.chktrimtrailingspaces.caption
+msgid "Delete trailing spaces"
+msgstr "Ta bort avslutande blanksteg"
+
+#: tfrmoptionseditor.chktrimtrailingspaces.hint
+msgid "Auto delete trailing spaces, this applies only to edited lines"
+msgstr "Ta automatiskt bort avslutande blanksteg, detta gäller endast redigerade rader"
+
+#: tfrmoptionseditor.edtabwidth.hint
+msgctxt "tfrmoptionseditor.edtabwidth.hint"
+msgid "Please note that the \"Smart Tabs\" option takes precedence over the tabulation to be performed"
+msgstr ""
+"Observera att alternativet ”Smarta tabbar” har företräde framför den tabulering som annars skulle"
+" utföras"
+
+#: tfrmoptionseditor.gbinternaleditor.caption
+msgid "Internal editor options"
+msgstr "Alternativ för intern redigerare"
+
+#: tfrmoptionseditor.lblblockindent.caption
+msgid "Block indent:"
+msgstr "Blockindrag:"
+
+#: tfrmoptionseditor.lbltabwidth.caption
+msgid "Tab width:"
+msgstr "Tabbredd:"
+
+#: tfrmoptionseditor.lbltabwidth.hint
+msgctxt "tfrmoptionseditor.lbltabwidth.hint"
+msgid "Please note that the \"Smart Tabs\" option takes precedence over the tabulation to be performed"
+msgstr ""
+"Observera att alternativet ”Smarta tabbar” har företräde framför den tabulering som annars skulle"
+" utföras"
+
+#: tfrmoptionseditorcolors.backgroundlabel.caption
+msgctxt "tfrmoptionseditorcolors.backgroundlabel.caption"
+msgid "Bac&kground"
+msgstr "Bak&grund"
+
+#: tfrmoptionseditorcolors.backgroundusedefaultcheckbox.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.BACKGROUNDUSEDEFAULTCHECKBOX.CAPTION"
+msgid "Bac&kground"
+msgstr "Bak&grund"
+
+#: tfrmoptionseditorcolors.btnresetmask.hint
+msgid "Reset"
+msgstr "Återställ"
+
+#: tfrmoptionseditorcolors.bvlattributesection.caption
+msgid "Element Attributes"
+msgstr "Objektattribut"
+
+#: tfrmoptionseditorcolors.foregroundlabel.caption
+msgctxt "tfrmoptionseditorcolors.foregroundlabel.caption"
+msgid "Fo&reground"
+msgstr "För&grund"
+
+#: tfrmoptionseditorcolors.foregroundusedefaultcheckbox.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.FOREGROUNDUSEDEFAULTCHECKBOX.CAPTION"
+msgid "Fo&reground"
+msgstr "För&grund"
+
+#: tfrmoptionseditorcolors.framecolorusedefaultcheckbox.caption
+msgid "&Text-mark"
+msgstr "&Textmarkering"
+
+#: tfrmoptionseditorcolors.tbtnglobal.caption
+msgid "Use (and edit) &global scheme settings"
+msgstr "Använd (och redigera) &globala schemainställningar"
+
+#: tfrmoptionseditorcolors.tbtnlocal.caption
+msgid "Use &local scheme settings"
+msgstr "Använd &lokala schemainställningar"
+
+#: tfrmoptionseditorcolors.textboldcheckbox.caption
+msgid "&Bold"
+msgstr "&Fet"
+
+#: tfrmoptionseditorcolors.textboldradioinvert.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTBOLDRADIOINVERT.CAPTION"
+msgid "In&vert"
+msgstr "In&vertera"
+
+#: tfrmoptionseditorcolors.textboldradiooff.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTBOLDRADIOOFF.CAPTION"
+msgid "O&ff"
+msgstr "A&v"
+
+#: tfrmoptionseditorcolors.textboldradioon.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTBOLDRADIOON.CAPTION"
+msgid "O&n"
+msgstr "&På"
+
+#: tfrmoptionseditorcolors.textitaliccheckbox.caption
+msgid "&Italic"
+msgstr "&Kursiv"
+
+#: tfrmoptionseditorcolors.textitalicradioinvert.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTITALICRADIOINVERT.CAPTION"
+msgid "In&vert"
+msgstr "In&vertera"
+
+#: tfrmoptionseditorcolors.textitalicradiooff.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTITALICRADIOOFF.CAPTION"
+msgid "O&ff"
+msgstr "A&v"
+
+#: tfrmoptionseditorcolors.textitalicradioon.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTITALICRADIOON.CAPTION"
+msgid "O&n"
+msgstr "&På"
+
+#: tfrmoptionseditorcolors.textstrikeoutcheckbox.caption
+msgid "&Strike Out"
+msgstr "&Genomstruken"
+
+#: tfrmoptionseditorcolors.textstrikeoutradioinvert.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTSTRIKEOUTRADIOINVERT.CAPTION"
+msgid "In&vert"
+msgstr "In&vertera"
+
+#: tfrmoptionseditorcolors.textstrikeoutradiooff.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTSTRIKEOUTRADIOOFF.CAPTION"
+msgid "O&ff"
+msgstr "A&v"
+
+#: tfrmoptionseditorcolors.textstrikeoutradioon.caption
+msgctxt "TFRMOPTIONSEDITORCOLORS.TEXTSTRIKEOUTRADIOON.CAPTION"
+msgid "O&n"
+msgstr "&På"
+
+#: tfrmoptionseditorcolors.textunderlinecheckbox.caption
+msgid "&Underline"
+msgstr "&Understruken"
+
+#: tfrmoptionseditorcolors.textunderlineradioinvert.caption
+msgctxt "tfrmoptionseditorcolors.textunderlineradioinvert.caption"
+msgid "In&vert"
+msgstr "In&vertera"
+
+#: tfrmoptionseditorcolors.textunderlineradiooff.caption
+msgctxt "tfrmoptionseditorcolors.textunderlineradiooff.caption"
+msgid "O&ff"
+msgstr "A&v"
+
+#: tfrmoptionseditorcolors.textunderlineradioon.caption
+msgctxt "tfrmoptionseditorcolors.textunderlineradioon.caption"
+msgid "O&n"
+msgstr "&På"
+
+#: tfrmoptionsfavoritetabs.btnadd.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.BTNADD.CAPTION"
+msgid "Add..."
+msgstr "Lägg till..."
+
+#: tfrmoptionsfavoritetabs.btndelete.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.BTNDELETE.CAPTION"
+msgid "Delete..."
+msgstr "Ta bort..."
+
+#: tfrmoptionsfavoritetabs.btnimportexport.caption
+msgid "Import/Export"
+msgstr "Import/export"
+
+#: tfrmoptionsfavoritetabs.btninsert.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.BTNINSERT.CAPTION"
+msgid "Insert..."
+msgstr "Infoga..."
+
+#: tfrmoptionsfavoritetabs.btnrename.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.BTNRENAME.CAPTION"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmoptionsfavoritetabs.btnsort.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.BTNSORT.CAPTION"
+msgid "Sort..."
+msgstr "Sortera..."
+
+#: tfrmoptionsfavoritetabs.cbexistingtabstokeep.text
+msgctxt "tfrmoptionsfavoritetabs.cbexistingtabstokeep.text"
+msgid "None"
+msgstr "Ingen"
+
+#: tfrmoptionsfavoritetabs.cbfullexpandtree.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.CBFULLEXPANDTREE.CAPTION"
+msgid "Always expand tree"
+msgstr "Fäll alltid ut trädet"
+
+#: tfrmoptionsfavoritetabs.cbsavedirhistory.text
+msgctxt "tfrmoptionsfavoritetabs.cbsavedirhistory.text"
+msgid "No"
+msgstr "Nej"
+
+#: tfrmoptionsfavoritetabs.cbtargetpanelleftsavedtabs.text
+msgctxt "tfrmoptionsfavoritetabs.cbtargetpanelleftsavedtabs.text"
+msgid "Left"
+msgstr "Vänster"
+
+#: tfrmoptionsfavoritetabs.cbtargetpanelrightsavedtabs.text
+msgctxt "tfrmoptionsfavoritetabs.cbtargetpanelrightsavedtabs.text"
+msgid "Right"
+msgstr "Höger"
+
+#: tfrmoptionsfavoritetabs.gbfavoritetabs.caption
+msgid "Favorite Tabs list (reorder by drag && drop)"
+msgstr "Lista över favoritflikar (ordna om med dra && släpp)"
+
+#: tfrmoptionsfavoritetabs.gbfavoritetabsotheroptions.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.GBFAVORITETABSOTHEROPTIONS.CAPTION"
+msgid "Other options"
+msgstr "Övriga alternativ"
+
+#: tfrmoptionsfavoritetabs.gpsavedtabsrestorationaction.caption
+msgid "What to restore where for the selected entry:"
+msgstr "Vad som ska återställas och var för den markerade posten:"
+
+#: tfrmoptionsfavoritetabs.lblexistingtabstokeep.caption
+msgid "Existing tabs to keep:"
+msgstr "Befintliga flikar att behålla:"
+
+#: tfrmoptionsfavoritetabs.lblsavedirhistory.caption
+msgid "Save dir history:"
+msgstr "Spara kataloghistorik:"
+
+#: tfrmoptionsfavoritetabs.lbltargetpanelleftsavedtabs.caption
+msgid "Tabs saved on left to be restored to:"
+msgstr "Flikar som sparats till vänster ska återställas till:"
+
+#: tfrmoptionsfavoritetabs.lbltargetpanelrightsavedtabs.caption
+msgid "Tabs saved on right to be restored to:"
+msgstr "Flikar som sparats till höger ska återställas till:"
+
+#: tfrmoptionsfavoritetabs.miaddseparator.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIADDSEPARATOR.CAPTION"
+msgid "a separator"
+msgstr "en avgränsare"
+
+#: tfrmoptionsfavoritetabs.miaddseparator2.caption
+msgid "Add separator"
+msgstr "Lägg till avgränsare"
+
+#: tfrmoptionsfavoritetabs.miaddsubmenu.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIADDSUBMENU.CAPTION"
+msgid "sub-menu"
+msgstr "undermeny"
+
+#: tfrmoptionsfavoritetabs.miaddsubmenu2.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIADDSUBMENU2.CAPTION"
+msgid "Add sub-menu"
+msgstr "Lägg till undermeny"
+
+#: tfrmoptionsfavoritetabs.micollapseall.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MICOLLAPSEALL.CAPTION"
+msgid "Collapse all"
+msgstr "Fäll ihop alla"
+
+#: tfrmoptionsfavoritetabs.micurrentlevelofitemonly.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MICURRENTLEVELOFITEMONLY.CAPTION"
+msgid "...current level of item(s) selected only"
+msgstr "...endast aktuell nivå för markerade objekt"
+
+#: tfrmoptionsfavoritetabs.micutselection.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MICUTSELECTION.CAPTION"
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: tfrmoptionsfavoritetabs.mideleteallfavoritetabs.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIDELETEALLFAVORITETABS.CAPTION"
+msgid "delete all!"
+msgstr "ta bort alla!"
+
+#: tfrmoptionsfavoritetabs.mideletecompletesubmenu.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIDELETECOMPLETESUBMENU.CAPTION"
+msgid "sub-menu and all its elements"
+msgstr "undermeny och alla dess objekt"
+
+#: tfrmoptionsfavoritetabs.mideletejustsubmenu.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIDELETEJUSTSUBMENU.CAPTION"
+msgid "just sub-menu but keep elements"
+msgstr "bara undermenyn men behåll objekten"
+
+#: tfrmoptionsfavoritetabs.mideleteselectedentry.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIDELETESELECTEDENTRY.CAPTION"
+msgid "selected item"
+msgstr "markerat objekt"
+
+#: tfrmoptionsfavoritetabs.mideleteselectedentry2.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIDELETESELECTEDENTRY2.CAPTION"
+msgid "Delete selected item"
+msgstr "Ta bort markerat objekt"
+
+#: tfrmoptionsfavoritetabs.miexporttolegacytabsfile.caption
+msgid "Export selection to legacy .tab file(s)"
+msgstr "Exportera markering till äldre .tab-fil(er)"
+
+#: tfrmoptionsfavoritetabs.mifavoritetabstestmenu.caption
+msgid "FavoriteTabsTestMenu"
+msgstr "Testmeny för favoritflikar"
+
+#: tfrmoptionsfavoritetabs.miimportlegacytabfilesaccsetting.caption
+msgid "Import legacy .tab file(s) according to default setting"
+msgstr "Importera äldre .tab-fil(er) enligt standardinställningen"
+
+#: tfrmoptionsfavoritetabs.miimportlegacytabfilesatpos.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIIMPORTLEGACYTABFILESATPOS.CAPTION"
+msgid "Import legacy .tab file(s) at selected position"
+msgstr "Importera äldre .tab-fil(er) på markerad position"
+
+#: tfrmoptionsfavoritetabs.miimportlegacytabfilesatpos1.caption
+msgctxt "tfrmoptionsfavoritetabs.miimportlegacytabfilesatpos1.caption"
+msgid "Import legacy .tab file(s) at selected position"
+msgstr "Importera äldre .tab-fil(er) på markerad position"
+
+#: tfrmoptionsfavoritetabs.miimportlegacytabfilesinsubatpos.caption
+msgid "Import legacy .tab file(s) at selected position in a sub menu"
+msgstr "Importera äldre .tab-fil(er) på markerad position i en undermeny"
+
+#: tfrmoptionsfavoritetabs.miinsertseparator.caption
+msgid "Insert separator"
+msgstr "Infoga avgränsare"
+
+#: tfrmoptionsfavoritetabs.miinsertsubmenu.caption
+msgid "Insert sub-menu"
+msgstr "Infoga undermeny"
+
+#: tfrmoptionsfavoritetabs.miopenallbranches.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIOPENALLBRANCHES.CAPTION"
+msgid "Open all branches"
+msgstr "Öppna alla grenar"
+
+#: tfrmoptionsfavoritetabs.mipasteselection.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIPASTESELECTION.CAPTION"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: tfrmoptionsfavoritetabs.mirename.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MIRENAME.CAPTION"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmoptionsfavoritetabs.misorteverything.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MISORTEVERYTHING.CAPTION"
+msgid "...everything, from A to Z!"
+msgstr "...allt, från A till Ö!"
+
+#: tfrmoptionsfavoritetabs.misortsinglegroup.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MISORTSINGLEGROUP.CAPTION"
+msgid "...single group of item(s) only"
+msgstr "...endast en grupp med objekt"
+
+#: tfrmoptionsfavoritetabs.misortsinglegroup2.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MISORTSINGLEGROUP2.CAPTION"
+msgid "Sort single group of item(s) only"
+msgstr "Sortera endast en grupp med objekt"
+
+#: tfrmoptionsfavoritetabs.misortsinglesubmenu.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MISORTSINGLESUBMENU.CAPTION"
+msgid "...content of submenu(s) selected, no sublevel"
+msgstr "...innehållet i markerade undermenyer, inga undernivåer"
+
+#: tfrmoptionsfavoritetabs.misortsubmenuandsublevel.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MISORTSUBMENUANDSUBLEVEL.CAPTION"
+msgid "...content of submenu(s) selected and all sublevels"
+msgstr "...innehållet i markerade undermenyer och alla undernivåer"
+
+#: tfrmoptionsfavoritetabs.mitestresultingfavoritetabsmenu.caption
+msgctxt "TFRMOPTIONSFAVORITETABS.MITESTRESULTINGFAVORITETABSMENU.CAPTION"
+msgid "Test resulting menu"
+msgstr "Testa resulterande meny"
+
+#: tfrmoptionsfileassoc.btnaddact.caption
+msgctxt "tfrmoptionsfileassoc.btnaddact.caption"
+msgid "Add"
+msgstr "Lägg till"
+
+#: tfrmoptionsfileassoc.btnaddext.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNADDEXT.CAPTION"
+msgid "Add"
+msgstr "Lägg till"
+
+#: tfrmoptionsfileassoc.btnaddnewtype.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNADDNEWTYPE.CAPTION"
+msgid "A&dd"
+msgstr "Lä&gg till"
+
+#: tfrmoptionsfileassoc.btncloneact.caption
+msgid "C&lone"
+msgstr "K&lona"
+
+#: tfrmoptionsfileassoc.btncommands.hint
+msgctxt "tfrmoptionsfileassoc.btncommands.hint"
+msgid "Select your internal command"
+msgstr "Välj internt kommando"
+
+#: tfrmoptionsfileassoc.btndownact.caption
+msgctxt "tfrmoptionsfileassoc.btndownact.caption"
+msgid "Do&wn"
+msgstr "&Ned"
+
+#: tfrmoptionsfileassoc.btneditext.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNEDITEXT.CAPTION"
+msgid "Edi&t"
+msgstr "Redi&gera"
+
+#: tfrmoptionsfileassoc.btninsertact.caption
+msgctxt "tfrmoptionsfileassoc.btninsertact.caption"
+msgid "Insert"
+msgstr "Infoga"
+
+#: tfrmoptionsfileassoc.btninsertext.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNINSERTEXT.CAPTION"
+msgid "&Insert"
+msgstr "&Infoga"
+
+#: tfrmoptionsfileassoc.btnparametershelper.hint
+msgctxt "tfrmoptionsfileassoc.btnparametershelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsfileassoc.btnrelativecommand.hint
+msgctxt "tfrmoptionsfileassoc.btnrelativecommand.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsfileassoc.btnremoveact.caption
+msgid "Remo&ve"
+msgstr "Ta &bort"
+
+#: tfrmoptionsfileassoc.btnremoveext.caption
+msgid "Re&move"
+msgstr "Ta &bort"
+
+#: tfrmoptionsfileassoc.btnremovetype.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNREMOVETYPE.CAPTION"
+msgid "&Remove"
+msgstr "&Ta bort"
+
+#: tfrmoptionsfileassoc.btnrenametype.caption
+msgctxt "tfrmoptionsfileassoc.btnrenametype.caption"
+msgid "R&ename"
+msgstr "&Byt namn"
+
+#: tfrmoptionsfileassoc.btnstartpathpathhelper.hint
+msgctxt "tfrmoptionsfileassoc.btnstartpathpathhelper.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsfileassoc.btnstartpathvarhelper.hint
+msgctxt "tfrmoptionsfileassoc.btnstartpathvarhelper.hint"
+msgid "Variable reminder helper"
+msgstr "Hjälp för variabelpåminnelser"
+
+#: tfrmoptionsfileassoc.btnupact.caption
+msgctxt "TFRMOPTIONSFILEASSOC.BTNUPACT.CAPTION"
+msgid "&Up"
+msgstr "&Upp"
+
+#: tfrmoptionsfileassoc.destartpath.hint
+msgid "Starting path of the command. Never quote this string."
+msgstr "Startkatalog för kommandot. Sätt aldrig den här strängen inom citattecken."
+
+#: tfrmoptionsfileassoc.edbactionname.hint
+msgid ""
+"Name of the action. It is never passed to the system, it's just a mnemonic name chosen by you, "
+"for you"
+msgstr "Åtgärdens namn. Det skickas aldrig till systemet utan är bara ett minnesnamn som du själv väljer."
+
+#: tfrmoptionsfileassoc.edtparams.hint
+msgid "Parameter to pass to the command. Long filename with spaces should be quoted (manually entering)."
+msgstr ""
+"Parameter som skickas till kommandot. Långa filnamn med blanksteg ska anges inom citattecken (vid"
+" manuell inmatning)."
+
+#: tfrmoptionsfileassoc.fnecommand.hint
+msgid "Command to execute. Never quote this string."
+msgstr "Kommando som ska köras. Sätt aldrig den här strängen inom citattecken."
+
+#: tfrmoptionsfileassoc.gbactiondescription.caption
+msgid "Action description"
+msgstr "Åtgärdsbeskrivning"
+
+#: tfrmoptionsfileassoc.gbactions.caption
+msgctxt "tfrmoptionsfileassoc.gbactions.caption"
+msgid "Actions"
+msgstr "Åtgärder"
+
+#: tfrmoptionsfileassoc.gbexts.caption
+msgid "Extensions"
+msgstr "Filändelser"
+
+#: tfrmoptionsfileassoc.gbexts.hint
+msgid "Can be sorted by drag & drop"
+msgstr "Kan sorteras med dra & släpp"
+
+#: tfrmoptionsfileassoc.gbfiletypes.caption
+msgctxt "tfrmoptionsfileassoc.gbfiletypes.caption"
+msgid "File types"
+msgstr "Filtyper"
+
+#: tfrmoptionsfileassoc.gbicon.caption
+msgid "Icon"
+msgstr "Ikon"
+
+#: tfrmoptionsfileassoc.lbactions.hint
+msgid "Actions may be sorted by drag & drop"
+msgstr "Åtgärder kan sorteras med dra & släpp"
+
+#: tfrmoptionsfileassoc.lbexts.hint
+msgid "Extensions may be sorted by drag & drop"
+msgstr "Filändelser kan sorteras med dra & släpp"
+
+#: tfrmoptionsfileassoc.lbfiletypes.hint
+msgid "File types may be sorted by drag & drop"
+msgstr "Filtyper kan sorteras med dra & släpp"
+
+#: tfrmoptionsfileassoc.lblaction.caption
+msgid "Action &name:"
+msgstr "Åtgärds&namn:"
+
+#: tfrmoptionsfileassoc.lblcommand.caption
+msgctxt "tfrmoptionsfileassoc.lblcommand.caption"
+msgid "Command:"
+msgstr "Kommando:"
+
+#: tfrmoptionsfileassoc.lblexternalparameters.caption
+msgctxt "tfrmoptionsfileassoc.lblexternalparameters.caption"
+msgid "Parameter&s:"
+msgstr "Parame&trar:"
+
+#: tfrmoptionsfileassoc.lblstartpath.caption
+msgctxt "tfrmoptionsfileassoc.lblstartpath.caption"
+msgid "Start pat&h:"
+msgstr "Startsök&väg:"
+
+#: tfrmoptionsfileassoc.menuitem3.caption
+msgid "Custom with..."
+msgstr "Anpassat med..."
+
+#: tfrmoptionsfileassoc.micustom.caption
+msgid "Custom"
+msgstr "Anpassat"
+
+#: tfrmoptionsfileassoc.miedit.caption
+msgctxt "TFRMOPTIONSFILEASSOC.MIEDIT.CAPTION"
+msgid "Edit"
+msgstr "Redigera"
+
+#: tfrmoptionsfileassoc.mieditor.caption
+msgid "Open in Editor"
+msgstr "Öppna i redigeraren"
+
+#: tfrmoptionsfileassoc.mieditwith.caption
+msgid "Edit with..."
+msgstr "Redigera med..."
+
+#: tfrmoptionsfileassoc.migetoutputfromcommand.caption
+msgid "Get output from command"
+msgstr "Hämta utdata från kommando"
+
+#: tfrmoptionsfileassoc.miinternaleditor.caption
+msgid "Open in Internal Editor"
+msgstr "Öppna i intern redigerare"
+
+#: tfrmoptionsfileassoc.miinternalviewer.caption
+msgid "Open in Internal Viewer"
+msgstr "Öppna i intern visare"
+
+#: tfrmoptionsfileassoc.miopen.caption
+msgctxt "TFRMOPTIONSFILEASSOC.MIOPEN.CAPTION"
+msgid "Open"
+msgstr "Öppna"
+
+#: tfrmoptionsfileassoc.miopenwith.caption
+msgid "Open with..."
+msgstr "Öppna med..."
+
+#: tfrmoptionsfileassoc.mishell.caption
+msgid "Run in terminal"
+msgstr "Kör i terminal"
+
+#: tfrmoptionsfileassoc.miview.caption
+msgctxt "TFRMOPTIONSFILEASSOC.MIVIEW.CAPTION"
+msgid "View"
+msgstr "Visa"
+
+#: tfrmoptionsfileassoc.miviewer.caption
+msgid "Open in Viewer"
+msgstr "Öppna i visaren"
+
+#: tfrmoptionsfileassoc.miviewwith.caption
+msgid "View with..."
+msgstr "Visa med..."
+
+#: tfrmoptionsfileassoc.sbtnicon.hint
+msgid "Click me to change icon!"
+msgstr "Klicka här för att byta ikon!"
+
+#: tfrmoptionsfileassocextra.btnpathtoberelativetoall.caption
+msgid "Apply current settings to all current configured filenames and paths"
+msgstr "Verkställ aktuella inställningar på alla konfigurerade filnamn och sökvägar"
+
+#: tfrmoptionsfileassocextra.cbdefaultcontextactions.caption
+msgid "Default context actions (View/Edit)"
+msgstr "Standardåtgärder i snabbmenyn (Visa/Redigera)"
+
+#: tfrmoptionsfileassocextra.cbexecuteviashell.caption
+msgctxt "tfrmoptionsfileassocextra.cbexecuteviashell.caption"
+msgid "Execute via shell"
+msgstr "Kör via skal"
+
+#: tfrmoptionsfileassocextra.cbextendedcontextmenu.caption
+msgid "Extended context menu"
+msgstr "Utökad snabbmeny"
+
+#: tfrmoptionsfileassocextra.cbincludeconfigfileassoc.caption
+msgid "File association configuration"
+msgstr "Konfiguration av filassociationer"
+
+#: tfrmoptionsfileassocextra.cboffertoaddtofileassociations.caption
+msgid "Offer to add selection to file association when not included already"
+msgstr "Erbjud att lägga till markeringen i filassociationer om den inte redan ingår"
+
+#: tfrmoptionsfileassocextra.cboffertoaddtofileassociations.hint
+msgctxt "tfrmoptionsfileassocextra.cboffertoaddtofileassociations.hint"
+msgid ""
+"When accessing file association, offer to add current selected file if not already included in a "
+"configured file type"
+msgstr ""
+"När filassociationer öppnas, erbjud att lägga till den aktuellt markerade filen om den inte redan"
+" ingår i en konfigurerad filtyp"
+
+#: tfrmoptionsfileassocextra.cbopensystemwithterminalclose.caption
+msgctxt "tfrmoptionsfileassocextra.cbopensystemwithterminalclose.caption"
+msgid "Execute via terminal and close"
+msgstr "Kör via terminal och stäng"
+
+#: tfrmoptionsfileassocextra.cbopensystemwithterminalstayopen.caption
+msgctxt "tfrmoptionsfileassocextra.cbopensystemwithterminalstayopen.caption"
+msgid "Execute via terminal and stay open"
+msgstr "Kör via terminal och håll öppen"
+
+#: tfrmoptionsfileassocextra.ckbfileassoccommand.caption
+msgctxt "tfrmoptionsfileassocextra.ckbfileassoccommand.caption"
+msgid "Commands"
+msgstr "Kommandon"
+
+#: tfrmoptionsfileassocextra.ckbfileassocicons.caption
+msgctxt "tfrmoptionsfileassocextra.ckbfileassocicons.caption"
+msgid "Icons"
+msgstr "Ikoner"
+
+#: tfrmoptionsfileassocextra.ckbfileassocstartpath.caption
+msgctxt "tfrmoptionsfileassocextra.ckbfileassocstartpath.caption"
+msgid "Starting paths"
+msgstr "Startsökvägar"
+
+#: tfrmoptionsfileassocextra.gbextendedcontextmenuoptions.caption
+msgid "Extended options items:"
+msgstr "Utökade alternativ:"
+
+#: tfrmoptionsfileassocextra.gbtoolbaroptionsextra.caption
+msgctxt "tfrmoptionsfileassocextra.gbtoolbaroptionsextra.caption"
+msgid "Paths"
+msgstr "Sökvägar"
+
+#: tfrmoptionsfileassocextra.lbfileassocfilenamestyle.caption
+msgctxt "tfrmoptionsfileassocextra.lbfileassocfilenamestyle.caption"
+msgid "Way to set paths when adding elements for icons, commands and starting paths:"
+msgstr "Sätt att ange sökvägar när objekt läggs till för ikoner, kommandon och startsökvägar:"
+
+#: tfrmoptionsfileassocextra.lblapplysettingsfor.caption
+msgctxt "tfrmoptionsfileassocextra.lblapplysettingsfor.caption"
+msgid "Do this for files and path for:"
+msgstr "Gör detta för filer och sökvägar för:"
+
+#: tfrmoptionsfileassocextra.lbpathtoberelativeto.caption
+msgctxt "tfrmoptionsfileassocextra.lbpathtoberelativeto.caption"
+msgid "Path to be relative to:"
+msgstr "Sökvägen ska vara relativ till:"
+
+#: tfrmoptionsfileoperations.bvlconfirmations.caption
+msgid "Show confirmation window for:"
+msgstr "Visa bekräftelsefönster för:"
+
+#: tfrmoptionsfileoperations.cbcopyconfirmation.caption
+msgid "Cop&y operation"
+msgstr "Kop&iering"
+
+#: tfrmoptionsfileoperations.cbdeleteconfirmation.caption
+msgid "&Delete operation"
+msgstr "&Borttagning"
+
+#: tfrmoptionsfileoperations.cbdeletetotrash.caption
+msgid "Dele&te to recycle bin (Shift key reverses this setting)"
+msgstr "Ta &bort till papperskorgen (Shift vänder på inställningen)"
+
+#: tfrmoptionsfileoperations.cbdeletetotrashconfirmation.caption
+msgid "D&elete to trash operation"
+msgstr "Ta &bort till papperskorgen"
+
+#: tfrmoptionsfileoperations.cbdropreadonlyflag.caption
+msgid "D&rop readonly flag"
+msgstr "Ta &bort skrivskyddsflaggan"
+
+#: tfrmoptionsfileoperations.cbmoveconfirmation.caption
+msgid "&Move operation"
+msgstr "&Flyttning"
+
+#: tfrmoptionsfileoperations.cbprocesscomments.caption
+msgid "&Process comments with files/folders"
+msgstr "&Hantera kommentarer tillsammans med filer/mappar"
+
+#: tfrmoptionsfileoperations.cbrenameselonlyname.caption
+msgid "Select &file name without extension when renaming"
+msgstr "Markera &filnamnet utan filändelse vid namnbyte"
+
+#: tfrmoptionsfileoperations.cbshowcopytabselectpanel.caption
+msgid "Sho&w tab select panel in copy/move dialog"
+msgstr "Visa flikvals&panelen i dialogen Kopiera/Flytta"
+
+#: tfrmoptionsfileoperations.cbskipfileoperror.caption
+msgid "S&kip file operations errors and write them to log window"
+msgstr "Hoppa över fel vid filåtgärder och s&kriv dem i loggfönstret"
+
+#: tfrmoptionsfileoperations.cbtestarchiveconfirmation.caption
+msgid "Test archive operation"
+msgstr "Testa arkivåtgärd"
+
+#: tfrmoptionsfileoperations.cbverifychecksumconfirmation.caption
+msgid "Verify checksum operation"
+msgstr "Verifiera kontrollsumma"
+
+#: tfrmoptionsfileoperations.gbexecutingoperations.caption
+msgid "Executing operations"
+msgstr "Köra åtgärder"
+
+#: tfrmoptionsfileoperations.gbuserinterface.caption
+msgid "User interface"
+msgstr "Användargränssnitt"
+
+#: tfrmoptionsfileoperations.lblbuffersize.caption
+msgid "&Buffer size for file operations (in KB):"
+msgstr "&Buffertstorlek för filåtgärder (i kB):"
+
+#: tfrmoptionsfileoperations.lblhashbuffersize.caption
+msgid "Buffer size for &hash calculation (in KB):"
+msgstr "Buffertstorlek för &hashberäkning (i kB):"
+
+#: tfrmoptionsfileoperations.lblprogresskind.caption
+msgid "Show operations progress &initially in"
+msgstr "Visa åtgärdsförlopp &inledningsvis i"
+
+#: tfrmoptionsfileoperations.lbltypeofduplicatedrename.caption
+msgid "Duplicated name auto-rename style:"
+msgstr "Stil för automatisk namnändring av dubbletter:"
+
+#: tfrmoptionsfileoperations.lblwipepassnumber.caption
+msgid "&Number of wipe passes:"
+msgstr "&Antal överskrivningspass vid säker radering:"
+
+#: tfrmoptionsfilepanelscolors.btnresettodcdefault.caption
+msgid "Reset to DC default"
+msgstr "Återställ till DC-standard"
+
+#: tfrmoptionsfilepanelscolors.cballowovercolor.caption
+msgctxt "TFRMOPTIONSFILEPANELSCOLORS.CBALLOWOVERCOLOR.CAPTION"
+msgid "Allow Overcolor"
+msgstr "Tillåt överfärgning"
+
+#: tfrmoptionsfilepanelscolors.cbbuseframecursor.caption
+msgid "Use &Frame Cursor"
+msgstr "Använd &rammarkör"
+
+#: tfrmoptionsfilepanelscolors.cbbuseinactiveselcolor.caption
+msgid "Use Inactive Sel Color"
+msgstr "Använd färg för inaktiv markering"
+
+#: tfrmoptionsfilepanelscolors.cbbuseinvertedselection.caption
+msgid "U&se Inverted Selection"
+msgstr "An&vänd inverterad markering"
+
+#: tfrmoptionsfilepanelscolors.cbusecursorborder.caption
+msgctxt "TFRMOPTIONSFILEPANELSCOLORS.CBUSECURSORBORDER.CAPTION"
+msgid "Cursor border"
+msgstr "Markörram"
+
+#: tfrmoptionsfilepanelscolors.dbcurrentpath.caption
+msgid "Current Path"
+msgstr "Aktuell sökväg"
+
+#: tfrmoptionsfilepanelscolors.lblbackgroundcolor.caption
+msgid "Bac&kground:"
+msgstr "Bak&grund:"
+
+#: tfrmoptionsfilepanelscolors.lblbackgroundcolor2.caption
+msgid "Backg&round 2:"
+msgstr "Bakg&rund 2:"
+
+#: tfrmoptionsfilepanelscolors.lblcursorcolor.caption
+msgid "C&ursor Color:"
+msgstr "Mar&körfärg:"
+
+#: tfrmoptionsfilepanelscolors.lblcursortext.caption
+msgid "Cursor Te&xt:"
+msgstr "Markörte&xt:"
+
+#: tfrmoptionsfilepanelscolors.lblinactivecursorcolor.caption
+msgctxt "TFRMOPTIONSFILEPANELSCOLORS.LBLINACTIVECURSORCOLOR.CAPTION"
+msgid "Inactive Cursor Color:"
+msgstr "Färg för inaktiv markör:"
+
+#: tfrmoptionsfilepanelscolors.lblinactivemarkcolor.caption
+msgctxt "TFRMOPTIONSFILEPANELSCOLORS.LBLINACTIVEMARKCOLOR.CAPTION"
+msgid "Inactive Mark Color:"
+msgstr "Färg för inaktiv markering:"
+
+#: tfrmoptionsfilepanelscolors.lblinactivepanelbrightness.caption
+msgid "&Brightness level of inactive panel:"
+msgstr "&Ljusstyrka för inaktiv panel:"
+
+#: tfrmoptionsfilepanelscolors.lblmarkcolor.caption
+msgid "&Mark Color:"
+msgstr "&Markeringsfärg:"
+
+#: tfrmoptionsfilepanelscolors.lblpathactiveback.caption
+msgctxt "tfrmoptionsfilepanelscolors.lblpathactiveback.caption"
+msgid "Background:"
+msgstr "Bakgrund:"
+
+#: tfrmoptionsfilepanelscolors.lblpathactivetext.caption
+msgctxt "tfrmoptionsfilepanelscolors.lblpathactivetext.caption"
+msgid "Text Color:"
+msgstr "Textfärg:"
+
+#: tfrmoptionsfilepanelscolors.lblpathinactiveback.caption
+msgid "Inactive Background:"
+msgstr "Inaktiv bakgrund:"
+
+#: tfrmoptionsfilepanelscolors.lblpathinactivetext.caption
+msgid "Inactive Text Color:"
+msgstr "Inaktiv textfärg:"
+
+#: tfrmoptionsfilepanelscolors.lblpreview.caption
+msgid ""
+"Below is a preview. You may move cursor, select file and get immediately an actual look and feel "
+"of the various settings."
+msgstr ""
+"Nedan visas en förhandsgranskning. Du kan flytta markören och markera en fil för att omedelbart "
+"se hur de olika inställningarna ser ut och fungerar."
+
+#: tfrmoptionsfilepanelscolors.lbltextcolor.caption
+msgid "T&ext Color:"
+msgstr "T&extfärg:"
+
+#: tfrmoptionsfilesearch.cbinitiallyclearfilemask.caption
+msgid "When launching file search, clear file mask filter"
+msgstr "Rensa filmaskfiltret när filsökning startas"
+
+#: tfrmoptionsfilesearch.cbpartialnamesearch.caption
+msgid "&Search for part of file name"
+msgstr "&Sök efter en del av filnamnet"
+
+#: tfrmoptionsfilesearch.cbshowmenubarinfindfiles.caption
+msgid "Show menu bar in \"Find files\""
+msgstr "Visa menyrad i ”Sök filer”"
+
+#: tfrmoptionsfilesearch.dbtextsearch.caption
+msgid "Text search in files"
+msgstr "Textsökning i filer"
+
+#: tfrmoptionsfilesearch.gbfilesearch.caption
+msgctxt "TFRMOPTIONSFILESEARCH.GBFILESEARCH.CAPTION"
+msgid "File search"
+msgstr "Filsökning"
+
+#: tfrmoptionsfilesearch.lblnewsearchfilters.caption
+msgid "Current filters with \"New search\" button:"
+msgstr "Aktuella filter med knappen ”Ny sökning”:"
+
+#: tfrmoptionsfilesearch.lblsearchdefaulttemplate.caption
+msgid "Default search template:"
+msgstr "Standardmall för sökning:"
+
+#: tfrmoptionsfilesearch.rbusemmapinsearch.caption
+msgid "Use memory mapping for search te&xt in files"
+msgstr "Använd minnesmappning för att söka te&xt i filer"
+
+#: tfrmoptionsfilesearch.rbusestreaminsearch.caption
+msgid "&Use stream for search text in files"
+msgstr "&Använd dataström för textsökning i filer"
+
+#: tfrmoptionsfilesviews.btndefault.caption
+msgctxt "tfrmoptionsfilesviews.btndefault.caption"
+msgid "De&fault"
+msgstr "St&andard"
+
+#: tfrmoptionsfilesviews.gbformatting.caption
+msgid "Formatting"
+msgstr "Formatering"
+
+#: tfrmoptionsfilesviews.gbpersonalizedabbreviationtouse.caption
+msgid "Personalized abbreviations to use:"
+msgstr "Personliga förkortningar att använda:"
+
+#: tfrmoptionsfilesviews.gbsorting.caption
+msgid "Sorting"
+msgstr "Sortering"
+
+#: tfrmoptionsfilesviews.lbl1k.caption
+msgid "1K ="
+msgstr "1K ="
+
+#: tfrmoptionsfilesviews.lblbyte.caption
+msgid "&Byte:"
+msgstr "&Byte:"
+
+#: tfrmoptionsfilesviews.lblcasesensitivity.caption
+msgid "Case s&ensitivity:"
+msgstr "Skiftläges&känslighet:"
+
+#: tfrmoptionsfilesviews.lbldatetimeexample.caption
+msgid "Incorrect format"
+msgstr "Felaktigt format"
+
+#: tfrmoptionsfilesviews.lbldatetimeformat.caption
+msgid "&Date and time format:"
+msgstr "&Datum- och tidsformat:"
+
+#: tfrmoptionsfilesviews.lblfilesizeformat.caption
+msgid "File si&ze format:"
+msgstr "Format för filsto&rlek:"
+
+#: tfrmoptionsfilesviews.lblfootersizeformat.caption
+msgid "&Footer format:"
+msgstr "&Sidfotsformat:"
+
+#: tfrmoptionsfilesviews.lblgigabyte.caption
+msgid "&Gigabyte:"
+msgstr "&Gigabyte:"
+
+#: tfrmoptionsfilesviews.lblheadersizeformat.caption
+msgid "&Header format:"
+msgstr "&Rubrikformat:"
+
+#: tfrmoptionsfilesviews.lblkilobyte.caption
+msgid "&Kilobyte:"
+msgstr "&Kilobyte:"
+
+#: tfrmoptionsfilesviews.lblmegabyte.caption
+msgid "Megab&yte:"
+msgstr "Megab&yte:"
+
+#: tfrmoptionsfilesviews.lblnewfilesposition.caption
+msgid "&Insert new files:"
+msgstr "&Infoga nya filer:"
+
+#: tfrmoptionsfilesviews.lbloperationsizeformat.caption
+msgid "O&peration size format:"
+msgstr "Format för å&tgärdsstorlek:"
+
+#: tfrmoptionsfilesviews.lblsortfoldermode.caption
+msgid "So&rting directories:"
+msgstr "So&rtering av kataloger:"
+
+#: tfrmoptionsfilesviews.lblsortmethod.caption
+msgid "&Sort method:"
+msgstr "&Sorteringsmetod:"
+
+#: tfrmoptionsfilesviews.lblterabyte.caption
+msgid "&Terabyte:"
+msgstr "&Terabyte:"
+
+#: tfrmoptionsfilesviews.lblupdatedfilesposition.caption
+msgid "&Move updated files:"
+msgstr "&Flytta uppdaterade filer:"
+
+#: tfrmoptionsfilesviews.rb1000.caption
+msgid "1000"
+msgstr "1000"
+
+#: tfrmoptionsfilesviews.rb1024.caption
+msgid "1024"
+msgstr "1024"
+
+#: tfrmoptionsfilesviewscomplement.btnaddattribute.caption
+msgctxt "tfrmoptionsfilesviewscomplement.btnaddattribute.caption"
+msgid "&Add"
+msgstr "&Lägg till"
+
+#: tfrmoptionsfilesviewscomplement.btnattrshelp.caption
+msgctxt "tfrmoptionsfilesviewscomplement.btnattrshelp.caption"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: tfrmoptionsfilesviewscomplement.cbdblclicktoparent.caption
+msgid "Enable changing to &parent folder when double-clicking on empty part of file view"
+msgstr "Aktivera byte till &överordnad mapp när du dubbelklickar på en tom del av filvyn"
+
+#: tfrmoptionsfilesviewscomplement.cbdelayloadingtabs.caption
+msgid "Do&n't load file list until a tab is activated"
+msgstr "Läs i&nte in fillistan förrän en flik aktiveras"
+
+#: tfrmoptionsfilesviewscomplement.cbdirbrackets.caption
+msgid "S&how square brackets around directories"
+msgstr "V&isa hakparenteser runt kataloger"
+
+#: tfrmoptionsfilesviewscomplement.cbhighlightupdatedfiles.caption
+msgid "Hi&ghlight new and updated files"
+msgstr "Framhäv n&ya och uppdaterade filer"
+
+#: tfrmoptionsfilesviewscomplement.cbinplacerename.caption
+msgid "Enable inplace &renaming when clicking twice on a name"
+msgstr "Aktivera namnbyte på plats &när du klickar två gånger på ett namn"
+
+#: tfrmoptionsfilesviewscomplement.cblistfilesinthread.caption
+msgid "Load &file list in separate thread"
+msgstr "Läs in &fillistan i separat tråd"
+
+#: tfrmoptionsfilesviewscomplement.cbloadiconsseparately.caption
+msgid "Load icons af&ter file list"
+msgstr "Läs in ikoner ef&ter fillistan"
+
+#: tfrmoptionsfilesviewscomplement.cbshowsystemfiles.caption
+msgid "Show s&ystem and hidden files"
+msgstr "Visa s&ystemfiler och dolda filer"
+
+#: tfrmoptionsfilesviewscomplement.cbspacemovesdown.caption
+msgid "&When selecting files with <SPACEBAR>, move down to next file (as with <INSERT>)"
+msgstr "&När filer markeras med <MELLANSLAG>, flytta ned till nästa fil (som med <INSERT>)"
+
+#: tfrmoptionsfilesviewscomplement.chkmarkmaskfilterwindows.caption
+msgid "Windows style filter when marking files (\"*.*\" also select files without extension, etc.)"
+msgstr ""
+"Använd Windows-liknande filter vid markering av filer (”*.*” markerar även filer utan filändelse "
+"osv.)"
+
+#: tfrmoptionsfilesviewscomplement.chkmarkmaskshowattribute.caption
+msgid "Use an independent attribute filter in mask input dialog each time"
+msgstr "Använd ett oberoende attributfilter i maskdialogen varje gång"
+
+#: tfrmoptionsfilesviewscomplement.gbmarking.caption
+msgid "Marking/Unmarking entries"
+msgstr "Markering/avmarkering av poster"
+
+#: tfrmoptionsfilesviewscomplement.lbattributemask.caption
+msgid "Default attribute mask value to use:"
+msgstr "Standardvärde för attributmask:"
+
+#: tfrmoptionsfilesviewscomplement.lblextralinespan.caption
+msgctxt "tfrmoptionsfilesviewscomplement.lblextralinespan.caption"
+msgid "Extra line span:"
+msgstr "Extra radavstånd:"
+
+#: tfrmoptionsfiletypescolors.btnaddcategory.caption
+msgctxt "TFRMOPTIONSFILETYPESCOLORS.BTNADDCATEGORY.CAPTION"
+msgid "A&dd"
+msgstr "Lä&gg till"
+
+#: tfrmoptionsfiletypescolors.btndeletecategory.caption
+msgctxt "TFRMOPTIONSFILETYPESCOLORS.BTNDELETECATEGORY.CAPTION"
+msgid "D&elete"
+msgstr "Ta &bort"
+
+#: tfrmoptionsfiletypescolors.btnsearchtemplate.hint
+msgctxt "tfrmoptionsfiletypescolors.btnsearchtemplate.hint"
+msgid "Template..."
+msgstr "Mall..."
+
+#: tfrmoptionsfiletypescolors.gbfiletypescolors.caption
+msgid "File types colors (sort by drag&&drop)"
+msgstr "Färger för filtyper (sortera med dra&&släpp)"
+
+#: tfrmoptionsfiletypescolors.lblcategoryattr.caption
+msgid "Category a&ttributes:"
+msgstr "Kategoriat&tribut:"
+
+#: tfrmoptionsfiletypescolors.lblcategorycolor.caption
+msgid "Category co&lor:"
+msgstr "Kategorifä&rg:"
+
+#: tfrmoptionsfiletypescolors.lblcategorymask.caption
+msgctxt "tfrmoptionsfiletypescolors.lblcategorymask.caption"
+msgid "Category &mask:"
+msgstr "Kategori&mask:"
+
+#: tfrmoptionsfiletypescolors.lblcategoryname.caption
+msgctxt "tfrmoptionsfiletypescolors.lblcategoryname.caption"
+msgid "Category &name:"
+msgstr "Kategori&namn:"
+
+#: tfrmoptionsfonts.hint
+msgctxt "tfrmoptionsfonts.hint"
+msgid "Fonts"
+msgstr "Teckensnitt"
+
+#: tfrmoptionshotkeys.actaddhotkey.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTADDHOTKEY.CAPTION"
+msgid "Add &hotkey"
+msgstr "Lägg till &kortkommando"
+
+#: tfrmoptionshotkeys.actcopy.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTCOPY.CAPTION"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: tfrmoptionshotkeys.actdelete.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTDELETE.CAPTION"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmoptionshotkeys.actdeletehotkey.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTDELETEHOTKEY.CAPTION"
+msgid "&Delete hotkey"
+msgstr "&Ta bort kortkommando"
+
+#: tfrmoptionshotkeys.actedithotkey.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTEDITHOTKEY.CAPTION"
+msgid "&Edit hotkey"
+msgstr "&Redigera kortkommando"
+
+#: tfrmoptionshotkeys.actnextcategory.caption
+msgid "Next category"
+msgstr "Nästa kategori"
+
+#: tfrmoptionshotkeys.actpopupfilerelatedmenu.caption
+msgid "Make popup the file related menu"
+msgstr "Visa filrelaterad meny som popup"
+
+#: tfrmoptionshotkeys.actpreviouscategory.caption
+msgid "Previous category"
+msgstr "Föregående kategori"
+
+#: tfrmoptionshotkeys.actrename.caption
+msgctxt "TFRMOPTIONSHOTKEYS.ACTRENAME.CAPTION"
+msgid "Rename"
+msgstr "Byt namn"
+
+#: tfrmoptionshotkeys.actrestoredefault.caption
+msgid "Restore DC default"
+msgstr "Återställ DC-standard"
+
+#: tfrmoptionshotkeys.actsavenow.caption
+msgid "Save now"
+msgstr "Spara nu"
+
+#: tfrmoptionshotkeys.actsortbycommand.caption
+msgid "Sort by command name"
+msgstr "Sortera efter kommandonamn"
+
+#: tfrmoptionshotkeys.actsortbyhotkeysgrouped.caption
+msgid "Sort by hotkeys (grouped)"
+msgstr "Sortera efter kortkommandon (grupperade)"
+
+#: tfrmoptionshotkeys.actsortbyhotkeysoneperline.caption
+msgid "Sort by hotkeys (one per row)"
+msgstr "Sortera efter kortkommandon (ett per rad)"
+
+#: tfrmoptionshotkeys.lbfilter.caption
+msgid "&Filter"
+msgstr "&Filter"
+
+#: tfrmoptionshotkeys.lblcategories.caption
+msgid "C&ategories:"
+msgstr "K&ategorier:"
+
+#: tfrmoptionshotkeys.lblcommands.caption
+msgid "Co&mmands:"
+msgstr "Ko&mmandon:"
+
+#: tfrmoptionshotkeys.lblscfiles.caption
+msgid "&Shortcut files:"
+msgstr "&Kortkommandofiler:"
+
+#: tfrmoptionshotkeys.lblsortorder.caption
+msgid "So&rt order:"
+msgstr "So&rteringsordning:"
+
+#: tfrmoptionshotkeys.micategories.caption
+msgid "Categories"
+msgstr "Kategorier"
+
+#: tfrmoptionshotkeys.micommands.caption
+msgctxt "TFRMOPTIONSHOTKEYS.MICOMMANDS.CAPTION"
+msgid "Command"
+msgstr "Kommando"
+
+#: tfrmoptionshotkeys.misortorder.caption
+msgid "Sort order"
+msgstr "Sorteringsordning"
+
+#: tfrmoptionshotkeys.stgcommands.columns[0].title.caption
+msgctxt "tfrmoptionshotkeys.stgcommands.columns[0].title.caption"
+msgid "Command"
+msgstr "Kommando"
+
+#: tfrmoptionshotkeys.stgcommands.columns[1].title.caption
+msgctxt "tfrmoptionshotkeys.stgcommands.columns[1].title.caption"
+msgid "Hotkeys"
+msgstr "Kortkommandon"
+
+#: tfrmoptionshotkeys.stgcommands.columns[2].title.caption
+msgctxt "tfrmoptionshotkeys.stgcommands.columns[2].title.caption"
+msgid "Description"
+msgstr "Beskrivning"
+
+#: tfrmoptionshotkeys.stghotkeys.columns[0].title.caption
+msgctxt "tfrmoptionshotkeys.stghotkeys.columns[0].title.caption"
+msgid "Hotkey"
+msgstr "Kortkommando"
+
+#: tfrmoptionshotkeys.stghotkeys.columns[1].title.caption
+msgctxt "tfrmoptionshotkeys.stghotkeys.columns[1].title.caption"
+msgid "Parameters"
+msgstr "Parametrar"
+
+#: tfrmoptionshotkeys.stghotkeys.columns[2].title.caption
+msgid "Controls"
+msgstr "Kontroller"
+
+#: tfrmoptionsicloud.appslistview.columns[0].caption
+msgctxt "tfrmoptionsicloud.appslistview.columns[0].caption"
+msgid "Applications"
+msgstr "Program"
+
+#: tfrmoptionsicloud.appslistview.columns[1].caption
+msgctxt "tfrmoptionsicloud.appslistview.columns[1].caption"
+msgid "Count of Contents"
+msgstr "Antal innehållsobjekt"
+
+#: tfrmoptionsicons.cbiconsexclude.caption
+msgctxt "TFRMOPTIONSICONS.CBICONSEXCLUDE.CAPTION"
+msgid "For the following &paths and their subdirectories:"
+msgstr "För följande &sökvägar och deras underkataloger:"
+
+#: tfrmoptionsicons.cbiconsinmenus.caption
+msgid "Show icons for actions in &menus"
+msgstr "Visa ikoner för åtgärder i &menyer"
+
+#: tfrmoptionsicons.cbiconsinmenussize.text
+msgctxt "TFRMOPTIONSICONS.CBICONSINMENUSSIZE.TEXT"
+msgid "16x16"
+msgstr "16x16"
+
+#: tfrmoptionsicons.cbiconsonbuttons.caption
+msgid "Show icons on buttons"
+msgstr "Visa ikoner på knappar"
+
+#: tfrmoptionsicons.cbiconsshowoverlay.caption
+msgid "Show o&verlay icons, e.g. for links"
+msgstr "Visa ö&verlagringsikoner, t.ex. för länkar"
+
+#: tfrmoptionsicons.chkshowhiddendimmed.caption
+msgid "&Dimmed hidden files (slower)"
+msgstr "&Tona ned dolda filer (långsammare)"
+
+#: tfrmoptionsicons.gbdisablespecialicons.caption
+msgid "Disable special icons"
+msgstr "Inaktivera specialikoner"
+
+#: tfrmoptionsicons.gbiconssize.caption
+msgid " Icon size "
+msgstr " Ikonstorlek "
+
+#: tfrmoptionsicons.gbicontheme.caption
+msgid "Icon theme"
+msgstr "Ikontema"
+
+#: tfrmoptionsicons.gbshowicons.caption
+msgid "Show icons"
+msgstr "Visa ikoner"
+
+#: tfrmoptionsicons.gbshowiconsmode.caption
+msgid " Show icons to the left of the filename "
+msgstr " Visa ikoner till vänster om filnamnet "
+
+#: tfrmoptionsicons.lbldiskpanel.caption
+msgid "Disk panel:"
+msgstr "Enhetspanel:"
+
+#: tfrmoptionsicons.lblfilepanel.caption
+msgid "File panel:"
+msgstr "Filpanel:"
+
+#: tfrmoptionsicons.rbiconsshowall.caption
+msgctxt "tfrmoptionsicons.rbiconsshowall.caption"
+msgid "A&ll"
+msgstr "A&lla"
+
+#: tfrmoptionsicons.rbiconsshowallandexe.caption
+msgid "All associated + &EXE/LNK (slow)"
+msgstr "Alla associerade + &EXE/LNK (långsamt)"
+
+#: tfrmoptionsicons.rbiconsshownone.caption
+msgid "&No icons"
+msgstr "&Inga ikoner"
+
+#: tfrmoptionsicons.rbiconsshowstandard.caption
+msgid "Only &standard icons"
+msgstr "Endast &standardikoner"
+
+#: tfrmoptionsignorelist.btnaddsel.caption
+msgid "A&dd selected names"
+msgstr "Lägg till &markerade namn"
+
+#: tfrmoptionsignorelist.btnaddselwithpath.caption
+msgid "Add selected names with &full path"
+msgstr "Lägg till markerade namn med &fullständig sökväg"
+
+#: tfrmoptionsignorelist.btnrelativesavein.hint
+msgctxt "TFRMOPTIONSIGNORELIST.BTNRELATIVESAVEIN.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsignorelist.chkignoreenable.caption
+msgid "&Ignore (don't show) the following files and folders:"
+msgstr "&Ignorera (visa inte) följande filer och mappar:"
+
+#: tfrmoptionsignorelist.lblsavein.caption
+msgid "&Save in:"
+msgstr "&Spara i:"
+
+#: tfrmoptionskeyboard.cbfnkey.caption
+msgid ""
+"Force F1, F2, etc. to be treated as function keys\n"
+"ignore the settings in System Settings > Keyboard"
+msgstr ""
+"Tvinga F1, F2 osv. att behandlas som funktionstangenter\n"
+"ignorera inställningarna i Systeminställningar > Tangentbord"
+
+#: tfrmoptionskeyboard.cbfnkey.hint
+msgid ""
+"This feature requires additional system permission.\n"
+"\n"
+"Enabling it will automatically guide you to the\n"
+"System Settings > Privacy && Security > Accessibility Panel.\n"
+"\n"
+"Each time a new version of DC is installed, you must first\n"
+"remove DC from the list and then add it back in."
+msgstr ""
+"Den här funktionen kräver ytterligare systembehörighet.\n"
+"\n"
+"När den aktiveras vägleds du automatiskt till\n"
+"Systeminställningar > Integritet och säkerhet > Hjälpmedel.\n"
+"\n"
+"Varje gång en ny version av DC installeras måste du först\n"
+"ta bort DC från listan och sedan lägga till det igen."
+
+#: tfrmoptionskeyboard.cblynxlike.caption
+msgid "Le&ft, Right arrows change directory (Lynx-like movement)"
+msgstr "&Vänster- och högerpilar byter katalog (Lynx-liknande förflyttning)"
+
+#: tfrmoptionskeyboard.gbtyping.caption
+msgid "Typing"
+msgstr "Inmatning"
+
+#: tfrmoptionskeyboard.lblalt.caption
+msgid "Alt+L&etters:"
+msgstr "Alt+&bokstäver:"
+
+#: tfrmoptionskeyboard.lblctrlalt.caption
+msgid "Ctrl+Alt+Le&tters:"
+msgstr "Ctrl+Alt+bo&kstäver:"
+
+#: tfrmoptionskeyboard.lblnomodifier.caption
+msgid "&Letters:"
+msgstr "&Bokstäver:"
+
+#: tfrmoptionslayout.cbflatdiskpanel.caption
+msgctxt "tfrmoptionslayout.cbflatdiskpanel.caption"
+msgid "&Flat buttons"
+msgstr "&Platta knappar"
+
+#: tfrmoptionslayout.cbflatinterface.caption
+msgid "Flat i&nterface"
+msgstr "Platt g&ränssnitt"
+
+#: tfrmoptionslayout.cbfreespaceind.caption
+msgid "Show fr&ee space indicator on drive label"
+msgstr "Visa indikator för le&digt utrymme på enhetsetiketten"
+
+#: tfrmoptionslayout.cblogwindow.caption
+msgid "Show lo&g window"
+msgstr "Visa lo&ggfönster"
+
+#: tfrmoptionslayout.cbpanelofoperations.caption
+msgid "Show panel of operation in background"
+msgstr "Visa åtgärdspanel i bakgrunden"
+
+#: tfrmoptionslayout.cbproginmenubar.caption
+msgid "Show common progress in menu bar"
+msgstr "Visa övergripande förlopp i menyraden"
+
+#: tfrmoptionslayout.cbshowcmdline.caption
+msgid "Show command l&ine"
+msgstr "Visa kommandor&ad"
+
+#: tfrmoptionslayout.cbshowcurdir.caption
+msgid "Show current director&y"
+msgstr "Visa aktuell katalo&g"
+
+#: tfrmoptionslayout.cbshowdiskpanel.caption
+msgid "Show &drive buttons"
+msgstr "Visa &enhetsknappar"
+
+#: tfrmoptionslayout.cbshowdrivefreespace.caption
+msgid "Show free s&pace label"
+msgstr "Visa etikett för ledigt u&trymme"
+
+#: tfrmoptionslayout.cbshowdriveslistbutton.caption
+msgid "Show drives list bu&tton"
+msgstr "Visa knapp för enhetslis&ta"
+
+#: tfrmoptionslayout.cbshowkeyspanel.caption
+msgid "Show function &key buttons"
+msgstr "Visa knappar för &funktionstangenter"
+
+#: tfrmoptionslayout.cbshowmainmenu.caption
+msgid "Show &main menu"
+msgstr "Visa &huvudmeny"
+
+#: tfrmoptionslayout.cbshowmaintoolbar.caption
+msgid "Show tool&bar"
+msgstr "Visa verktygs&fält"
+
+#: tfrmoptionslayout.cbshowshortdrivefreespace.caption
+msgid "Show short free space &label"
+msgstr "Visa &kort etikett för ledigt utrymme"
+
+#: tfrmoptionslayout.cbshowstatusbar.caption
+msgid "Show &status bar"
+msgstr "Visa &statusfält"
+
+#: tfrmoptionslayout.cbshowtabheader.caption
+msgid "S&how tabstop header"
+msgstr "Visa r&ubrik för tabbstopp"
+
+#: tfrmoptionslayout.cbshowtabs.caption
+msgid "Sho&w folder tabs"
+msgstr "Visa m&appflikar"
+
+#: tfrmoptionslayout.cbtermwindow.caption
+msgid "Show te&rminal window"
+msgstr "Visa te&rminalfönster"
+
+#: tfrmoptionslayout.cbtwodiskpanels.caption
+msgid "Show two drive button bars (fi&xed width, above file windows)"
+msgstr "Visa två fält med enhetsknappar (fa&st bredd, ovanför filpanelerna)"
+
+#: tfrmoptionslayout.chkshowmiddletoolbar.caption
+msgid "Show middle toolbar"
+msgstr "Visa mittenverktygsfält"
+
+#: tfrmoptionslayout.gbscreenlayout.caption
+msgid " Screen layout "
+msgstr " Skärmlayout "
+
+#: tfrmoptionslog.btnrelativelogfile.hint
+msgctxt "TFRMOPTIONSLOG.BTNRELATIVELOGFILE.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionslog.btnviewlogfile.hint
+msgctxt "tfrmoptionslog.btnviewlogfile.hint"
+msgid "View log file content"
+msgstr "Visa loggfilens innehåll"
+
+#: tfrmoptionslog.cbincludedateinlogfilename.caption
+msgid "Include date in log filename"
+msgstr "Inkludera datum i loggfilens namn"
+
+#: tfrmoptionslog.cblogarcop.caption
+msgid "&Pack/Unpack"
+msgstr "&Packa/packa upp"
+
+#: tfrmoptionslog.cblogcommandlineexecution.caption
+msgid "External command line execution"
+msgstr "Körning av extern kommandorad"
+
+#: tfrmoptionslog.cblogcpmvln.caption
+msgid "Cop&y/Move/Create link/symlink"
+msgstr "Kop&iera/flytta/skapa länk/symbolisk länk"
+
+#: tfrmoptionslog.cblogdelete.caption
+msgctxt "TFRMOPTIONSLOG.CBLOGDELETE.CAPTION"
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: tfrmoptionslog.cblogdirop.caption
+msgid "Crea&te/Delete directories"
+msgstr "S&kapa/ta bort kataloger"
+
+#: tfrmoptionslog.cblogerrors.caption
+msgid "Log &errors"
+msgstr "Logga &fel"
+
+#: tfrmoptionslog.cblogfile.caption
+msgid "C&reate a log file:"
+msgstr "Skapa en &loggfil:"
+
+#: tfrmoptionslog.cblogfilecount.caption
+msgid "Maximum log file count"
+msgstr "Maximalt antal loggfiler"
+
+#: tfrmoptionslog.cbloginfo.caption
+msgid "Log &information messages"
+msgstr "Logga &informationsmeddelanden"
+
+#: tfrmoptionslog.cblogstartshutdown.caption
+msgid "Start/shutdown"
+msgstr "Start/avslut"
+
+#: tfrmoptionslog.cblogsuccess.caption
+msgid "Log &successful operations"
+msgstr "Logga &lyckade åtgärder"
+
+#: tfrmoptionslog.cblogvfs.caption
+msgid "&File system plugins"
+msgstr "&Filsysteminsticksmoduler"
+
+#: tfrmoptionslog.gblogfile.caption
+msgid "File operation log file"
+msgstr "Loggfil för filåtgärder"
+
+#: tfrmoptionslog.gblogfileop.caption
+msgid "Log operations"
+msgstr "Logga åtgärder"
+
+#: tfrmoptionslog.gblogfilestatus.caption
+msgid "Operation status"
+msgstr "Åtgärdsstatus"
+
+#: tfrmoptionsmisc.btnrelativeoutputpathfortoolbar.hint
+msgctxt "TFRMOPTIONSMISC.BTNRELATIVEOUTPUTPATHFORTOOLBAR.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsmisc.btnrelativetcconfigfile.hint
+msgctxt "TFRMOPTIONSMISC.BTNRELATIVETCCONFIGFILE.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsmisc.btnrelativetcexecutablefile.hint
+msgctxt "TFRMOPTIONSMISC.BTNRELATIVETCEXECUTABLEFILE.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsmisc.btnthumbcompactcache.caption
+msgid "&Remove thumbnails for no longer existing files"
+msgstr "&Ta bort miniatyrer för filer som inte längre finns"
+
+#: tfrmoptionsmisc.btnviewconfigfile.hint
+msgctxt "TFRMOPTIONSMISC.BTNVIEWCONFIGFILE.HINT"
+msgid "View configuration file content"
+msgstr "Visa konfigurationsfilens innehåll"
+
+#: tfrmoptionsmisc.chkdesccreateunicode.caption
+msgctxt "TFRMOPTIONSMISC.CHKDESCCREATEUNICODE.CAPTION"
+msgid "Create new with the encoding:"
+msgstr "Skapa ny med kodningen:"
+
+#: tfrmoptionsmisc.chkgotoroot.caption
+msgid "Always &go to the root of a drive when changing drives"
+msgstr "Gå alltid till &roten på en enhet när du byter enhet"
+
+#: tfrmoptionsmisc.chkshowcurdirtitlebar.caption
+msgid "Show &current directory in the main window title bar"
+msgstr "Visa &aktuell katalog i huvudfönstrets namnlist"
+
+#: tfrmoptionsmisc.chkshowsplashform.caption
+msgid "Show &splash screen"
+msgstr "Visa &startbild"
+
+#: tfrmoptionsmisc.chkshowwarningmessages.caption
+msgid "Show &warning messages (\"OK\" button only)"
+msgstr "Visa &varningsmeddelanden (endast knappen ”OK”)"
+
+#: tfrmoptionsmisc.chkthumbsave.caption
+msgid "&Save thumbnails in cache"
+msgstr "&Spara miniatyrer i cache"
+
+#: tfrmoptionsmisc.dblthumbnails.caption
+msgctxt "TFRMOPTIONSMISC.DBLTHUMBNAILS.CAPTION"
+msgid "Thumbnails"
+msgstr "Miniatyrer"
+
+#: tfrmoptionsmisc.gbfilecomments.caption
+msgid "File comments (descript.ion)"
+msgstr "Filkommentarer (descript.ion)"
+
+#: tfrmoptionsmisc.gbtcexportimport.caption
+msgid "Regarding TC export/import:"
+msgstr "Angående TC-export/import:"
+
+#: tfrmoptionsmisc.lbldefaultencoding.caption
+msgid "&Default single-byte text encoding:"
+msgstr "&Standardkodning för enkelbyte-text:"
+
+#: tfrmoptionsmisc.lbldescrdefaultencoding.caption
+msgctxt "TFRMOPTIONSMISC.LBLDESCRDEFAULTENCODING.CAPTION"
+msgid "Default encoding:"
+msgstr "Standardkodning:"
+
+#: tfrmoptionsmisc.lbltcconfig.caption
+msgid "Configuration file:"
+msgstr "Konfigurationsfil:"
+
+#: tfrmoptionsmisc.lbltcexecutable.caption
+msgid "TC executable:"
+msgstr "TC-körbar fil:"
+
+#: tfrmoptionsmisc.lbltcpathfortool.caption
+msgid "Toolbar output path:"
+msgstr "Utdatasökväg för verktygsfält:"
+
+#: tfrmoptionsmisc.lblthumbpixels.caption
+msgid "pixels"
+msgstr "pixlar"
+
+#: tfrmoptionsmisc.lblthumbseparator.caption
+msgctxt "tfrmoptionsmisc.lblthumbseparator.caption"
+msgid "X"
+msgstr "X"
+
+#: tfrmoptionsmisc.lblthumbsize.caption
+msgid "&Thumbnail size:"
+msgstr "&Miniatyrstorlek:"
+
+#: tfrmoptionsmouse.cbselectionbymouse.caption
+msgid "&Selection by mouse"
+msgstr "&Markering med mus"
+
+#: tfrmoptionsmouse.chkcursornofollow.caption
+msgid "The text cursor no longer follows the mouse cursor"
+msgstr "Textmarkören följer inte längre muspekaren"
+
+#: tfrmoptionsmouse.chkmouseselectioniconclick.caption
+msgid "By clic&king on icon"
+msgstr "Genom att kli&cka på ikonen"
+
+#: tfrmoptionsmouse.chkzoomwithctrlwheel.caption
+msgctxt "tfrmoptionsmouse.chkzoomwithctrlwheel.caption"
+msgid "Zoom with Ctrl + Scroll Wheel"
+msgstr "Zooma med Ctrl + mushjul"
+
+#: tfrmoptionsmouse.gbopenwith.caption
+msgctxt "tfrmoptionsmouse.gbopenwith.caption"
+msgid "Open with"
+msgstr "Öppna med"
+
+#: tfrmoptionsmouse.gbscrolling.caption
+msgid "Scrolling"
+msgstr "Rullning"
+
+#: tfrmoptionsmouse.gbselection.caption
+msgid "Selection"
+msgstr "Markering"
+
+#: tfrmoptionsmouse.gbzoom.caption
+msgctxt "tfrmoptionsmouse.gbzoom.caption"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: tfrmoptionsmouse.lblmousemode.caption
+msgid "&Mode:"
+msgstr "&Läge:"
+
+#: tfrmoptionsmouse.rbdoubleclick.caption
+msgid "Double click"
+msgstr "Dubbelklick"
+
+#: tfrmoptionsmouse.rbscrolllinebyline.caption
+msgid "&Line by line"
+msgstr "&Rad för rad"
+
+#: tfrmoptionsmouse.rbscrolllinebylinecursor.caption
+msgid "Line by line &with cursor movement"
+msgstr "Rad för rad &med markörförflyttning"
+
+#: tfrmoptionsmouse.rbscrollpagebypage.caption
+msgid "&Page by page"
+msgstr "&Sida för sida"
+
+#: tfrmoptionsmouse.rbsingleclickboth.caption
+msgid "Single click (opens files and folders)"
+msgstr "Enkelklick (öppnar filer och mappar)"
+
+#: tfrmoptionsmouse.rbsingleclickfolders.caption
+msgid "Single click (opens folders, double click for files)"
+msgstr "Enkelklick (öppnar mappar, dubbelklick för filer)"
+
+#: tfrmoptionsmultirename.btnmulrenlogfilenamerelative.hint
+msgctxt "tfrmoptionsmultirename.btnmulrenlogfilenamerelative.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionsmultirename.btnmulrenlogfilenameview.hint
+msgctxt "tfrmoptionsmultirename.btnmulrenlogfilenameview.hint"
+msgid "View log file content"
+msgstr "Visa loggfilens innehåll"
+
+#: tfrmoptionsmultirename.ckbdailyindividualdirmultrenlog.caption
+msgid "Individual directories per day"
+msgstr "Separata kataloger per dag"
+
+#: tfrmoptionsmultirename.ckbfilenamewithfullpathinlog.caption
+msgid "Log filenames with full path"
+msgstr "Logga filnamn med fullständig sökväg"
+
+#: tfrmoptionsmultirename.ckbshowmenubarontop.caption
+msgid "Show menu bar on top "
+msgstr "Visa menyrad överst"
+
+#: tfrmoptionsmultirename.gbsaverenaminglog.caption
+msgid "Rename log"
+msgstr "Namnbyteslogg"
+
+#: tfrmoptionsmultirename.lbinvalidcharreplacement.caption
+msgid "Replace invalid filename character b&y"
+msgstr "Ersätt ogiltigt tecken i filnamn me&d"
+
+#: tfrmoptionsmultirename.rbrenaminglogappendsamefile.caption
+msgid "Append in the same rename log file"
+msgstr "Lägg till i samma namnbytesloggfil"
+
+#: tfrmoptionsmultirename.rbrenaminglogperpreset.caption
+msgid "Per preset"
+msgstr "Per förinställning"
+
+#: tfrmoptionsmultirename.rgexitmodifiedpreset.caption
+msgid "Exit with modified preset"
+msgstr "Avsluta med ändrad förinställning"
+
+#: tfrmoptionsmultirename.rglaunchbehavior.caption
+msgid "Preset at launch"
+msgstr "Förinställning vid start"
+
+#: tfrmoptionspluginsbase.btnaddplugin.caption
+msgctxt "tfrmoptionspluginsbase.btnaddplugin.caption"
+msgid "A&dd"
+msgstr "&Lägg till"
+
+#: tfrmoptionspluginsbase.btnconfigplugin.caption
+msgctxt "tfrmoptionspluginsbase.btnconfigplugin.caption"
+msgid "Con&figure"
+msgstr "Kon&figurera"
+
+#: tfrmoptionspluginsbase.btnenableplugin.caption
+msgctxt "tfrmoptionspluginsbase.btnenableplugin.caption"
+msgid "E&nable"
+msgstr "A&ktivera"
+
+#: tfrmoptionspluginsbase.btnremoveplugin.caption
+msgctxt "tfrmoptionspluginsbase.btnremoveplugin.caption"
+msgid "&Remove"
+msgstr "&Ta bort"
+
+#: tfrmoptionspluginsbase.btntweakplugin.caption
+msgctxt "tfrmoptionspluginsbase.btntweakplugin.caption"
+msgid "&Tweak"
+msgstr "&Justera"
+
+#: tfrmoptionspluginsbase.lblplugindescription.caption
+msgctxt "tfrmoptionspluginsbase.lblplugindescription.caption"
+msgid "Description"
+msgstr "Beskrivning"
+
+#: tfrmoptionspluginsbase.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginsbase.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginsbase.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginsbase.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginsbase.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginsbase.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginsbase.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginsbase.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionspluginsdsx.lblplugindescription.caption
+msgctxt "tfrmoptionspluginsdsx.lblplugindescription.caption"
+msgid ""
+"Searc&h plugins allow one to use alternative search algorithms or external tools (like "
+"\"locate\", etc.)"
+msgstr ""
+"Sö&kinsticksmoduler gör det möjligt att använda alternativa sökalgoritmer eller externa verktyg "
+"(som ”locate” osv.)"
+
+#: tfrmoptionspluginsdsx.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginsdsx.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginsdsx.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginsdsx.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginsdsx.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginsdsx.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginsdsx.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginsdsx.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionspluginsgroup.btnpathtoberelativetoall.caption
+msgid "Apply current settings to all current configured plugins"
+msgstr "Verkställ aktuella inställningar på alla konfigurerade insticksmoduler"
+
+#: tfrmoptionspluginsgroup.ckbautotweak.caption
+msgid "When adding a new plugin, automatically go in tweak window"
+msgstr "När en ny insticksmodul läggs till, öppna automatiskt justeringsfönstret"
+
+#: tfrmoptionspluginsgroup.gbconfiguration.caption
+msgid "Configuration:"
+msgstr "Konfiguration:"
+
+#: tfrmoptionspluginsgroup.lbllualibraryfilename.caption
+msgid "Lua library file to use:"
+msgstr "Lua-biblioteksfil att använda:"
+
+#: tfrmoptionspluginsgroup.lbpathtoberelativeto.caption
+msgctxt "tfrmoptionspluginsgroup.lbpathtoberelativeto.caption"
+msgid "Path to be relative to:"
+msgstr "Sökvägen ska vara relativ till:"
+
+#: tfrmoptionspluginsgroup.lbpluginfilenamestyle.caption
+msgid "Plugin filename style when adding a new plugin:"
+msgstr "Stil för insticksmodulens filnamn när en ny insticksmodul läggs till:"
+
+#: tfrmoptionspluginswcx.lblplugindescription.caption
+msgctxt "tfrmoptionspluginswcx.lblplugindescription.caption"
+msgid "Pack&er plugins are used to work with archives"
+msgstr "Pack&ningsinsticksmoduler används för att arbeta med arkiv"
+
+#: tfrmoptionspluginswcx.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginswcx.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginswcx.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginswcx.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginswcx.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginswcx.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginswcx.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginswcx.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionspluginswdx.lblplugindescription.caption
+msgctxt "tfrmoptionspluginswdx.lblplugindescription.caption"
+msgid ""
+"Content plu&gins allow one to display extended file details like mp3 tags or image attributes in "
+"file lists, or use them in search and multi-rename tool"
+msgstr ""
+"Innehållsinsticks&moduler kan visa utökade fildetaljer, som MP3-taggar eller bildegenskaper, i "
+"fillistor eller använda dem vid sökning och massomdöpning"
+
+#: tfrmoptionspluginswdx.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginswdx.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginswdx.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginswdx.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginswdx.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginswdx.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginswdx.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginswdx.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionspluginswfx.lblplugindescription.caption
+msgctxt "tfrmoptionspluginswfx.lblplugindescription.caption"
+msgid ""
+"Fi&le system plugins allow access to disks inaccessible by operating system or to external "
+"devices like smartphones."
+msgstr ""
+"Fi&lsysteminsticksmoduler ger åtkomst till diskar som operativsystemet inte kan nå eller till "
+"externa enheter som smarttelefoner."
+
+#: tfrmoptionspluginswfx.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginswfx.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginswfx.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginswfx.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginswfx.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginswfx.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginswfx.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginswfx.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionspluginswlx.lblplugindescription.caption
+msgctxt "tfrmoptionspluginswlx.lblplugindescription.caption"
+msgid ""
+"Vie&wer plugins allow one to display file formats like images, spreadsheets, databases etc. in "
+"Viewer (F3, Ctrl+Q)"
+msgstr ""
+"Visa&rinsticksmoduler gör det möjligt att visa filformat som bilder, kalkylblad, databaser osv. i"
+" visaren (F3, Ctrl+Q)"
+
+#: tfrmoptionspluginswlx.stgplugins.columns[0].title.caption
+msgctxt "tfrmoptionspluginswlx.stgplugins.columns[0].title.caption"
+msgid "Active"
+msgstr "Aktiv"
+
+#: tfrmoptionspluginswlx.stgplugins.columns[1].title.caption
+msgctxt "tfrmoptionspluginswlx.stgplugins.columns[1].title.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmoptionspluginswlx.stgplugins.columns[2].title.caption
+msgctxt "tfrmoptionspluginswlx.stgplugins.columns[2].title.caption"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: tfrmoptionspluginswlx.stgplugins.columns[3].title.caption
+msgctxt "tfrmoptionspluginswlx.stgplugins.columns[3].title.caption"
+msgid "File name"
+msgstr "Filnamn"
+
+#: tfrmoptionsquicksearchfilter.cbexactbeginning.caption
+msgid "&Beginning (name must start with first typed character)"
+msgstr "&Början (namnet måste börja med det först inskrivna tecknet)"
+
+#: tfrmoptionsquicksearchfilter.cbexactending.caption
+msgid "En&ding (last character before a typed dot . must match)"
+msgstr "Sl&utet (sista tecknet före en inskriven punkt . måste matcha)"
+
+#: tfrmoptionsquicksearchfilter.cgpoptions.caption
+msgctxt "TFRMOPTIONSQUICKSEARCHFILTER.CGPOPTIONS.CAPTION"
+msgid "Options"
+msgstr "Alternativ"
+
+#: tfrmoptionsquicksearchfilter.gbexactnamematch.caption
+msgid "Exact name match"
+msgstr "Exakt namnmatchning"
+
+#: tfrmoptionsquicksearchfilter.rgpsearchcase.caption
+msgid "Search case"
+msgstr "Sökningens skiftläge"
+
+#: tfrmoptionsquicksearchfilter.rgpsearchitems.caption
+msgid "Search for these items"
+msgstr "Sök efter dessa objekt"
+
+#: tfrmoptionstabs.cbkeeprenamednamebacktonormal.caption
+msgid "Keep renamed name when unlocking a tab"
+msgstr "Behåll det nya namnet när en flik låses upp"
+
+#: tfrmoptionstabs.cbtabsactivateonclick.caption
+msgid "Activate target &panel when clicking on one of its Tabs"
+msgstr "Aktivera mål&panelen när du klickar på en av dess flikar"
+
+#: tfrmoptionstabs.cbtabsalwaysvisible.caption
+msgid "&Show tab header also when there is only one tab"
+msgstr "&Visa flikhuvud även när det bara finns en flik"
+
+#: tfrmoptionstabs.cbtabscloseduplicatewhenclosing.caption
+msgid "Close duplicate tabs when closing application"
+msgstr "Stäng dubblettflikar när programmet avslutas"
+
+#: tfrmoptionstabs.cbtabsconfirmcloseall.caption
+msgid "Con&firm close all tabs"
+msgstr "Bekrä&fta stängning av alla flikar"
+
+#: tfrmoptionstabs.cbtabsconfirmcloselocked.caption
+msgid "Confirm close locked tabs"
+msgstr "Bekräfta stängning av låsta flikar"
+
+#: tfrmoptionstabs.cbtabslimitoption.caption
+msgid "&Limit tab title length to"
+msgstr "&Begränsa flikrubrikens längd till"
+
+#: tfrmoptionstabs.cbtabslockedasterisk.caption
+msgid "Show locked tabs &with an asterisk *"
+msgstr "Visa låsta flikar &med en asterisk *"
+
+#: tfrmoptionstabs.cbtabsmultilines.caption
+msgid "&Tabs on multiple lines"
+msgstr "&Flikar på flera rader"
+
+#: tfrmoptionstabs.cbtabsopenforeground.caption
+msgid "Ctrl+&Up opens new tab in foreground"
+msgstr "Ctrl+&Upp öppnar ny flik i förgrunden"
+
+#: tfrmoptionstabs.cbtabsopennearcurrent.caption
+msgid "Open &new tabs near current tab"
+msgstr "Öppna &nya flikar nära aktuell flik"
+
+#: tfrmoptionstabs.cbtabsreusetabwhenpossible.caption
+msgid "Reuse existing tab when possible"
+msgstr "Återanvänd befintlig flik när det är möjligt"
+
+#: tfrmoptionstabs.cbtabsshowclosebutton.caption
+msgid "Show ta&b close button"
+msgstr "Visa stän&gknapp på flik"
+
+#: tfrmoptionstabs.cbtabsshowdriveletter.caption
+msgid "Always show drive letter in tab title"
+msgstr "Visa alltid enhetsbokstav i flikrubriken"
+
+#: tfrmoptionstabs.cbtabsunavailablemarker.caption
+msgid "Mark unavailable path in tab title with &a question mark ?"
+msgstr "Markera otillgänglig sökväg i flikrubriken med &ett frågetecken ?"
+
+#: tfrmoptionstabs.gbtabs.caption
+msgid "Folder tabs headers"
+msgstr "Rubriker för mappflikar"
+
+#: tfrmoptionstabs.lblchar.caption
+msgid "characters"
+msgstr "tecken"
+
+#: tfrmoptionstabs.lbltabsactionondoubleclick.caption
+msgid "Action to do when double click on a tab:"
+msgstr "Åtgärd vid dubbelklick på en flik:"
+
+#: tfrmoptionstabs.lbltabsposition.caption
+msgid "Ta&bs position"
+msgstr "Fli&karnas placering"
+
+#: tfrmoptionstabsextra.cbdefaultexistingtabstokeep.text
+msgctxt "TFRMOPTIONSTABSEXTRA.CBDEFAULTEXISTINGTABSTOKEEP.TEXT"
+msgid "None"
+msgstr "Ingen"
+
+#: tfrmoptionstabsextra.cbdefaultsavedirhistory.text
+msgctxt "TFRMOPTIONSTABSEXTRA.CBDEFAULTSAVEDIRHISTORY.TEXT"
+msgid "No"
+msgstr "Nej"
+
+#: tfrmoptionstabsextra.cbdefaulttargetpanelleftsaved.text
+msgctxt "TFRMOPTIONSTABSEXTRA.CBDEFAULTTARGETPANELLEFTSAVED.TEXT"
+msgid "Left"
+msgstr "Vänster"
+
+#: tfrmoptionstabsextra.cbdefaulttargetpanelrightsaved.text
+msgctxt "TFRMOPTIONSTABSEXTRA.CBDEFAULTTARGETPANELRIGHTSAVED.TEXT"
+msgid "Right"
+msgstr "Höger"
+
+#: tfrmoptionstabsextra.cbgotoconfigafterresave.caption
+msgid "Goto to Favorite Tabs Configuration after resaving"
+msgstr "Gå till konfigurationen av favoritflikar efter omsparning"
+
+#: tfrmoptionstabsextra.cbgotoconfigaftersave.caption
+msgid "Goto to Favorite Tabs Configuration after saving a new one"
+msgstr "Gå till konfigurationen av favoritflikar efter att en ny har sparats"
+
+#: tfrmoptionstabsextra.cbusefavoritetabsextraoptions.caption
+msgid "Enable Favorite Tabs extra options (select target side when restore, etc.)"
+msgstr "Aktivera extra alternativ för favoritflikar (välj målsida vid återställning osv.)"
+
+#: tfrmoptionstabsextra.gbdefaulttabsavedrestoration.caption
+msgid "Default extra settings when saving new Favorite Tabs:"
+msgstr "Extra standardinställningar när nya favoritflikar sparas:"
+
+#: tfrmoptionstabsextra.gbtabs.caption
+msgid "Folder tabs headers extra"
+msgstr "Extra inställningar för mappflikarnas rubriker"
+
+#: tfrmoptionstabsextra.lbldefaultexistingtabstokeep.caption
+msgid "When restoring tab, existing tabs to keep:"
+msgstr "När flikar återställs, befintliga flikar att behålla:"
+
+#: tfrmoptionstabsextra.lbldefaulttargetpanelleftsaved.caption
+msgid "Tabs saved on left will be restored to:"
+msgstr "Flikar som sparats till vänster återställs till:"
+
+#: tfrmoptionstabsextra.lbldefaulttargetpanelrightsaved.caption
+msgid "Tabs saved on right will be restored to:"
+msgstr "Flikar som sparats till höger återställs till:"
+
+#: tfrmoptionstabsextra.lblfavoritetabssavedirhistory.caption
+msgctxt "tfrmoptionstabsextra.lblfavoritetabssavedirhistory.caption"
+msgid "Keep saving dir history with Favorite Tabs:"
+msgstr "Fortsätt spara kataloghistorik med favoritflikar:"
+
+#: tfrmoptionstabsextra.rgwheretoadd.caption
+msgid "Default position in menu when saving a new Favorite Tabs:"
+msgstr "Standardposition i menyn när nya favoritflikar sparas:"
+
+#: tfrmoptionsterminal.edrunintermcloseparams.hint
+#
+msgctxt "TFRMOPTIONSTERMINAL.EDRUNINTERMCLOSEPARAMS.HINT"
+msgid "{command} should normally be present here to reflect the command to be run in terminal"
+msgstr "{command} bör normalt finnas här för att motsvara kommandot som ska köras i terminalen"
+
+#: tfrmoptionsterminal.edrunintermstayopenparams.hint
+#
+msgctxt "TFRMOPTIONSTERMINAL.EDRUNINTERMSTAYOPENPARAMS.HINT"
+msgid "{command} should normally be present here to reflect the command to be run in terminal"
+msgstr "{command} bör normalt finnas här för att motsvara kommandot som ska köras i terminalen"
+
+#: tfrmoptionsterminal.gbjustrunterminal.caption
+msgid "Command for just running terminal:"
+msgstr "Kommando för att bara starta terminalen:"
+
+#: tfrmoptionsterminal.gbruninterminalclose.caption
+msgid "Command for running a command in terminal and close after:"
+msgstr "Kommando för att köra ett kommando i terminalen och sedan stänga:"
+
+#: tfrmoptionsterminal.gbruninterminalstayopen.caption
+msgid "Command for running a command in terminal and stay open:"
+msgstr "Kommando för att köra ett kommando i terminalen och hålla den öppen:"
+
+#: tfrmoptionsterminal.lbrunintermclosecmd.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNINTERMCLOSECMD.CAPTION"
+msgid "Command:"
+msgstr "Kommando:"
+
+#: tfrmoptionsterminal.lbrunintermcloseparams.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNINTERMCLOSEPARAMS.CAPTION"
+msgid "Parameters:"
+msgstr "Parametrar:"
+
+#: tfrmoptionsterminal.lbrunintermstayopencmd.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNINTERMSTAYOPENCMD.CAPTION"
+msgid "Command:"
+msgstr "Kommando:"
+
+#: tfrmoptionsterminal.lbrunintermstayopenparams.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNINTERMSTAYOPENPARAMS.CAPTION"
+msgid "Parameters:"
+msgstr "Parametrar:"
+
+#: tfrmoptionsterminal.lbruntermcmd.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNTERMCMD.CAPTION"
+msgid "Command:"
+msgstr "Kommando:"
+
+#: tfrmoptionsterminal.lbruntermparams.caption
+msgctxt "TFRMOPTIONSTERMINAL.LBRUNTERMPARAMS.CAPTION"
+msgid "Parameters:"
+msgstr "Parametrar:"
+
+#: tfrmoptionstoolbarbase.btnclonebutton.caption
+msgid "C&lone button"
+msgstr "K&lona knapp"
+
+#: tfrmoptionstoolbarbase.btndeletebutton.caption
+msgctxt "tfrmoptionstoolbarbase.BTNDELETEBUTTON.CAPTION"
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: tfrmoptionstoolbarbase.btnedithotkey.caption
+msgid "Edit hot&key"
+msgstr "Redigera kort&kommando"
+
+#: tfrmoptionstoolbarbase.btninsertbutton.caption
+msgid "&Insert new button"
+msgstr "&Infoga ny knapp"
+
+#: tfrmoptionstoolbarbase.btnopencmddlg.caption
+msgid "Select"
+msgstr "Välj"
+
+#: tfrmoptionstoolbarbase.btnother.caption
+msgctxt "tfrmoptionstoolbarbase.btnother.caption"
+msgid "Other..."
+msgstr "Annat..."
+
+#: tfrmoptionstoolbarbase.btnremovehotkey.caption
+msgid "Remove hotke&y"
+msgstr "Ta bort kortko&mmando"
+
+#: tfrmoptionstoolbarbase.btnsuggestiontooltip.caption
+msgid "Suggest"
+msgstr "Föreslå"
+
+#: tfrmoptionstoolbarbase.btnsuggestiontooltip.hint
+msgid "Have DC suggest the tooltip based on button type, command and parameters"
+msgstr "Låt DC föreslå verktygstipset baserat på knapptyp, kommando och parametrar"
+
+#: tfrmoptionstoolbarbase.cbflatbuttons.caption
+msgctxt "tfrmoptionstoolbarbase.CBFLATBUTTONS.CAPTION"
+msgid "&Flat buttons"
+msgstr "&Platta knappar"
+
+#: tfrmoptionstoolbarbase.cbreporterrorwithcommands.caption
+msgid "Report errors with commands"
+msgstr "Rapportera fel med kommandon"
+
+#: tfrmoptionstoolbarbase.cbshowcaptions.caption
+msgid "Sho&w captions"
+msgstr "Visa &texter"
+
+#: tfrmoptionstoolbarbase.edtinternalparameters.hint
+msgid "Enter command parameters, each in a separate line. Press F1 to see help on parameters."
+msgstr "Ange kommandoparametrar, en per rad. Tryck F1 för hjälp om parametrar."
+
+#: tfrmoptionstoolbarbase.gbgroupbox.caption
+msgid "Appearance"
+msgstr "Utseende"
+
+#: tfrmoptionstoolbarbase.lblbarsize.caption
+msgid "&Bar size:"
+msgstr "&Fältstorlek:"
+
+#: tfrmoptionstoolbarbase.lblexternalcommand.caption
+msgctxt "tfrmoptionstoolbarbase.lblexternalcommand.caption"
+msgid "Co&mmand:"
+msgstr "Ko&mmando:"
+
+#: tfrmoptionstoolbarbase.lblexternalparameters.caption
+msgctxt "tfrmoptionstoolbarbase.LBLEXTERNALPARAMETERS.CAPTION"
+msgid "Parameter&s:"
+msgstr "Parame&trar:"
+
+#: tfrmoptionstoolbarbase.lblhelponinternalcommand.caption
+msgctxt "tfrmoptionstoolbarbase.LBLHELPONINTERNALCOMMAND.CAPTION"
+msgid "Help"
+msgstr "Hjälp"
+
+#: tfrmoptionstoolbarbase.lblhotkey.caption
+msgid "Hot key:"
+msgstr "Kortkommando:"
+
+#: tfrmoptionstoolbarbase.lbliconfile.caption
+msgid "Ico&n:"
+msgstr "Iko&n:"
+
+#: tfrmoptionstoolbarbase.lbliconsize.caption
+msgid "Icon si&ze:"
+msgstr "Ikonstor&lek:"
+
+#: tfrmoptionstoolbarbase.lblinternalcommand.caption
+msgctxt "tfrmoptionstoolbarbase.lblinternalcommand.caption"
+msgid "Co&mmand:"
+msgstr "Ko&mmando:"
+
+#: tfrmoptionstoolbarbase.lblinternalparameters.caption
+msgid "&Parameters:"
+msgstr "&Parametrar:"
+
+#: tfrmoptionstoolbarbase.lblstartpath.caption
+msgctxt "tfrmoptionstoolbarbase.LBLSTARTPATH.CAPTION"
+msgid "Start pat&h:"
+msgstr "Startsök&väg:"
+
+#: tfrmoptionstoolbarbase.lblstyle.caption
+msgid "Style:"
+msgstr "Stil:"
+
+#: tfrmoptionstoolbarbase.lbltooltip.caption
+msgid "&Tooltip:"
+msgstr "&Verktygstips:"
+
+#: tfrmoptionstoolbarbase.miaddallcmds.caption
+msgid "Add toolbar with ALL DC commands"
+msgstr "Lägg till verktygsfält med ALLA DC-kommandon"
+
+#: tfrmoptionstoolbarbase.miaddexternalcommandsubmenu.caption
+msgid "for an external command"
+msgstr "för ett externt kommando"
+
+#: tfrmoptionstoolbarbase.miaddinternalcommandsubmenu.caption
+msgid "for an internal command"
+msgstr "för ett internt kommando"
+
+#: tfrmoptionstoolbarbase.miaddseparatorsubmenu.caption
+msgid "for a separator"
+msgstr "för en avgränsare"
+
+#: tfrmoptionstoolbarbase.miaddsubtoolbarsubmenu.caption
+msgid "for a sub-tool bar"
+msgstr "för ett underverktygsfält"
+
+#: tfrmoptionstoolbarbase.mibackup.caption
+msgctxt "tfrmoptionstoolbarbase.MIBACKUP.CAPTION"
+msgid "Backup..."
+msgstr "Säkerhetskopiera..."
+
+#: tfrmoptionstoolbarbase.miexport.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORT.CAPTION"
+msgid "Export..."
+msgstr "Exportera..."
+
+#: tfrmoptionstoolbarbase.miexportcurrent.caption
+msgid "Current toolbar..."
+msgstr "Aktuellt verktygsfält..."
+
+#: tfrmoptionstoolbarbase.miexportcurrenttodcbar.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTCURRENTTODCBAR.CAPTION"
+msgid "to a Toolbar File (.toolbar)"
+msgstr "till en verktygsfältsfil (.toolbar)"
+
+#: tfrmoptionstoolbarbase.miexportcurrenttotcbarkeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTCURRENTTOTCBARKEEP.CAPTION"
+msgid "to a TC .BAR file (keep existing)"
+msgstr "till en TC .BAR-fil (behåll befintliga)"
+
+#: tfrmoptionstoolbarbase.miexportcurrenttotcbarnokeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTCURRENTTOTCBARNOKEEP.CAPTION"
+msgid "to a TC .BAR file (erase existing)"
+msgstr "till en TC .BAR-fil (radera befintliga)"
+
+#: tfrmoptionstoolbarbase.miexportcurrenttotcinikeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTCURRENTTOTCINIKEEP.CAPTION"
+msgid "to a \"wincmd.ini\" of TC (keep existing)"
+msgstr "till TC:s ”wincmd.ini” (behåll befintliga)"
+
+#: tfrmoptionstoolbarbase.miexportcurrenttotcininokeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTCURRENTTOTCININOKEEP.CAPTION"
+msgid "to a \"wincmd.ini\" of TC (erase existing)"
+msgstr "till TC:s ”wincmd.ini” (radera befintliga)"
+
+#: tfrmoptionstoolbarbase.miexporttop.caption
+msgid "Top toolbar..."
+msgstr "Övre verktygsfält..."
+
+#: tfrmoptionstoolbarbase.miexporttoptobackup.caption
+msgid "Save a backup of Toolbar"
+msgstr "Spara en säkerhetskopia av verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miexporttoptodcbar.caption
+msgctxt "tfrmoptionstoolbarbase.miexporttoptodcbar.caption"
+msgid "to a Toolbar File (.toolbar)"
+msgstr "till en verktygsfältsfil (.toolbar)"
+
+#: tfrmoptionstoolbarbase.miexporttoptotcbarkeep.caption
+msgctxt "tfrmoptionstoolbarbase.miexporttoptotcbarkeep.caption"
+msgid "to a TC .BAR file (keep existing)"
+msgstr "till en TC .BAR-fil (behåll befintliga)"
+
+#: tfrmoptionstoolbarbase.miexporttoptotcbarnokeep.caption
+msgctxt "tfrmoptionstoolbarbase.miexporttoptotcbarnokeep.caption"
+msgid "to a TC .BAR file (erase existing)"
+msgstr "till en TC .BAR-fil (radera befintliga)"
+
+#: tfrmoptionstoolbarbase.miexporttoptotcinikeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTTOPTOTCINIKEEP.CAPTION"
+msgid "to a \"wincmd.ini\" of TC (keep existing)"
+msgstr "till TC:s ”wincmd.ini” (behåll befintliga)"
+
+#: tfrmoptionstoolbarbase.miexporttoptotcininokeep.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXPORTTOPTOTCININOKEEP.CAPTION"
+msgid "to a \"wincmd.ini\" of TC (erase existing)"
+msgstr "till TC:s ”wincmd.ini” (radera befintliga)"
+
+#: tfrmoptionstoolbarbase.miexternalcommandaftercurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXTERNALCOMMANDAFTERCURRENT.CAPTION"
+msgid "just after current selection"
+msgstr "direkt efter aktuell markering"
+
+#: tfrmoptionstoolbarbase.miexternalcommandfirstelement.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXTERNALCOMMANDFIRSTELEMENT.CAPTION"
+msgid "as first element"
+msgstr "som första objekt"
+
+#: tfrmoptionstoolbarbase.miexternalcommandlastelement.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXTERNALCOMMANDLASTELEMENT.CAPTION"
+msgid "as last element"
+msgstr "som sista objekt"
+
+#: tfrmoptionstoolbarbase.miexternalcommandpriorcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIEXTERNALCOMMANDPRIORCURRENT.CAPTION"
+msgid "just prior current selection"
+msgstr "direkt före aktuell markering"
+
+#: tfrmoptionstoolbarbase.miimport.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORT.CAPTION"
+msgid "Import..."
+msgstr "Importera..."
+
+#: tfrmoptionstoolbarbase.miimportbackup.caption
+msgid "Restore a backup of Toolbar"
+msgstr "Återställ en säkerhetskopia av verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportbackupaddcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTBACKUPADDCURRENT.CAPTION"
+msgid "to add to current toolbar"
+msgstr "för att lägga till i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimportbackupaddmenucurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTBACKUPADDMENUCURRENT.CAPTION"
+msgid "to add to a new toolbar to current toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimportbackupaddmenutop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTBACKUPADDMENUTOP.CAPTION"
+msgid "to add to a new toolbar to top toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportbackupaddtop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTBACKUPADDTOP.CAPTION"
+msgid "to add to top toolbar"
+msgstr "för att lägga till i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportbackupreplacetop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTBACKUPREPLACETOP.CAPTION"
+msgid "to replace top toolbar"
+msgstr "för att ersätta det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportdcbar.caption
+msgid "from a Toolbar File (.toolbar)"
+msgstr "från en verktygsfältsfil (.toolbar)"
+
+#: tfrmoptionstoolbarbase.miimportdcbaraddcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.miimportdcbaraddcurrent.caption"
+msgid "to add to current toolbar"
+msgstr "för att lägga till i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimportdcbaraddmenucurrent.caption
+msgctxt "tfrmoptionstoolbarbase.miimportdcbaraddmenucurrent.caption"
+msgid "to add to a new toolbar to current toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimportdcbaraddmenutop.caption
+msgctxt "tfrmoptionstoolbarbase.miimportdcbaraddmenutop.caption"
+msgid "to add to a new toolbar to top toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportdcbaraddtop.caption
+msgctxt "tfrmoptionstoolbarbase.miimportdcbaraddtop.caption"
+msgid "to add to top toolbar"
+msgstr "för att lägga till i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimportdcbarreplacetop.caption
+msgctxt "tfrmoptionstoolbarbase.miimportdcbarreplacetop.caption"
+msgid "to replace top toolbar"
+msgstr "för att ersätta det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttcbar.caption
+msgid "from a single TC .BAR file"
+msgstr "från en enskild TC .BAR-fil"
+
+#: tfrmoptionstoolbarbase.miimporttcbaraddcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCBARADDCURRENT.CAPTION"
+msgid "to add to current toolbar"
+msgstr "för att lägga till i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimporttcbaraddmenucurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCBARADDMENUCURRENT.CAPTION"
+msgid "to add to a new toolbar to current toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimporttcbaraddmenutop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCBARADDMENUTOP.CAPTION"
+msgid "to add to a new toolbar to top toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttcbaraddtop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCBARADDTOP.CAPTION"
+msgid "to add to top toolbar"
+msgstr "för att lägga till i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttcbarreplacetop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCBARREPLACETOP.CAPTION"
+msgid "to replace top toolbar"
+msgstr "för att ersätta det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttcini.caption
+msgid "from \"wincmd.ini\" of TC..."
+msgstr "från TC:s ”wincmd.ini”..."
+
+#: tfrmoptionstoolbarbase.miimporttciniaddcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCINIADDCURRENT.CAPTION"
+msgid "to add to current toolbar"
+msgstr "för att lägga till i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimporttciniaddmenucurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCINIADDMENUCURRENT.CAPTION"
+msgid "to add to a new toolbar to current toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i aktuellt verktygsfält"
+
+#: tfrmoptionstoolbarbase.miimporttciniaddmenutop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCINIADDMENUTOP.CAPTION"
+msgid "to add to a new toolbar to top toolbar"
+msgstr "för att lägga till ett nytt verktygsfält i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttciniaddtop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCINIADDTOP.CAPTION"
+msgid "to add to top toolbar"
+msgstr "för att lägga till i det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miimporttcinireplacetop.caption
+msgctxt "tfrmoptionstoolbarbase.MIIMPORTTCINIREPLACETOP.CAPTION"
+msgid "to replace top toolbar"
+msgstr "för att ersätta det övre verktygsfältet"
+
+#: tfrmoptionstoolbarbase.miinternalcommandaftercurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIINTERNALCOMMANDAFTERCURRENT.CAPTION"
+msgid "just after current selection"
+msgstr "direkt efter aktuell markering"
+
+#: tfrmoptionstoolbarbase.miinternalcommandfirstelement.caption
+msgctxt "tfrmoptionstoolbarbase.MIINTERNALCOMMANDFIRSTELEMENT.CAPTION"
+msgid "as first element"
+msgstr "som första objekt"
+
+#: tfrmoptionstoolbarbase.miinternalcommandlastelement.caption
+msgctxt "tfrmoptionstoolbarbase.MIINTERNALCOMMANDLASTELEMENT.CAPTION"
+msgid "as last element"
+msgstr "som sista objekt"
+
+#: tfrmoptionstoolbarbase.miinternalcommandpriorcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MIINTERNALCOMMANDPRIORCURRENT.CAPTION"
+msgid "just prior current selection"
+msgstr "direkt före aktuell markering"
+
+#: tfrmoptionstoolbarbase.misearchandreplace.caption
+msgctxt "tfrmoptionstoolbarbase.MISEARCHANDREPLACE.CAPTION"
+msgid "Search and replace..."
+msgstr "Sök och ersätt..."
+
+#: tfrmoptionstoolbarbase.miseparatoraftercurrent.caption
+msgctxt "tfrmoptionstoolbarbase.miseparatoraftercurrent.caption"
+msgid "just after current selection"
+msgstr "direkt efter aktuell markering"
+
+#: tfrmoptionstoolbarbase.miseparatorfirstitem.caption
+msgctxt "tfrmoptionstoolbarbase.miseparatorfirstitem.caption"
+msgid "as first element"
+msgstr "som första objekt"
+
+#: tfrmoptionstoolbarbase.miseparatorlastelement.caption
+msgctxt "tfrmoptionstoolbarbase.miseparatorlastelement.caption"
+msgid "as last element"
+msgstr "som sista objekt"
+
+#: tfrmoptionstoolbarbase.miseparatorpriorcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.miseparatorpriorcurrent.caption"
+msgid "just prior current selection"
+msgstr "direkt före aktuell markering"
+
+#: tfrmoptionstoolbarbase.misrcrplallofall.caption
+msgid "in all of all the above..."
+msgstr "i allt ovanstående..."
+
+#: tfrmoptionstoolbarbase.misrcrplcommands.caption
+msgid "in all commands..."
+msgstr "i alla kommandon..."
+
+#: tfrmoptionstoolbarbase.misrcrpliconnames.caption
+msgid "in all icon names..."
+msgstr "i alla ikonnamn..."
+
+#: tfrmoptionstoolbarbase.misrcrplparameters.caption
+msgid "in all parameters..."
+msgstr "i alla parametrar..."
+
+#: tfrmoptionstoolbarbase.misrcrplstartpath.caption
+msgid "in all start path..."
+msgstr "i alla startsökvägar..."
+
+#: tfrmoptionstoolbarbase.misubtoolbaraftercurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MISUBTOOLBARAFTERCURRENT.CAPTION"
+msgid "just after current selection"
+msgstr "direkt efter aktuell markering"
+
+#: tfrmoptionstoolbarbase.misubtoolbarfirstelement.caption
+msgctxt "tfrmoptionstoolbarbase.MISUBTOOLBARFIRSTELEMENT.CAPTION"
+msgid "as first element"
+msgstr "som första objekt"
+
+#: tfrmoptionstoolbarbase.misubtoolbarlastelement.caption
+msgctxt "tfrmoptionstoolbarbase.MISUBTOOLBARLASTELEMENT.CAPTION"
+msgid "as last element"
+msgstr "som sista objekt"
+
+#: tfrmoptionstoolbarbase.misubtoolbarpriorcurrent.caption
+msgctxt "tfrmoptionstoolbarbase.MISUBTOOLBARPRIORCURRENT.CAPTION"
+msgid "just prior current selection"
+msgstr "direkt före aktuell markering"
+
+#: tfrmoptionstoolbarbase.rblinebreak.caption
+msgid "Line break"
+msgstr "Radbrytning"
+
+#: tfrmoptionstoolbarbase.rbseparator.caption
+msgid "Separator"
+msgstr "Avgränsare"
+
+#: tfrmoptionstoolbarbase.rbspace.caption
+msgid "Space"
+msgstr "Blanksteg"
+
+#: tfrmoptionstoolbarbase.rgtoolitemtype.caption
+msgid "Button type"
+msgstr "Knapptyp"
+
+#: tfrmoptionstoolbarextra.btnpathtoberelativetoall.caption
+msgid "Apply current settings to all configured filenames and paths"
+msgstr "Verkställ aktuella inställningar på alla konfigurerade filnamn och sökvägar"
+
+#: tfrmoptionstoolbarextra.ckbtoolbarcommand.caption
+msgctxt "tfrmoptionstoolbarextra.ckbtoolbarcommand.caption"
+msgid "Commands"
+msgstr "Kommandon"
+
+#: tfrmoptionstoolbarextra.ckbtoolbaricons.caption
+msgctxt "tfrmoptionstoolbarextra.ckbtoolbaricons.caption"
+msgid "Icons"
+msgstr "Ikoner"
+
+#: tfrmoptionstoolbarextra.ckbtoolbarstartpath.caption
+msgctxt "tfrmoptionstoolbarextra.ckbtoolbarstartpath.caption"
+msgid "Starting paths"
+msgstr "Startsökvägar"
+
+#: tfrmoptionstoolbarextra.gbtoolbaroptionsextra.caption
+msgctxt "tfrmoptionstoolbarextra.gbtoolbaroptionsextra.caption"
+msgid "Paths"
+msgstr "Sökvägar"
+
+#: tfrmoptionstoolbarextra.lblapplysettingsfor.caption
+msgid "Do this for files and paths for:"
+msgstr "Gör detta för filer och sökvägar för:"
+
+#: tfrmoptionstoolbarextra.lbpathtoberelativeto.caption
+msgctxt "tfrmoptionstoolbarextra.lbpathtoberelativeto.caption"
+msgid "Path to be relative to:"
+msgstr "Sökvägen ska vara relativ till:"
+
+#: tfrmoptionstoolbarextra.lbtoolbarfilenamestyle.caption
+msgctxt "tfrmoptionstoolbarextra.lbtoolbarfilenamestyle.caption"
+msgid "Way to set paths when adding elements for icons, commands and starting paths:"
+msgstr "Sätt att ange sökvägar när objekt läggs till för ikoner, kommandon och startsökvägar:"
+
+#: tfrmoptionstoolbase.btnrelativetoolpath.hint
+msgctxt "TFRMOPTIONSTOOLBASE.BTNRELATIVETOOLPATH.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmoptionstoolbase.cbtoolskeepterminalopen.caption
+msgid "&Keep terminal window open after executing program"
+msgstr "&Håll terminalfönstret öppet efter att programmet körts"
+
+#: tfrmoptionstoolbase.cbtoolsruninterminal.caption
+msgid "&Execute in terminal"
+msgstr "&Kör i terminal"
+
+#: tfrmoptionstoolbase.cbtoolsuseexternalprogram.caption
+msgid "&Use external program"
+msgstr "&Använd externt program"
+
+#: tfrmoptionstoolbase.lbltoolsparameters.caption
+msgid "A&dditional parameters"
+msgstr "Y&tterligare parametrar"
+
+#: tfrmoptionstoolbase.lbltoolspath.caption
+msgid "&Path to program to execute"
+msgstr "&Sökväg till programmet som ska köras"
+
+#: tfrmoptionstooltips.btnaddtooltipsfiletype.caption
+msgctxt "tfrmoptionstooltips.btnaddtooltipsfiletype.caption"
+msgid "A&dd"
+msgstr "Lä&gg till"
+
+#: tfrmoptionstooltips.btnapplytooltipsfiletype.caption
+msgctxt "tfrmoptionstooltips.btnapplytooltipsfiletype.caption"
+msgid "A&pply"
+msgstr "V&erkställ"
+
+#: tfrmoptionstooltips.btncopytooltipsfiletype.caption
+msgctxt "tfrmoptionstooltips.btncopytooltipsfiletype.caption"
+msgid "Cop&y"
+msgstr "Kop&iera"
+
+#: tfrmoptionstooltips.btndeletetooltipsfiletype.caption
+msgctxt "tfrmoptionstooltips.btndeletetooltipsfiletype.caption"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: tfrmoptionstooltips.btnfieldssearchtemplate.hint
+msgctxt "TFRMOPTIONSTOOLTIPS.BTNFIELDSSEARCHTEMPLATE.HINT"
+msgid "Template..."
+msgstr "Mall..."
+
+#: tfrmoptionstooltips.btnrenametooltipsfiletype.caption
+msgctxt "tfrmoptionstooltips.btnrenametooltipsfiletype.caption"
+msgid "&Rename"
+msgstr "&Byt namn"
+
+#: tfrmoptionstooltips.btntooltipother.caption
+msgctxt "tfrmoptionstooltips.btntooltipother.caption"
+msgid "Oth&er..."
+msgstr "A&nnat..."
+
+#: tfrmoptionstooltips.bvltooltips1.caption
+msgid "Tooltip configuration for selected file type:"
+msgstr "Konfiguration av verktygstips för markerad filtyp:"
+
+#: tfrmoptionstooltips.bvltooltips2.caption
+msgid "General options about tooltips:"
+msgstr "Allmänna alternativ för verktygstips:"
+
+#: tfrmoptionstooltips.chkshowtooltip.caption
+msgid "&Show tooltip for files in the file panel"
+msgstr "&Visa verktygstips för filer i filpanelen"
+
+#: tfrmoptionstooltips.lblfieldslist.caption
+msgid "Category &hint:"
+msgstr "Kategori&tips:"
+
+#: tfrmoptionstooltips.lblfieldsmask.caption
+msgctxt "TFRMOPTIONSTOOLTIPS.LBLFIELDSMASK.CAPTION"
+msgid "Category &mask:"
+msgstr "Kategori&mask:"
+
+#: tfrmoptionstooltips.lbltooltiphidingdelay.caption
+msgid "Tooltip hiding delay:"
+msgstr "Fördröjning innan verktygstips döljs:"
+
+#: tfrmoptionstooltips.lbltooltipshowingmode.caption
+msgid "Tooltip showing mode:"
+msgstr "Visningsläge för verktygstips:"
+
+#: tfrmoptionstooltips.lbltooltipslistbox.caption
+msgid "&File types:"
+msgstr "&Filtyper:"
+
+#: tfrmoptionstooltips.mitooltipsfiletypediscardmodification.caption
+msgid "Discard Modifications"
+msgstr "Förkasta ändringar"
+
+#: tfrmoptionstooltips.mitooltipsfiletypeexport.caption
+msgctxt "tfrmoptionstooltips.mitooltipsfiletypeexport.caption"
+msgid "Export..."
+msgstr "Exportera..."
+
+#: tfrmoptionstooltips.mitooltipsfiletypeimport.caption
+msgctxt "tfrmoptionstooltips.mitooltipsfiletypeimport.caption"
+msgid "Import..."
+msgstr "Importera..."
+
+#: tfrmoptionstooltips.mitooltipsfiletypesortfiletype.caption
+msgid "Sort Tooltip File Types"
+msgstr "Sortera filtyper för verktygstips"
+
+#: tfrmoptionstreeviewmenu.ckbdirectoryhotlistfromdoubleclick.caption
+msgid "With double-click on the bar on top of a file panel"
+msgstr "Genom att dubbelklicka på fältet överst i en filpanel"
+
+#: tfrmoptionstreeviewmenu.ckbdirectoryhotlistfrommenucommand.caption
+msgctxt "tfrmoptionstreeviewmenu.ckbdirectoryhotlistfrommenucommand.caption"
+msgid "With the menu and internal command"
+msgstr "Med menyn och internt kommando"
+
+#: tfrmoptionstreeviewmenu.ckbdoubleclickselect.caption
+msgid "Double click in tree select and exit"
+msgstr "Dubbelklick i trädet markerar och stänger"
+
+#: tfrmoptionstreeviewmenu.ckbfavoritatabsfrommenucommand.caption
+msgctxt "TFRMOPTIONSTREEVIEWMENU.CKBFAVORITATABSFROMMENUCOMMAND.CAPTION"
+msgid "With the menu and internal command"
+msgstr "Med menyn och internt kommando"
+
+#: tfrmoptionstreeviewmenu.ckbfavoritetabsfromdoubleclick.caption
+msgid "With double-click on a tab (if configured for it)"
+msgstr "Genom att dubbelklicka på en flik (om konfigurerat)"
+
+#: tfrmoptionstreeviewmenu.ckbshortcutselectandclose.caption
+msgid "When using the keyboard shortcut, it will exit the window returning the current choice"
+msgstr "När kortkommandot används stängs fönstret och det aktuella valet returneras"
+
+#: tfrmoptionstreeviewmenu.ckbsingleclickselect.caption
+msgid "Single mouse click in tree select and exit"
+msgstr "Ett musklick i trädet markerar och stänger"
+
+#: tfrmoptionstreeviewmenu.ckbuseforcommandlinehistory.caption
+msgid "Use it for Command Line History"
+msgstr "Använd för kommandoradshistorik"
+
+#: tfrmoptionstreeviewmenu.ckbusefordirhistory.caption
+msgid "Use it for the Dir History"
+msgstr "Använd för kataloghistorik"
+
+#: tfrmoptionstreeviewmenu.ckbuseforviewhistory.caption
+msgid "Use it for the View History (Visited paths for active view)"
+msgstr "Använd för vyhistorik (besökta sökvägar för aktiv vy)"
+
+#: tfrmoptionstreeviewmenu.gbbehavior.caption
+msgid "Behavior regarding selection:"
+msgstr "Beteende för markering:"
+
+#: tfrmoptionstreeviewmenu.gbtreeviewmenusettings.caption
+msgid "Tree View Menus related options:"
+msgstr "Alternativ för trädvymenyer:"
+
+#: tfrmoptionstreeviewmenu.gbwheretousetreeviewmenu.caption
+msgid "Where to use Tree View Menus:"
+msgstr "Var trädvymenyer ska användas:"
+
+#: tfrmoptionstreeviewmenu.lblnote.caption
+msgid ""
+"*NOTE: Regarding the options like the case sensitivity, ignoring accents or not, these are saved "
+"and restored individually for each context from a usage and session to another."
+msgstr ""
+"*OBS: Alternativ som skiftlägeskänslighet och om accenter ska ignoreras sparas och återställs "
+"individuellt för varje sammanhang mellan användningar och sessioner."
+
+#: tfrmoptionstreeviewmenu.lbluseindirectoryhotlist.caption
+msgid "With Directory Hotlist:"
+msgstr "Med katalogfavoriter:"
+
+#: tfrmoptionstreeviewmenu.lblusewithfavoritetabs.caption
+msgid "With Favorite Tabs:"
+msgstr "Med favoritflikar:"
+
+#: tfrmoptionstreeviewmenu.lblusewithhistory.caption
+msgid "With History:"
+msgstr "Med historik:"
+
+#: tfrmoptionstreeviewmenucolor.btfont.caption
+msgctxt "tfrmoptionstreeviewmenucolor.btfont.caption"
+msgid "..."
+msgstr "..."
+
+#: tfrmoptionstreeviewmenucolor.cbkusagekeyboardshortcut.caption
+msgid "Use and display keyboard shortcut for choosing items"
+msgstr "Använd och visa kortkommando för att välja objekt"
+
+#: tfrmoptionstreeviewmenucolor.gbfont.caption
+msgid "Font"
+msgstr "Teckensnitt"
+
+#: tfrmoptionstreeviewmenucolor.gblayoutandcolors.caption
+msgid "Layout and colors options:"
+msgstr "Alternativ för layout och färger:"
+
+#: tfrmoptionstreeviewmenucolor.lblbackgroundcolor.caption
+msgid "Background color:"
+msgstr "Bakgrundsfärg:"
+
+#: tfrmoptionstreeviewmenucolor.lblcursorcolor.caption
+msgid "Cursor color:"
+msgstr "Markörfärg:"
+
+#: tfrmoptionstreeviewmenucolor.lblfoundtextcolor.caption
+msgid "Found text color:"
+msgstr "Färg för hittad text:"
+
+#: tfrmoptionstreeviewmenucolor.lblfoundtextundercursor.caption
+msgid "Found text under cursor:"
+msgstr "Hittad text under markören:"
+
+#: tfrmoptionstreeviewmenucolor.lblnormaltextcolor.caption
+msgid "Normal text color:"
+msgstr "Normal textfärg:"
+
+#: tfrmoptionstreeviewmenucolor.lblnormaltextundercursor.caption
+msgid "Normal text under cursor:"
+msgstr "Normal text under markören:"
+
+#: tfrmoptionstreeviewmenucolor.lblpreview.caption
+msgid "Tree View Menu Preview:"
+msgstr "Förhandsgranskning av trädvymeny:"
+
+#: tfrmoptionstreeviewmenucolor.lblsecondarytextcolor.caption
+msgid "Secondary text color:"
+msgstr "Sekundär textfärg:"
+
+#: tfrmoptionstreeviewmenucolor.lblsecondarytextundercursor.caption
+msgid "Secondary text under cursor:"
+msgstr "Sekundär text under markören:"
+
+#: tfrmoptionstreeviewmenucolor.lblshortcutcolor.caption
+msgid "Shortcut color:"
+msgstr "Kortkommandofärg:"
+
+#: tfrmoptionstreeviewmenucolor.lblshortcutundercursor.caption
+msgid "Shortcut under cursor:"
+msgstr "Kortkommando under markören:"
+
+#: tfrmoptionstreeviewmenucolor.lblunselectabletextcolor.caption
+msgid "Unselectable text color:"
+msgstr "Färg för text som inte kan markeras:"
+
+#: tfrmoptionstreeviewmenucolor.lblunselectableundercursor.caption
+msgid "Unselectable under cursor:"
+msgstr "Text som inte kan markeras under markören:"
+
+#: tfrmoptionstreeviewmenucolor.treeviewmenusample.hint
+msgid ""
+"Change color on left and you'll see here a preview of what your Tree View Menus will look likes "
+"with this sample."
+msgstr ""
+"Ändra färgerna till vänster så ser du här en förhandsgranskning av hur dina trädvymenyer kommer "
+"att se ut i exemplet."
+
+#: tfrmoptionsviewer.gbinternalviewer.caption
+msgid "Internal viewer options"
+msgstr "Alternativ för intern visare"
+
+#: tfrmoptionsviewer.lblnumbercolumnsviewer.caption
+msgid "&Number of columns in book viewer"
+msgstr "&Antal kolumner i bokvisaren"
+
+#: tfrmpackdlg.btnconfig.caption
+msgctxt "tfrmpackdlg.btnconfig.caption"
+msgid "Con&figure"
+msgstr "Kon&figurera"
+
+#: tfrmpackdlg.caption
+msgid "Pack files"
+msgstr "Packa filer"
+
+#: tfrmpackdlg.cbcreateseparatearchives.caption
+msgid "C&reate separate archives, one per selected file/dir"
+msgstr "S&kapa separata arkiv, ett per markerad fil/katalog"
+
+#: tfrmpackdlg.cbcreatesfx.caption
+msgid "Create self e&xtracting archive"
+msgstr "Skapa självuppackande arki&v"
+
+#: tfrmpackdlg.cbencrypt.caption
+msgctxt "tfrmpackdlg.cbencrypt.caption"
+msgid "Encr&ypt"
+msgstr "Kr&yptera"
+
+#: tfrmpackdlg.cbmovetoarchive.caption
+msgid "Mo&ve to archive"
+msgstr "Fl&ytta till arkiv"
+
+#: tfrmpackdlg.cbmultivolume.caption
+msgid "&Multiple disk archive"
+msgstr "&Arkiv på flera diskar"
+
+#: tfrmpackdlg.cbputintarfirst.caption
+msgid "P&ut in the TAR archive first"
+msgstr "Lä&gg först i TAR-arkiv"
+
+#: tfrmpackdlg.cbstoredir.caption
+msgid "Also &pack path names (only recursed)"
+msgstr "Packa även &sökvägar (endast rekursivt)"
+
+#: tfrmpackdlg.lblprompt.caption
+msgid "Pack file(s) to the file:"
+msgstr "Packa fil(er) till filen:"
+
+#: tfrmpackdlg.rgpacker.caption
+msgid "Packer"
+msgstr "Arkiverare"
+
+#: tfrmpackinfodlg.btnclose.caption
+msgctxt "TFRMPACKINFODLG.BTNCLOSE.CAPTION"
+msgid "&Close"
+msgstr "&Stäng"
+
+#: tfrmpackinfodlg.btnunpackallandexec.caption
+msgid "Unpack &all and execute"
+msgstr "Packa upp &alla och kör"
+
+#: tfrmpackinfodlg.btnunpackandexec.caption
+msgid "&Unpack and execute"
+msgstr "&Packa upp och kör"
+
+#: tfrmpackinfodlg.caption
+msgid "Properties of packed file"
+msgstr "Egenskaper för packad fil"
+
+#: tfrmpackinfodlg.lblattributes.caption
+msgid "Attributes:"
+msgstr "Attribut:"
+
+#: tfrmpackinfodlg.lblcompressionratio.caption
+msgid "Compression ratio:"
+msgstr "Komprimeringsgrad:"
+
+#: tfrmpackinfodlg.lbldate.caption
+msgid "Date:"
+msgstr "Datum:"
+
+#: tfrmpackinfodlg.lblmethod.caption
+msgid "Method:"
+msgstr "Metod:"
+
+#: tfrmpackinfodlg.lbloriginalsize.caption
+msgid "Original size:"
+msgstr "Ursprunglig storlek:"
+
+#: tfrmpackinfodlg.lblpackedfile.caption
+msgid "File:"
+msgstr "Fil:"
+
+#: tfrmpackinfodlg.lblpackedsize.caption
+msgid "Packed size:"
+msgstr "Packad storlek:"
+
+#: tfrmpackinfodlg.lblpacker.caption
+msgid "Packer:"
+msgstr "Arkiverare:"
+
+#: tfrmpackinfodlg.lbltime.caption
+msgid "Time:"
+msgstr "Tid:"
+
+#: tfrmprintsetup.caption
+msgid "Print configuration"
+msgstr "Utskriftskonfiguration"
+
+#: tfrmprintsetup.gbmargins.caption
+msgid "Margins (mm)"
+msgstr "Marginaler (mm)"
+
+#: tfrmprintsetup.lblbottom.caption
+msgid "&Bottom:"
+msgstr "&Nederkant:"
+
+#: tfrmprintsetup.lblleft.caption
+msgid "&Left:"
+msgstr "&Vänster:"
+
+#: tfrmprintsetup.lblright.caption
+msgid "&Right:"
+msgstr "&Höger:"
+
+#: tfrmprintsetup.lbltop.caption
+msgid "&Top:"
+msgstr "&Överkant:"
+
+#: tfrmquicksearch.btncancel.caption
+msgctxt "TFRMQUICKSEARCH.BTNCANCEL.CAPTION"
+msgid "X"
+msgstr "X"
+
+#: tfrmquicksearch.btncancel.hint
+msgid "Close filter panel"
+msgstr "Stäng filterpanelen"
+
+#: tfrmquicksearch.edtsearch.hint
+msgid "Enter text to search for or filter by"
+msgstr "Ange text att söka efter eller filtrera på"
+
+#: tfrmquicksearch.sbcasesensitive.caption
+msgid "Aa"
+msgstr "Aa"
+
+#: tfrmquicksearch.sbcasesensitive.hint
+msgid "Case Sensitive"
+msgstr "Skiftlägeskänslig"
+
+#: tfrmquicksearch.sbdiacritics.caption
+msgid "Ďï"
+msgstr "Ďï"
+
+#: tfrmquicksearch.sbdiacritics.hint
+msgid "Diacritics and ligatures"
+msgstr "Diakritiska tecken och ligaturer"
+
+#: tfrmquicksearch.sbdirectories.caption
+msgid "D"
+msgstr "D"
+
+#: tfrmquicksearch.sbdirectories.hint
+msgctxt "TFRMQUICKSEARCH.SBDIRECTORIES.HINT"
+msgid "Directories"
+msgstr "Kataloger"
+
+#: tfrmquicksearch.sbfiles.caption
+msgid "F"
+msgstr "F"
+
+#: tfrmquicksearch.sbfiles.hint
+msgctxt "TFRMQUICKSEARCH.SBFILES.HINT"
+msgid "Files"
+msgstr "Filer"
+
+#: tfrmquicksearch.sbmatchbeginning.caption
+msgid "{"
+msgstr "{"
+
+#: tfrmquicksearch.sbmatchbeginning.hint
+msgid "Match Beginning"
+msgstr "Matcha början"
+
+#: tfrmquicksearch.sbmatchending.caption
+msgid "}"
+msgstr "}"
+
+#: tfrmquicksearch.sbmatchending.hint
+msgid "Match Ending"
+msgstr "Matcha slutet"
+
+#: tfrmquicksearch.tglfilter.caption
+msgid "Filter"
+msgstr "Filter"
+
+#: tfrmquicksearch.tglfilter.hint
+msgid "Toggle between search or filter"
+msgstr "Växla mellan sökning och filtrering"
+
+#: tfrmsearchplugin.btnadd.caption
+msgid "&More rules"
+msgstr "&Fler regler"
+
+#: tfrmsearchplugin.btndelete.caption
+msgid "L&ess rules"
+msgstr "F&ärre regler"
+
+#: tfrmsearchplugin.chkuseplugins.caption
+msgid "Use &content plugins, combine with:"
+msgstr "Använd &innehållsinsticksmoduler, kombinera med:"
+
+#: tfrmsearchplugin.lblfield.caption
+msgctxt "tfrmsearchplugin.lblfield.caption"
+msgid "Field"
+msgstr "Fält"
+
+#: tfrmsearchplugin.lbloperator.caption
+msgctxt "tfrmsearchplugin.lbloperator.caption"
+msgid "Operator"
+msgstr "Operator"
+
+#: tfrmsearchplugin.lblplugin.caption
+msgctxt "tfrmsearchplugin.lblplugin.caption"
+msgid "Plugin"
+msgstr "Insticksmodul"
+
+#: tfrmsearchplugin.lblvalue.caption
+msgctxt "tfrmsearchplugin.lblvalue.caption"
+msgid "Value"
+msgstr "Värde"
+
+#: tfrmsearchplugin.rband.caption
+msgid "&AND (all match)"
+msgstr "&OCH (alla matchar)"
+
+#: tfrmsearchplugin.rbor.caption
+msgid "&OR (any match)"
+msgstr "&ELLER (någon matchar)"
+
+#: tfrmselectduplicates.btnapply.caption
+msgctxt "tfrmselectduplicates.btnapply.caption"
+msgid "&Apply"
+msgstr "&Verkställ"
+
+#: tfrmselectduplicates.btncancel.caption
+msgctxt "tfrmselectduplicates.btncancel.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmselectduplicates.btnexcludemask.hint
+msgctxt "tfrmselectduplicates.btnexcludemask.hint"
+msgid "Template..."
+msgstr "Mall..."
+
+#: tfrmselectduplicates.btnincludemask.hint
+msgctxt "tfrmselectduplicates.btnincludemask.hint"
+msgid "Template..."
+msgstr "Mall..."
+
+#: tfrmselectduplicates.btnok.caption
+msgctxt "tfrmselectduplicates.btnok.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmselectduplicates.caption
+msgid "Select duplicate files"
+msgstr "Markera dubblettfiler"
+
+#: tfrmselectduplicates.chkleaveunselected.caption
+msgid "&Leave at least one file in each group unselected:"
+msgstr "&Lämna minst en fil i varje grupp omarkerad:"
+
+#: tfrmselectduplicates.cmbincludemask.text
+msgctxt "tfrmselectduplicates.cmbincludemask.text"
+msgid "*"
+msgstr "*.*"
+
+#: tfrmselectduplicates.lblexcludemask.caption
+msgid "&Remove selection by name/extension:"
+msgstr "&Ta bort markering efter namn/filändelse:"
+
+#: tfrmselectduplicates.lblfirstmethod.caption
+msgid "&1."
+msgstr "&1."
+
+#: tfrmselectduplicates.lblincludemask.caption
+msgid "Select by &name/extension:"
+msgstr "Markera efter &namn/filändelse:"
+
+#: tfrmselectduplicates.lblsecondmethod.caption
+msgid "&2."
+msgstr "&2."
+
+#: tfrmselectpathrange.buttonpanel.cancelbutton.caption
+msgctxt "tfrmselectpathrange.buttonpanel.cancelbutton.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmselectpathrange.buttonpanel.okbutton.caption
+msgctxt "tfrmselectpathrange.buttonpanel.okbutton.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmselectpathrange.edseparator.editlabel.caption
+msgid "Sep&arator"
+msgstr "Av&gränsare"
+
+#: tfrmselectpathrange.gbcountfrom.caption
+msgid "Count from"
+msgstr "Räkna från"
+
+#: tfrmselectpathrange.lblresult.caption
+msgctxt "tfrmselectpathrange.lblresult.caption"
+msgid "Result:"
+msgstr "Resultat:"
+
+#: tfrmselectpathrange.lblselectdirectories.caption
+msgid "&Select the directories to insert (you may select more than one)"
+msgstr "&Välj kataloger att infoga (du kan välja fler än en)"
+
+#: tfrmselectpathrange.rbfirstfromend.caption
+msgctxt "tfrmselectpathrange.rbfirstfromend.caption"
+msgid "The en&d"
+msgstr "Sl&utet"
+
+#: tfrmselectpathrange.rbfirstfromstart.caption
+msgctxt "tfrmselectpathrange.rbfirstfromstart.caption"
+msgid "The sta&rt"
+msgstr "Bö&rjan"
+
+#: tfrmselecttextrange.buttonpanel.cancelbutton.caption
+msgctxt "tfrmselecttextrange.buttonpanel.cancelbutton.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmselecttextrange.buttonpanel.okbutton.caption
+msgctxt "tfrmselecttextrange.buttonpanel.okbutton.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmselecttextrange.gbcountfirstfrom.caption
+msgid "Count first from"
+msgstr "Räkna först från"
+
+#: tfrmselecttextrange.gbcountlastfrom.caption
+msgid "Count last from"
+msgstr "Räkna sist från"
+
+#: tfrmselecttextrange.gbrangedescription.caption
+msgid "Range description"
+msgstr "Intervallbeskrivning"
+
+#: tfrmselecttextrange.lblresult.caption
+msgctxt "tfrmselecttextrange.lblresult.caption"
+msgid "Result:"
+msgstr "Resultat:"
+
+#: tfrmselecttextrange.lblselecttext.caption
+msgid "&Select the characters to insert:"
+msgstr "&Välj tecken att infoga:"
+
+#: tfrmselecttextrange.rbdescriptionfirstlast.caption
+msgid "[&First:Last]"
+msgstr "[&Första:Sista]"
+
+#: tfrmselecttextrange.rbdescriptionfirstlength.caption
+msgid "[First,&Length]"
+msgstr "[Första,&Längd]"
+
+#: tfrmselecttextrange.rbfirstfromend.caption
+msgctxt "tfrmselecttextrange.rbfirstfromend.caption"
+msgid "The en&d"
+msgstr "Sl&utet"
+
+#: tfrmselecttextrange.rbfirstfromstart.caption
+msgctxt "tfrmselecttextrange.rbfirstfromstart.caption"
+msgid "The sta&rt"
+msgstr "Bö&rjan"
+
+#: tfrmselecttextrange.rblastfromend.caption
+msgid "The &end"
+msgstr "&Slutet"
+
+#: tfrmselecttextrange.rblastfromstart.caption
+msgid "The s&tart"
+msgstr "B&örjan"
+
+#: tfrmsetfileproperties.btncancel.caption
+msgctxt "TFRMSETFILEPROPERTIES.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmsetfileproperties.btnok.caption
+msgctxt "TFRMSETFILEPROPERTIES.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmsetfileproperties.caption
+msgid "Change attributes"
+msgstr "Ändra attribut"
+
+#: tfrmsetfileproperties.cbsgid.caption
+msgctxt "TFRMSETFILEPROPERTIES.CBSGID.CAPTION"
+msgid "SGID"
+msgstr "SGID"
+
+#: tfrmsetfileproperties.cbsticky.caption
+msgctxt "TFRMSETFILEPROPERTIES.CBSTICKY.CAPTION"
+msgid "Sticky"
+msgstr "Sticky"
+
+#: tfrmsetfileproperties.cbsuid.caption
+msgctxt "TFRMSETFILEPROPERTIES.CBSUID.CAPTION"
+msgid "SUID"
+msgstr "SUID"
+
+#: tfrmsetfileproperties.chkarchive.caption
+msgid "Archive"
+msgstr "Arkiv"
+
+#: tfrmsetfileproperties.chkcreationtime.caption
+msgctxt "tfrmsetfileproperties.chkcreationtime.caption"
+msgid "Created:"
+msgstr "Skapad:"
+
+#: tfrmsetfileproperties.chkhidden.caption
+msgid "Hidden"
+msgstr "Dold"
+
+#: tfrmsetfileproperties.chklastaccesstime.caption
+msgctxt "tfrmsetfileproperties.chklastaccesstime.caption"
+msgid "Accessed:"
+msgstr "Åtkommen:"
+
+#: tfrmsetfileproperties.chklastwritetime.caption
+msgctxt "tfrmsetfileproperties.chklastwritetime.caption"
+msgid "Modified:"
+msgstr "Ändrad:"
+
+#: tfrmsetfileproperties.chkreadonly.caption
+msgid "Read only"
+msgstr "Skrivskyddad"
+
+#: tfrmsetfileproperties.chkrecursive.caption
+msgid "Including subfolders"
+msgstr "Inkludera underkataloger"
+
+#: tfrmsetfileproperties.chksystem.caption
+msgctxt "tfrmsetfileproperties.chksystem.caption"
+msgid "System"
+msgstr "System"
+
+#: tfrmsetfileproperties.gbtimesamp.caption
+msgid "Timestamp properties"
+msgstr "Tidsstämpelegenskaper"
+
+#: tfrmsetfileproperties.gbunixattributes.caption
+msgctxt "TFRMSETFILEPROPERTIES.GBUNIXATTRIBUTES.CAPTION"
+msgid "Attributes"
+msgstr "Attribut"
+
+#: tfrmsetfileproperties.gbwinattributes.caption
+msgctxt "TFRMSETFILEPROPERTIES.GBWINATTRIBUTES.CAPTION"
+msgid "Attributes"
+msgstr "Attribut"
+
+#: tfrmsetfileproperties.lblattrbitsstr.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTRBITSSTR.CAPTION"
+msgid "Bits:"
+msgstr "Bitar:"
+
+#: tfrmsetfileproperties.lblattrgroupstr.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTRGROUPSTR.CAPTION"
+msgid "Group"
+msgstr "Grupp"
+
+#: tfrmsetfileproperties.lblattrinfo.caption
+msgctxt "tfrmsetfileproperties.lblattrinfo.caption"
+msgid "(gray field means unchanged value)"
+msgstr "(grått fält betyder oförändrat värde)"
+
+#: tfrmsetfileproperties.lblattrotherstr.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTROTHERSTR.CAPTION"
+msgid "Other"
+msgstr "Övriga"
+
+#: tfrmsetfileproperties.lblattrownerstr.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTROWNERSTR.CAPTION"
+msgid "Owner"
+msgstr "Ägare"
+
+#: tfrmsetfileproperties.lblattrtext.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTRTEXT.CAPTION"
+msgid "-----------"
+msgstr "-----------"
+
+#: tfrmsetfileproperties.lblattrtextstr.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLATTRTEXTSTR.CAPTION"
+msgid "Text:"
+msgstr "Text:"
+
+#: tfrmsetfileproperties.lblexec.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLEXEC.CAPTION"
+msgid "Execute"
+msgstr "Kör"
+
+#: tfrmsetfileproperties.lblmodeinfo.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLMODEINFO.CAPTION"
+msgid "(gray field means unchanged value)"
+msgstr "(grått fält betyder oförändrat värde)"
+
+#: tfrmsetfileproperties.lbloctal.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLOCTAL.CAPTION"
+msgid "Octal:"
+msgstr "Oktalt:"
+
+#: tfrmsetfileproperties.lblread.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLREAD.CAPTION"
+msgid "Read"
+msgstr "Läs"
+
+#: tfrmsetfileproperties.lblwrite.caption
+msgctxt "TFRMSETFILEPROPERTIES.LBLWRITE.CAPTION"
+msgid "Write"
+msgstr "Skriv"
+
+#: tfrmsetfileproperties.zvcreationdatetime.textfornulldate
+msgctxt "tfrmsetfileproperties.zvcreationdatetime.textfornulldate"
+msgid " "
+msgstr "  "
+
+#: tfrmsetfileproperties.zvlastaccessdatetime.textfornulldate
+msgctxt "tfrmsetfileproperties.zvlastaccessdatetime.textfornulldate"
+msgid " "
+msgstr "  "
+
+#: tfrmsetfileproperties.zvlastwritedatetime.textfornulldate
+msgctxt "tfrmsetfileproperties.zvlastwritedatetime.textfornulldate"
+msgid " "
+msgstr "  "
+
+#: tfrmsortanything.btnsort.caption
+msgid "&Sort"
+msgstr "&Sortera"
+
+#: tfrmsortanything.buttonpanel.cancelbutton.caption
+msgctxt "tfrmsortanything.buttonpanel.cancelbutton.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmsortanything.buttonpanel.okbutton.caption
+msgctxt "tfrmsortanything.buttonpanel.okbutton.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmsortanything.caption
+msgid "frmSortAnything"
+msgstr "frmSortAnything"
+
+#: tfrmsortanything.lblsortanything.caption
+msgid "Drag and drop elements to sort them"
+msgstr "Dra och släpp objekt för att sortera dem"
+
+#: tfrmsplitter.btnrelativeftchoice.hint
+msgctxt "TFRMSPLITTER.BTNRELATIVEFTCHOICE.HINT"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmsplitter.caption
+msgid "Splitter"
+msgstr "Fildelare"
+
+#: tfrmsplitter.cbrequireacrc32verificationfile.caption
+msgid "Require a CRC32 verification file"
+msgstr "Kräv en CRC32-verifieringsfil"
+
+#: tfrmsplitter.cmbxsize.text
+msgid "1457664B - 3.5\""
+msgstr "1457664B - 3,5\""
+
+#: tfrmsplitter.grbxsize.caption
+msgid "Size and number of parts"
+msgstr "Storlek och antal delar"
+
+#: tfrmsplitter.lbdirtarget.caption
+msgid "Split the file to directory:"
+msgstr "Dela filen till katalogen:"
+
+#: tfrmsplitter.lblnumberparts.caption
+msgid "&Number of parts"
+msgstr "&Antal delar"
+
+#: tfrmsplitter.rbtnbyte.caption
+msgid "&Bytes"
+msgstr "&Byte"
+
+#: tfrmsplitter.rbtngigab.caption
+msgid "&Gigabytes"
+msgstr "&Gigabyte"
+
+#: tfrmsplitter.rbtnkilob.caption
+msgid "&Kilobytes"
+msgstr "&Kilobyte"
+
+#: tfrmsplitter.rbtnmegab.caption
+msgid "&Megabytes"
+msgstr "&Megabyte"
+
+#: tfrmstartingsplash.caption
+msgctxt "TFRMSTARTINGSPLASH.CAPTION"
+msgid "Double Commander"
+msgstr "Double Commander"
+
+#: tfrmstartingsplash.lblbuild.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLBUILD.CAPTION"
+msgid "Build"
+msgstr "Byggversion"
+
+#: tfrmstartingsplash.lblcommit.caption
+msgctxt "tfrmstartingsplash.lblcommit.caption"
+msgid "Commit"
+msgstr "Commit"
+
+#: tfrmstartingsplash.lblfreepascalver.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLFREEPASCALVER.CAPTION"
+msgid "Free Pascal"
+msgstr "Free Pascal"
+
+#: tfrmstartingsplash.lbllazarusver.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLLAZARUSVER.CAPTION"
+msgid "Lazarus"
+msgstr "Lazarus"
+
+#: tfrmstartingsplash.lbloperatingsystem.caption
+msgid "Operating System"
+msgstr "Operativsystem"
+
+#: tfrmstartingsplash.lblplatform.caption
+msgid "Platform"
+msgstr "Plattform"
+
+#: tfrmstartingsplash.lblrevision.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLREVISION.CAPTION"
+msgid "Revision"
+msgstr "Revision"
+
+#: tfrmstartingsplash.lbltitle.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLTITLE.CAPTION"
+msgid "Double Commander"
+msgstr "Double Commander"
+
+#: tfrmstartingsplash.lblversion.caption
+msgctxt "TFRMSTARTINGSPLASH.LBLVERSION.CAPTION"
+msgid "Version"
+msgstr "Version"
+
+#: tfrmstartingsplash.lblwidgetsetver.caption
+msgid "WidgetsetVer"
+msgstr "WidgetsetVer"
+
+#: tfrmsymlink.btncancel.caption
+msgctxt "TFRMSYMLINK.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmsymlink.btnok.caption
+msgctxt "TFRMSYMLINK.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmsymlink.caption
+msgid "Create symbolic link"
+msgstr "Skapa symbolisk länk"
+
+#: tfrmsymlink.chkuserelativepath.caption
+msgid "Use &relative path when possible"
+msgstr "Använd &relativ sökväg när det är möjligt"
+
+#: tfrmsymlink.lblexistingfile.caption
+msgctxt "TFRMSYMLINK.LBLEXISTINGFILE.CAPTION"
+msgid "&Destination that the link will point to"
+msgstr "&Mål som länken ska peka på"
+
+#: tfrmsymlink.lbllinktocreate.caption
+msgctxt "TFRMSYMLINK.LBLLINKTOCREATE.CAPTION"
+msgid "&Link name"
+msgstr "&Länknamn"
+
+#: tfrmsyncdirsdlg.actdeleteboth.caption
+msgid "Delete on both sides"
+msgstr "Ta bort på båda sidor"
+
+#: tfrmsyncdirsdlg.actdeleteleft.caption
+msgid "<- Delete left"
+msgstr "<- Ta bort vänster"
+
+#: tfrmsyncdirsdlg.actdeleteright.caption
+msgid "-> Delete right"
+msgstr "-> Ta bort höger"
+
+#: tfrmsyncdirsdlg.actselectclear.caption
+msgid "Remove selection"
+msgstr "Ta bort markering"
+
+#: tfrmsyncdirsdlg.actselectcopydefault.caption
+msgid "Select for copying (default direction)"
+msgstr "Markera för kopiering (standardriktning)"
+
+#: tfrmsyncdirsdlg.actselectcopylefttoright.caption
+msgid "Select for copying -> (left to right)"
+msgstr "Markera för kopiering -> (vänster till höger)"
+
+#: tfrmsyncdirsdlg.actselectcopyreverse.caption
+msgid "Reverse copy direction"
+msgstr "Vänd kopieringsriktning"
+
+#: tfrmsyncdirsdlg.actselectcopyrighttoleft.caption
+msgid "Select for copying <- (right to left)"
+msgstr "Markera för kopiering <- (höger till vänster)"
+
+#: tfrmsyncdirsdlg.actselectdeleteboth.caption
+msgid "Select for deleting <-> (both)"
+msgstr "Markera för borttagning <-> (båda)"
+
+#: tfrmsyncdirsdlg.actselectdeleteleft.caption
+msgid "Select for deleting <- (left)"
+msgstr "Markera för borttagning <- (vänster)"
+
+#: tfrmsyncdirsdlg.actselectdeleteright.caption
+msgid "Select for deleting -> (right)"
+msgstr "Markera för borttagning -> (höger)"
+
+#: tfrmsyncdirsdlg.btnclose.caption
+msgctxt "TFRMSYNCDIRSDLG.BTNCLOSE.CAPTION"
+msgid "Close"
+msgstr "Stäng"
+
+#: tfrmsyncdirsdlg.btncompare.caption
+msgctxt "TFRMSYNCDIRSDLG.BTNCOMPARE.CAPTION"
+msgid "Compare"
+msgstr "Jämför"
+
+#: tfrmsyncdirsdlg.btnsearchtemplate.hint
+msgctxt "tfrmsyncdirsdlg.btnsearchtemplate.hint"
+msgid "Template..."
+msgstr "Mall..."
+
+#: tfrmsyncdirsdlg.btnsynchronize.caption
+msgctxt "tfrmsyncdirsdlg.btnsynchronize.caption"
+msgid "Synchronize"
+msgstr "Synkronisera"
+
+#: tfrmsyncdirsdlg.caption
+msgid "Synchronize directories"
+msgstr "Synkronisera kataloger"
+
+#: tfrmsyncdirsdlg.cbextfilter.text
+msgctxt "TFRMSYNCDIRSDLG.CBEXTFILTER.TEXT"
+msgid "*"
+msgstr "*"
+
+#: tfrmsyncdirsdlg.chkasymmetric.caption
+msgid "asymmetric"
+msgstr "asymmetrisk"
+
+#: tfrmsyncdirsdlg.chkbycontent.caption
+msgid "by content"
+msgstr "efter innehåll"
+
+#: tfrmsyncdirsdlg.chkemptydir.caption
+msgid "empty directories"
+msgstr "tomma kataloger"
+
+#: tfrmsyncdirsdlg.chkignoredate.caption
+msgid "ignore date"
+msgstr "ignorera datum"
+
+#: tfrmsyncdirsdlg.chkonlyselected.caption
+msgid "only selected"
+msgstr "endast markerade"
+
+#: tfrmsyncdirsdlg.chksubdirs.caption
+msgid "Subdirs"
+msgstr "Underkataloger"
+
+#: tfrmsyncdirsdlg.groupbox1.caption
+msgid "Show:"
+msgstr "Visa:"
+
+#: tfrmsyncdirsdlg.headerdg.columns[0].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[0].TITLE.CAPTION"
+msgid "Name"
+msgstr "Namn"
+
+#: tfrmsyncdirsdlg.headerdg.columns[1].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[1].TITLE.CAPTION"
+msgid "Size"
+msgstr "Storlek"
+
+#: tfrmsyncdirsdlg.headerdg.columns[2].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[2].TITLE.CAPTION"
+msgid "Date"
+msgstr "Datum"
+
+#: tfrmsyncdirsdlg.headerdg.columns[3].title.caption
+msgid "<=>"
+msgstr "<=>"
+
+#: tfrmsyncdirsdlg.headerdg.columns[4].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[4].TITLE.CAPTION"
+msgid "Date"
+msgstr "Datum"
+
+#: tfrmsyncdirsdlg.headerdg.columns[5].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[5].TITLE.CAPTION"
+msgid "Size"
+msgstr "Storlek"
+
+#: tfrmsyncdirsdlg.headerdg.columns[6].title.caption
+msgctxt "TFRMSYNCDIRSDLG.HEADERDG.COLUMNS[6].TITLE.CAPTION"
+msgid "Name"
+msgstr "Namn"
+
+#: tfrmsyncdirsdlg.label1.caption
+msgid "(in main window)"
+msgstr "(i huvudfönstret)"
+
+#: tfrmsyncdirsdlg.menuitemcompare.caption
+msgctxt "TFRMSYNCDIRSDLG.MENUITEMCOMPARE.CAPTION"
+msgid "Compare"
+msgstr "Jämför"
+
+#: tfrmsyncdirsdlg.menuitemviewleft.caption
+msgid "View left"
+msgstr "Visa vänster"
+
+#: tfrmsyncdirsdlg.menuitemviewright.caption
+msgid "View right"
+msgstr "Visa höger"
+
+#: tfrmsyncdirsdlg.sbcopyleft.caption
+msgctxt "TFRMSYNCDIRSDLG.SBCOPYLEFT.CAPTION"
+msgid "<"
+msgstr "<"
+
+#: tfrmsyncdirsdlg.sbcopyright.caption
+msgctxt "TFRMSYNCDIRSDLG.SBCOPYRIGHT.CAPTION"
+msgid ">"
+msgstr ">"
+
+#: tfrmsyncdirsdlg.sbduplicates.caption
+msgid "duplicates"
+msgstr "dubbletter"
+
+#: tfrmsyncdirsdlg.sbequal.caption
+msgctxt "tfrmsyncdirsdlg.sbequal.caption"
+msgid "="
+msgstr "="
+
+#: tfrmsyncdirsdlg.sbnotequal.caption
+msgctxt "tfrmsyncdirsdlg.sbnotequal.caption"
+msgid "!="
+msgstr "!="
+
+#: tfrmsyncdirsdlg.sbsingles.caption
+msgid "singles"
+msgstr "unika"
+
+#: tfrmsyncdirsdlg.sbunknown.caption
+msgid "?"
+msgstr "?"
+
+#: tfrmsyncdirsdlg.statusbar1.panels[0].text
+msgid "Please press \"Compare\" to start"
+msgstr "Tryck på ”Jämför” för att starta"
+
+#: tfrmsyncdirsperformdlg.caption
+msgctxt "TFRMSYNCDIRSPERFORMDLG.CAPTION"
+msgid "Synchronize"
+msgstr "Synkronisera"
+
+#: tfrmsyncdirsperformdlg.chkconfirmoverwrites.caption
+msgid "Confirm overwrites"
+msgstr "Bekräfta överskrivningar"
+
+#: tfrmtreeviewmenu.caption
+msgctxt "tfrmtreeviewmenu.caption"
+msgid "Tree View Menu"
+msgstr "Trädvymeny"
+
+#: tfrmtreeviewmenu.lblsearchingentry.caption
+msgid "Select your hot directory:"
+msgstr "Välj katalogfavorit:"
+
+#: tfrmtreeviewmenu.pmicasesensitive.caption
+msgid "Search is case sensitive"
+msgstr "Sökningen är skiftlägeskänslig"
+
+#: tfrmtreeviewmenu.pmifullcollapse.caption
+msgid "Full collapse"
+msgstr "Fäll ihop helt"
+
+#: tfrmtreeviewmenu.pmifullexpand.caption
+msgid "Full expand"
+msgstr "Fäll ut helt"
+
+#: tfrmtreeviewmenu.pmiignoreaccents.caption
+msgid "Search ignore accents and ligatures"
+msgstr "Sökningen ignorerar accenter och ligaturer"
+
+#: tfrmtreeviewmenu.pminotcasesensitive.caption
+msgid "Search is not case sensitive"
+msgstr "Sökningen är inte skiftlägeskänslig"
+
+#: tfrmtreeviewmenu.pminotignoreaccents.caption
+msgid "Search is strict regarding accents and ligatures"
+msgstr "Sökningen tar hänsyn till accenter och ligaturer"
+
+#: tfrmtreeviewmenu.pminotshowwholebranchifmatch.caption
+msgid "Don't show the branch content \"just\" because the searched string is found in the branche name"
+msgstr "Visa inte grenens innehåll ”bara” för att söksträngen finns i grenens namn"
+
+#: tfrmtreeviewmenu.pmishowwholebranchifmatch.caption
+msgid "If searched string is found in a branch name, show the whole branch even if elements don't match"
+msgstr "Om söksträngen finns i ett grennamn, visa hela grenen även om objekten inte matchar"
+
+#: tfrmtreeviewmenu.tbcancelandquit.hint
+msgid "Close Tree View Menu"
+msgstr "Stäng trädvymenyn"
+
+#: tfrmtreeviewmenu.tbconfigurationtreeviewmenus.hint
+msgctxt "TFRMTREEVIEWMENU.TBCONFIGURATIONTREEVIEWMENUS.HINT"
+msgid "Configuration of Tree View Menu"
+msgstr "Konfiguration av trädvymeny"
+
+#: tfrmtreeviewmenu.tbconfigurationtreeviewmenuscolors.hint
+msgctxt "TFRMTREEVIEWMENU.TBCONFIGURATIONTREEVIEWMENUSCOLORS.HINT"
+msgid "Configuration of Tree View Menu Colors"
+msgstr "Konfiguration av färger för trädvymeny"
+
+#: tfrmtweakplugin.btnadd.caption
+msgid "A&dd new"
+msgstr "Lä&gg till ny"
+
+#: tfrmtweakplugin.btncancel.caption
+msgctxt "TFRMTWEAKPLUGIN.BTNCANCEL.CAPTION"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: tfrmtweakplugin.btnchange.caption
+msgid "C&hange"
+msgstr "Ä&ndra"
+
+#: tfrmtweakplugin.btndefault.caption
+msgctxt "tfrmtweakplugin.btndefault.caption"
+msgid "De&fault"
+msgstr "St&andard"
+
+#: tfrmtweakplugin.btnok.caption
+msgctxt "TFRMTWEAKPLUGIN.BTNOK.CAPTION"
+msgid "&OK"
+msgstr "&OK"
+
+#: tfrmtweakplugin.btnrelativeplugin1.hint
+msgctxt "tfrmtweakplugin.btnrelativeplugin1.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmtweakplugin.btnrelativeplugin2.hint
+msgctxt "tfrmtweakplugin.btnrelativeplugin2.hint"
+msgid "Some functions to select appropriate path"
+msgstr "Funktioner för att välja lämplig sökväg"
+
+#: tfrmtweakplugin.btnremove.caption
+msgctxt "TFRMTWEAKPLUGIN.BTNREMOVE.CAPTION"
+msgid "&Remove"
+msgstr "&Ta bort"
+
+#: tfrmtweakplugin.caption
+msgid "Tweak plugin"
+msgstr "Justera insticksmodul"
+
+#: tfrmtweakplugin.cbpk_caps_by_content.caption
+msgid "De&tect archive type by content"
+msgstr "Identifiera arkivtyp efter &innehåll"
+
+#: tfrmtweakplugin.cbpk_caps_delete.caption
+msgid "Can de&lete files"
+msgstr "Kan ta &bort filer"
+
+#: tfrmtweakplugin.cbpk_caps_encrypt.caption
+msgid "Supports e&ncryption"
+msgstr "Stöder &kryptering"
+
+#: tfrmtweakplugin.cbpk_caps_hide.caption
+msgid "Sho&w as normal files (hide packer icon)"
+msgstr "Vi&sa som vanliga filer (dölj arkiveringsikon)"
+
+#: tfrmtweakplugin.cbpk_caps_mempack.caption
+msgid "Supports pac&king in memory"
+msgstr "Stöder pack&ning i minnet"
+
+#: tfrmtweakplugin.cbpk_caps_modify.caption
+msgid "Can &modify existing archives"
+msgstr "Kan &ändra befintliga arkiv"
+
+#: tfrmtweakplugin.cbpk_caps_multiple.caption
+msgid "&Archive can contain multiple files"
+msgstr "&Arkiv kan innehålla flera filer"
+
+#: tfrmtweakplugin.cbpk_caps_new.caption
+msgid "Can create new archi&ves"
+msgstr "Kan skapa nya arki&v"
+
+#: tfrmtweakplugin.cbpk_caps_options.caption
+msgid "S&upports the options dialogbox"
+msgstr "S&töder alternativdialogen"
+
+#: tfrmtweakplugin.cbpk_caps_searchtext.caption
+msgid "Allow searchin&g for text in archives"
+msgstr "Tillåt textsöknin&g i arkiv"
+
+#: tfrmtweakplugin.lbldescription.caption
+msgid "&Description:"
+msgstr "&Beskrivning:"
+
+#: tfrmtweakplugin.lbldetectstr.caption
+msgid "D&etect string:"
+msgstr "I&dentifieringssträng:"
+
+#: tfrmtweakplugin.lblextension.caption
+msgid "&Extension:"
+msgstr "&Filändelse:"
+
+#: tfrmtweakplugin.lblflags.caption
+msgid "Flags:"
+msgstr "Flaggor:"
+
+#: tfrmtweakplugin.lblname.caption
+msgctxt "tfrmtweakplugin.lblname.caption"
+msgid "&Name:"
+msgstr "&Namn:"
+
+#: tfrmtweakplugin.lblplugin.caption
+msgctxt "tfrmtweakplugin.lblplugin.caption"
+msgid "&Plugin:"
+msgstr "&Insticksmodul:"
+
+#: tfrmtweakplugin.lblplugin2.caption
+msgctxt "tfrmtweakplugin.lblplugin2.caption"
+msgid "&Plugin:"
+msgstr "&Insticksmodul:"
+
+#: tfrmviewer.actabout.caption
+msgid "About Viewer..."
+msgstr "Om visaren..."
+
+#: tfrmviewer.actabout.hint
+msgid "Displays the About message"
+msgstr "Visar meddelandet Om"
+
+#: tfrmviewer.actautoreload.caption
+msgid "Auto Reload"
+msgstr "Automatisk omläsning"
+
+#: tfrmviewer.actchangeencoding.caption
+msgid "Change encoding"
+msgstr "Byt kodning"
+
+#: tfrmviewer.actcopyfile.caption
+msgctxt "tfrmviewer.actcopyfile.caption"
+msgid "Copy File"
+msgstr "Kopiera fil"
+
+#: tfrmviewer.actcopyfile.hint
+msgctxt "TFRMVIEWER.ACTCOPYFILE.HINT"
+msgid "Copy File"
+msgstr "Kopiera fil"
+
+#: tfrmviewer.actcopytoclipboard.caption
+msgctxt "TFRMVIEWER.ACTCOPYTOCLIPBOARD.CAPTION"
+msgid "Copy To Clipboard"
+msgstr "Kopiera till urklipp"
+
+#: tfrmviewer.actcopytoclipboardformatted.caption
+msgid "Copy To Clipboard Formatted"
+msgstr "Kopiera formaterat till urklipp"
+
+#: tfrmviewer.actdeletefile.caption
+msgctxt "tfrmviewer.actdeletefile.caption"
+msgid "Delete File"
+msgstr "Ta bort fil"
+
+#: tfrmviewer.actdeletefile.hint
+msgctxt "TFRMVIEWER.ACTDELETEFILE.HINT"
+msgid "Delete File"
+msgstr "Ta bort fil"
+
+#: tfrmviewer.actexitviewer.caption
+msgctxt "TFRMVIEWER.ACTEXITVIEWER.CAPTION"
+msgid "E&xit"
+msgstr "A&vsluta"
+
+#: tfrmviewer.actfind.caption
+msgctxt "TFRMVIEWER.ACTFIND.CAPTION"
+msgid "Find"
+msgstr "Sök"
+
+#: tfrmviewer.actfindnext.caption
+msgctxt "TFRMVIEWER.ACTFINDNEXT.CAPTION"
+msgid "Find next"
+msgstr "Sök nästa"
+
+#: tfrmviewer.actfindprev.caption
+msgctxt "TFRMVIEWER.ACTFINDPREV.CAPTION"
+msgid "Find previous"
+msgstr "Sök föregående"
+
+#: tfrmviewer.actfullscreen.caption
+msgctxt "TFRMVIEWER.ACTFULLSCREEN.CAPTION"
+msgid "Full Screen"
+msgstr "Helskärm"
+
+#: tfrmviewer.actgotoline.caption
+msgctxt "tfrmviewer.actgotoline.caption"
+msgid "Goto Line..."
+msgstr "Gå till rad..."
+
+#: tfrmviewer.actgotoline.hint
+msgctxt "tfrmviewer.actgotoline.hint"
+msgid "Goto Line"
+msgstr "Gå till rad"
+
+#: tfrmviewer.actimagecenter.caption
+msgid "Center"
+msgstr "Centrera"
+
+#: tfrmviewer.actloadnextfile.caption
+msgid "&Next"
+msgstr "&Nästa"
+
+#: tfrmviewer.actloadnextfile.hint
+msgid "Load Next File"
+msgstr "Läs in nästa fil"
+
+#: tfrmviewer.actloadprevfile.caption
+msgid "&Previous"
+msgstr "&Föregående"
+
+#: tfrmviewer.actloadprevfile.hint
+msgid "Load Previous File"
+msgstr "Läs in föregående fil"
+
+#: tfrmviewer.actmirrorhorz.caption
+msgid "Mirror Horizontally"
+msgstr "Spegla horisontellt"
+
+#: tfrmviewer.actmirrorhorz.hint
+msgid "Mirror"
+msgstr "Spegla"
+
+#: tfrmviewer.actmirrorvert.caption
+msgid "Mirror Vertically"
+msgstr "Spegla vertikalt"
+
+#: tfrmviewer.actmovefile.caption
+msgctxt "tfrmviewer.actmovefile.caption"
+msgid "Move File"
+msgstr "Flytta fil"
+
+#: tfrmviewer.actmovefile.hint
+msgctxt "TFRMVIEWER.ACTMOVEFILE.HINT"
+msgid "Move File"
+msgstr "Flytta fil"
+
+#: tfrmviewer.actpreview.caption
+msgctxt "tfrmviewer.actpreview.caption"
+msgid "Preview"
+msgstr "Förhandsgranska"
+
+#: tfrmviewer.actprint.caption
+msgid "P&rint..."
+msgstr "S&kriv ut..."
+
+#: tfrmviewer.actprintsetup.caption
+msgid "Print &setup..."
+msgstr "Utskrifts&inställningar..."
+
+#: tfrmviewer.actreload.caption
+msgctxt "TFRMVIEWER.ACTRELOAD.CAPTION"
+msgid "Reload"
+msgstr "Läs om"
+
+#: tfrmviewer.actreload.hint
+msgid "Reload current file"
+msgstr "Läs om aktuell fil"
+
+#: tfrmviewer.actrotate180.caption
+msgid "+ 180"
+msgstr "+ 180"
+
+#: tfrmviewer.actrotate180.hint
+msgid "Rotate 180 degrees"
+msgstr "Rotera 180 grader"
+
+#: tfrmviewer.actrotate270.caption
+msgid "- 90"
+msgstr "- 90"
+
+#: tfrmviewer.actrotate270.hint
+msgid "Rotate -90 degrees"
+msgstr "Rotera -90 grader"
+
+#: tfrmviewer.actrotate90.caption
+msgid "+ 90"
+msgstr "+ 90"
+
+#: tfrmviewer.actrotate90.hint
+msgid "Rotate +90 degrees"
+msgstr "Rotera +90 grader"
+
+#: tfrmviewer.actsave.caption
+msgctxt "TFRMVIEWER.ACTSAVE.CAPTION"
+msgid "Save"
+msgstr "Spara"
+
+#: tfrmviewer.actsaveas.caption
+msgctxt "tfrmviewer.actsaveas.caption"
+msgid "Save As..."
+msgstr "Spara som..."
+
+#: tfrmviewer.actsaveas.hint
+msgid "Save File As..."
+msgstr "Spara fil som..."
+
+#: tfrmviewer.actscreenshot.caption
+msgctxt "TFRMVIEWER.ACTSCREENSHOT.CAPTION"
+msgid "Screenshot"
+msgstr "Skärmbild"
+
+#: tfrmviewer.actscreenshotdelay3sec.caption
+msgid "Delay 3 sec"
+msgstr "Fördröjning 3 sek"
+
+#: tfrmviewer.actscreenshotdelay5sec.caption
+msgid "Delay 5 sec"
+msgstr "Fördröjning 5 sek"
+
+#: tfrmviewer.actselectall.caption
+msgctxt "TFRMVIEWER.ACTSELECTALL.CAPTION"
+msgid "Select All"
+msgstr "Markera allt"
+
+#: tfrmviewer.actshowasbin.caption
+msgid "Show as &Bin"
+msgstr "Visa som &binärt"
+
+#: tfrmviewer.actshowasbook.caption
+msgid "Show as B&ook"
+msgstr "Visa som b&ok"
+
+#: tfrmviewer.actshowasdec.caption
+msgid "Show as &Dec"
+msgstr "Visa som &decimalt"
+
+#: tfrmviewer.actshowashex.caption
+msgid "Show as &Hex"
+msgstr "Visa som &hexadecimalt"
+
+#: tfrmviewer.actshowastext.caption
+msgid "Show as &Text"
+msgstr "Visa som &text"
+
+#: tfrmviewer.actshowaswraptext.caption
+msgid "Show as &Wrap text"
+msgstr "Visa som &radbruten text"
+
+#: tfrmviewer.actshowcaret.caption
+msgid "Show text c&ursor"
+msgstr "Visa text&markör"
+
+#: tfrmviewer.actshowcode.caption
+msgid "Code"
+msgstr "Kod"
+
+#: tfrmviewer.actshowgraphics.caption
+msgctxt "tfrmviewer.actshowgraphics.caption"
+msgid "Graphics"
+msgstr "Grafik"
+
+#: tfrmviewer.actshowoffice.caption
+msgid "Office XML (text only)"
+msgstr "Office XML (endast text)"
+
+#: tfrmviewer.actshowplugins.caption
+msgctxt "TFRMVIEWER.ACTSHOWPLUGINS.CAPTION"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmviewer.actshowtransparency.caption
+msgid "Show transparenc&y"
+msgstr "Visa transparen&s"
+
+#: tfrmviewer.actstretchimage.caption
+msgid "Stretch"
+msgstr "Sträck ut"
+
+#: tfrmviewer.actstretchimage.hint
+msgid "Stretch Image"
+msgstr "Sträck ut bild"
+
+#: tfrmviewer.actstretchonlylarge.caption
+msgid "Stretch only large"
+msgstr "Sträck endast stora"
+
+#: tfrmviewer.actundo.caption
+msgctxt "tfrmviewer.actundo.caption"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmviewer.actundo.hint
+msgctxt "TFRMVIEWER.ACTUNDO.HINT"
+msgid "Undo"
+msgstr "Ångra"
+
+#: tfrmviewer.actwraptext.caption
+msgid "&Wrap text"
+msgstr "&Radbryt text"
+
+#: tfrmviewer.actzoom.caption
+msgctxt "tfrmviewer.actzoom.caption"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: tfrmviewer.actzoomin.caption
+msgctxt "tfrmviewer.actzoomin.caption"
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: tfrmviewer.actzoomin.hint
+msgctxt "tfrmviewer.actzoomin.hint"
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: tfrmviewer.actzoomout.caption
+msgctxt "tfrmviewer.actzoomout.caption"
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: tfrmviewer.actzoomout.hint
+msgctxt "tfrmviewer.actzoomout.hint"
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: tfrmviewer.btncuttuimage.hint
+msgid "Crop"
+msgstr "Beskär"
+
+#: tfrmviewer.btnfullscreen.hint
+msgctxt "tfrmviewer.btnfullscreen.hint"
+msgid "Full Screen"
+msgstr "Helskärm"
+
+#: tfrmviewer.btngiftobmp.hint
+msgid "Export Frame"
+msgstr "Exportera bildruta"
+
+#: tfrmviewer.btnhightlight.hint
+msgctxt "TFRMVIEWER.BTNHIGHTLIGHT.HINT"
+msgid "Highlight"
+msgstr "Framhäv"
+
+#: tfrmviewer.btnnextgifframe.hint
+msgid "Next Frame"
+msgstr "Nästa bildruta"
+
+#: tfrmviewer.btnpaint.hint
+msgctxt "TFRMVIEWER.BTNPAINT.HINT"
+msgid "Paint"
+msgstr "Rita"
+
+#: tfrmviewer.btnpenwidth.caption
+msgctxt "tfrmviewer.btnpenwidth.caption"
+msgid "1"
+msgstr "1"
+
+#: tfrmviewer.btnprevgifframe.hint
+msgid "Previous Frame"
+msgstr "Föregående bildruta"
+
+#: tfrmviewer.btnredeye.hint
+msgid "Red Eyes"
+msgstr "Röda ögon"
+
+#: tfrmviewer.btnresize.hint
+msgid "Resize"
+msgstr "Ändra storlek"
+
+#: tfrmviewer.btnslideshow.caption
+msgctxt "tfrmviewer.btnslideshow.caption"
+msgid "Slide Show"
+msgstr "Bildspel"
+
+#: tfrmviewer.caption
+msgctxt "tfrmviewer.caption"
+msgid "Viewer"
+msgstr "Visare"
+
+#: tfrmviewer.miabout.caption
+msgctxt "TFRMVIEWER.MIABOUT.CAPTION"
+msgid "About"
+msgstr "Om"
+
+#: tfrmviewer.miedit.caption
+msgctxt "TFRMVIEWER.MIEDIT.CAPTION"
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: tfrmviewer.miellipse.caption
+msgid "Ellipse"
+msgstr "Ellips"
+
+#: tfrmviewer.miencoding.caption
+msgctxt "TFRMVIEWER.MIENCODING.CAPTION"
+msgid "En&coding"
+msgstr "Ko&dning"
+
+#: tfrmviewer.mifile.caption
+msgctxt "TFRMVIEWER.MIFILE.CAPTION"
+msgid "&File"
+msgstr "&Fil"
+
+#: tfrmviewer.miimage.caption
+msgid "&Image"
+msgstr "&Bild"
+
+#: tfrmviewer.mipen.caption
+msgctxt "tfrmviewer.mipen.caption"
+msgid "Pen"
+msgstr "Penna"
+
+#: tfrmviewer.mirect.caption
+msgid "Rect"
+msgstr "Rektangel"
+
+#: tfrmviewer.mirotate.caption
+msgid "Rotate"
+msgstr "Rotera"
+
+#: tfrmviewer.miscreenshot.caption
+msgctxt "tfrmviewer.miscreenshot.caption"
+msgid "Screenshot"
+msgstr "Skärmbild"
+
+#: tfrmviewer.miview.caption
+msgctxt "TFRMVIEWER.MIVIEW.CAPTION"
+msgid "&View"
+msgstr "&Visa"
+
+#: tfrmviewer.mnuplugins.caption
+msgctxt "tfrmviewer.mnuplugins.caption"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: tfrmviewoperations.btnstartpause.caption
+msgctxt "tfrmviewoperations.btnstartpause.caption"
+msgid "&Start"
+msgstr "&Starta"
+
+#: tfrmviewoperations.btnstop.caption
+msgid "S&top"
+msgstr "S&toppa"
+
+#: tfrmviewoperations.caption
+msgctxt "tfrmviewoperations.caption"
+msgid "File operations"
+msgstr "Filåtgärder"
+
+#: tfrmviewoperations.cbalwaysontop.caption
+msgid "Always on top"
+msgstr "Alltid överst"
+
+#: tfrmviewoperations.lblusedragdrop.caption
+msgid "&Use \"drag && drop\" to move operations between queues"
+msgstr "&Använd ”dra && släpp” för att flytta åtgärder mellan köer"
+
+#: tfrmviewoperations.mnucanceloperation.caption
+msgctxt "tfrmviewoperations.mnucanceloperation.caption"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmviewoperations.mnucancelqueue.caption
+msgctxt "tfrmviewoperations.mnucancelqueue.caption"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tfrmviewoperations.mnunewqueue.caption
+msgctxt "tfrmviewoperations.mnunewqueue.caption"
+msgid "New queue"
+msgstr "Ny kö"
+
+#: tfrmviewoperations.mnuoperationshowdetached.caption
+msgctxt "tfrmviewoperations.mnuoperationshowdetached.caption"
+msgid "Show in detached window"
+msgstr "Visa i fristående fönster"
+
+#: tfrmviewoperations.mnuputfirstinqueue.caption
+msgid "Put first in queue"
+msgstr "Placera först i kön"
+
+#: tfrmviewoperations.mnuputlastinqueue.caption
+msgid "Put last in queue"
+msgstr "Placera sist i kön"
+
+#: tfrmviewoperations.mnuqueue.caption
+msgctxt "tfrmviewoperations.mnuqueue.caption"
+msgid "Queue"
+msgstr "Kö"
+
+#: tfrmviewoperations.mnuqueue0.caption
+msgid "Out of queue"
+msgstr "Utanför kö"
+
+#: tfrmviewoperations.mnuqueue1.caption
+msgctxt "tfrmviewoperations.mnuqueue1.caption"
+msgid "Queue 1"
+msgstr "Kö 1"
+
+#: tfrmviewoperations.mnuqueue2.caption
+msgctxt "tfrmviewoperations.mnuqueue2.caption"
+msgid "Queue 2"
+msgstr "Kö 2"
+
+#: tfrmviewoperations.mnuqueue3.caption
+msgctxt "tfrmviewoperations.mnuqueue3.caption"
+msgid "Queue 3"
+msgstr "Kö 3"
+
+#: tfrmviewoperations.mnuqueue4.caption
+msgctxt "tfrmviewoperations.mnuqueue4.caption"
+msgid "Queue 4"
+msgstr "Kö 4"
+
+#: tfrmviewoperations.mnuqueue5.caption
+msgctxt "tfrmviewoperations.mnuqueue5.caption"
+msgid "Queue 5"
+msgstr "Kö 5"
+
+#: tfrmviewoperations.mnuqueueshowdetached.caption
+msgctxt "tfrmviewoperations.mnuqueueshowdetached.caption"
+msgid "Show in detached window"
+msgstr "Visa i fristående fönster"
+
+#: tfrmviewoperations.tbpauseall.caption
+msgid "&Pause all"
+msgstr "&Pausa alla"
+
+#: tgiocopymoveoperationoptionsui.cbfollowlinks.caption
+msgctxt "tgiocopymoveoperationoptionsui.cbfollowlinks.caption"
+msgid "Fo&llow links"
+msgstr "Fö&lj länkar"
+
+#: tgiocopymoveoperationoptionsui.lbldirectoryexists.caption
+msgctxt "tgiocopymoveoperationoptionsui.lbldirectoryexists.caption"
+msgid "When dir&ectory exists"
+msgstr "När &katalogen redan finns"
+
+#: tgiocopymoveoperationoptionsui.lblfileexists.caption
+msgctxt "tgiocopymoveoperationoptionsui.lblfileexists.caption"
+msgid "When file exists"
+msgstr "När filen redan finns"
+
+#: tmultiarchivecopyoperationoptionsui.lblfileexists.caption
+msgctxt "tmultiarchivecopyoperationoptionsui.lblfileexists.caption"
+msgid "When file exists"
+msgstr "När filen redan finns"
+
+#: ttfrmconfirmcommandline.btncancel.caption
+msgctxt "ttfrmconfirmcommandline.btncancel.caption"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: ttfrmconfirmcommandline.btnok.caption
+msgctxt "ttfrmconfirmcommandline.btnok.caption"
+msgid "&OK"
+msgstr "&OK"
+
+#: ttfrmconfirmcommandline.lblecommandline.editlabel.caption
+msgid "Command line:"
+msgstr "Kommandorad:"
+
+#: ttfrmconfirmcommandline.lbleparameters.editlabel.caption
+msgctxt "ttfrmconfirmcommandline.lbleparameters.editlabel.caption"
+msgid "Parameters:"
+msgstr "Parametrar:"
+
+#: ttfrmconfirmcommandline.lblestartpath.editlabel.caption
+msgid "Start path:"
+msgstr "Startsökväg:"
+
+#: twcxarchivecopyoperationoptionsui.btnconfig.caption
+msgctxt "twcxarchivecopyoperationoptionsui.btnconfig.caption"
+msgid "Con&figure"
+msgstr "Kon&figurera"
+
+#: twcxarchivecopyoperationoptionsui.cbencrypt.caption
+msgctxt "twcxarchivecopyoperationoptionsui.cbencrypt.caption"
+msgid "Encr&ypt"
+msgstr "Kr&yptera"
+
+#: twcxarchivecopyoperationoptionsui.lblfileexists.caption
+msgctxt "TWCXARCHIVECOPYOPERATIONOPTIONSUI.LBLFILEEXISTS.CAPTION"
+msgid "When file exists"
+msgstr "När filen redan finns"
+
+#: twfxplugincopymoveoperationoptionsui.cbcopytime.caption
+msgctxt "TWFXPLUGINCOPYMOVEOPERATIONOPTIONSUI.CBCOPYTIME.CAPTION"
+msgid "Copy d&ate/time"
+msgstr "Kopiera &datum/tid"
+
+#: twfxplugincopymoveoperationoptionsui.cbworkinbackground.caption
+msgid "Work in background (separate connection)"
+msgstr "Arbeta i bakgrunden (separat anslutning)"
+
+#: twfxplugincopymoveoperationoptionsui.lblfileexists.caption
+msgctxt "TWFXPLUGINCOPYMOVEOPERATIONOPTIONSUI.LBLFILEEXISTS.CAPTION"
+msgid "When file exists"
+msgstr "När filen redan finns"
+
+#: uadministrator.rselevationrequired
+msgid "You need to provide administrator permission"
+msgstr "Du måste ange administratörsbehörighet"
+
+#: uadministrator.rselevationrequiredcopy
+msgid "to copy this object:"
+msgstr "för att kopiera det här objektet:"
+
+#: uadministrator.rselevationrequiredcreate
+msgid "to create this object:"
+msgstr "för att skapa det här objektet:"
+
+#: uadministrator.rselevationrequireddelete
+msgid "to delete this object:"
+msgstr "för att ta bort det här objektet:"
+
+#: uadministrator.rselevationrequiredgetattributes
+msgid "to get attributes of this object:"
+msgstr "för att hämta attribut för det här objektet:"
+
+#: uadministrator.rselevationrequiredhardlink
+msgid "to create this hard link:"
+msgstr "för att skapa den här hårda länken:"
+
+#: uadministrator.rselevationrequiredopen
+msgid "to open this object:"
+msgstr "för att öppna det här objektet:"
+
+#: uadministrator.rselevationrequiredrename
+msgid "to rename this object:"
+msgstr "för att byta namn på det här objektet:"
+
+#: uadministrator.rselevationrequiredsetattributes
+msgid "to set attributes of this object:"
+msgstr "för att ställa in attribut för det här objektet:"
+
+#: uadministrator.rselevationrequiredsymlink
+msgid "to create this symbolic link:"
+msgstr "för att skapa den här symboliska länken:"
+
+#: uexifreader.rsdatetimeoriginal
+msgid "Date taken"
+msgstr "Fotodatum"
+
+#: uexifreader.rsimageheight
+msgctxt "uexifreader.rsimageheight"
+msgid "Height"
+msgstr "Höjd"
+
+#: uexifreader.rsimagewidth
+msgctxt "uexifreader.rsimagewidth"
+msgid "Width"
+msgstr "Bredd"
+
+#: uexifreader.rsmake
+msgid "Manufacturer"
+msgstr "Tillverkare"
+
+#: uexifreader.rsmodel
+msgid "Camera model"
+msgstr "Kameramodell"
+
+#: uexifreader.rsorientation
+msgid "Orientation"
+msgstr "Orientering"
+
+#: ulng.msgtrytolocatecrcfile
+#, object-pascal-format
+msgid ""
+"This file cannot be found and could help to validate final combination of files:\n"
+"%s\n"
+"\n"
+"Could you make it available and press \"OK\" when ready,\n"
+"or press \"CANCEL\" to continue without it?"
+msgstr ""
+"Den här filen kan inte hittas och kan hjälpa till att validera den slutliga kombinationen av "
+"filer:\n"
+"%s\n"
+"\n"
+"Kan du göra den tillgänglig och trycka på ”OK” när du är klar,\n"
+"eller trycka på ”AVBRYT” för att fortsätta utan den?"
+
+#: ulng.rsabbrevdisplaydir
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ulng.rsabbrevdisplaylink
+msgid "<LNK>"
+msgstr "<LNK>"
+
+#: ulng.rscancelfilter
+msgid "Cancel Quick Filter"
+msgstr "Avbryt snabbfilter"
+
+#: ulng.rscanceloperation
+msgid "Cancel Current Operation"
+msgstr "Avbryt aktuell åtgärd"
+
+#: ulng.rscaptionforaskingfilename
+msgid "Enter filename, with extension, for dropped text"
+msgstr "Ange filnamn med filändelse för den släppta texten"
+
+#: ulng.rscaptionfortextformattoimport
+msgid "Text format to import"
+msgstr "Textformat att importera"
+
+#: ulng.rschecksumverifybroken
+msgid "Broken:"
+msgstr "Trasig:"
+
+#: ulng.rschecksumverifygeneral
+msgid "General:"
+msgstr "Allmänt:"
+
+#: ulng.rschecksumverifymissing
+msgid "Missing:"
+msgstr "Saknas:"
+
+#: ulng.rschecksumverifyreaderror
+msgid "Read error:"
+msgstr "Läsfel:"
+
+#: ulng.rschecksumverifysuccess
+msgctxt "ulng.rschecksumverifysuccess"
+msgid "Success:"
+msgstr "Lyckades:"
+
+#: ulng.rschecksumverifytext
+msgid "Enter checksum and select algorithm:"
+msgstr "Ange kontrollsumma och välj algoritm:"
+
+#: ulng.rschecksumverifytitle
+msgid "Verify checksum"
+msgstr "Verifiera kontrollsumma"
+
+#: ulng.rschecksumverifytotal
+msgid "Total:"
+msgstr "Totalt:"
+
+#: ulng.rsclearfiltersornot
+msgid "Do you want to clear filters for this new search?"
+msgstr "Vill du rensa filtren för den här nya sökningen?"
+
+#: ulng.rsclipboardcontainsinvalidtoolbardata
+msgid "Clipboard doesn't contain any valid toolbar data."
+msgstr "Urklipp innehåller inga giltiga verktygsfältsdata."
+
+#: ulng.rscmdcategorylistinorder
+msgid ""
+"All;Active Panel;Left Panel;Right Panel;File "
+"Operations;Configuration;Network;Miscellaneous;Parallel "
+"Port;Print;Mark;Security;Clipboard;FTP;Navigation;Help;Window;Command "
+"Line;Tools;View;User;Tabs;Sorting;Log"
+msgstr ""
+"Alla;Aktiv panel;Vänster panel;Höger "
+"panel;Filåtgärder;Konfiguration;Nätverk;Övrigt;Parallellport;Utskrift;Markering;Säkerhet;Urklipp;FTP;Navigering;Hjälp;Fönster;Kommandorad;Verktyg;Visa;Användare;Flikar;Sortering;Logg"
+
+#: ulng.rscmdkindofsort
+msgid "Legacy sorted;A-Z sorted"
+msgstr "Äldre sortering;A–Ö-sortering"
+
+#: ulng.rscolattr
+msgid "Attr"
+msgstr "Attr"
+
+#: ulng.rscoldate
+msgctxt "ulng.rscoldate"
+msgid "Date"
+msgstr "Datum"
+
+#: ulng.rscolext
+msgid "Ext"
+msgstr "Änd"
+
+#: ulng.rscolname
+msgctxt "ulng.rscolname"
+msgid "Name"
+msgstr "Namn"
+
+#: ulng.rscolsize
+msgctxt "ulng.rscolsize"
+msgid "Size"
+msgstr "Storlek"
+
+#: ulng.rsconfcolalign
+msgid "Align"
+msgstr "Justering"
+
+#: ulng.rsconfcolcaption
+msgid "Caption"
+msgstr "Rubrik"
+
+#: ulng.rsconfcoldelete
+msgctxt "ulng.rsconfcoldelete"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: ulng.rsconfcolfieldcont
+msgid "Field contents"
+msgstr "Fältinnehåll"
+
+#: ulng.rsconfcolmove
+msgctxt "ulng.rsconfcolmove"
+msgid "Move"
+msgstr "Flytta"
+
+#: ulng.rsconfcolwidth
+msgctxt "ulng.rsconfcolwidth"
+msgid "Width"
+msgstr "Bredd"
+
+#: ulng.rsconfcustheader
+msgid "Customize column"
+msgstr "Anpassa kolumn"
+
+#: ulng.rsconfigurationfileassociation
+msgid "Configure file association"
+msgstr "Konfigurera filassociation"
+
+#: ulng.rsconfirmexecution
+msgid "Confirming command line and parameters"
+msgstr "Bekräftar kommandorad och parametrar"
+
+#: ulng.rscopynametemplate
+#, object-pascal-format
+msgid "Copy (%d) %s"
+msgstr "Kopiera (%d) %s"
+
+#: ulng.rsdarkmode
+msgid "Dark mode"
+msgstr "Mörkt läge"
+
+#: ulng.rsdarkmodeoptions
+msgid "Auto;Enabled;Disabled"
+msgstr "Automatiskt;Aktiverat;Inaktiverat"
+
+#: ulng.rsdefaultimporteddctoolbarhint
+msgid "Imported DC toolbar"
+msgstr "Importerat DC-verktygsfält"
+
+#: ulng.rsdefaultimportedtctoolbarhint
+msgid "Imported TC toolbar"
+msgstr "Importerat TC-verktygsfält"
+
+#: ulng.rsdefaultpersonalizedabbrevbyte
+msgctxt "ulng.rsdefaultpersonalizedabbrevbyte"
+msgid "B"
+msgstr "B"
+
+#: ulng.rsdefaultpersonalizedabbrevgiga
+msgid "GB"
+msgstr "GB"
+
+#: ulng.rsdefaultpersonalizedabbrevkilo
+msgid "KB"
+msgstr "kB"
+
+#: ulng.rsdefaultpersonalizedabbrevmega
+msgctxt "ulng.rsdefaultpersonalizedabbrevmega"
+msgid "MB"
+msgstr "MB"
+
+#: ulng.rsdefaultpersonalizedabbrevtera
+msgid "TB"
+msgstr "TB"
+
+#: ulng.rsdefaultsuffixdroppedtext
+msgid "_DroppedText"
+msgstr "_SläpptText"
+
+#: ulng.rsdefaultsuffixdroppedtexthtmlfilename
+msgid "_DroppedHTMLtext"
+msgstr "_SläpptHTMLtext"
+
+#: ulng.rsdefaultsuffixdroppedtextrichtextfilename
+msgid "_DroppedRichtext"
+msgstr "_SläpptRichtext"
+
+#: ulng.rsdefaultsuffixdroppedtextsimplefilename
+msgid "_DroppedSimpleText"
+msgstr "_SläpptEnkelText"
+
+#: ulng.rsdefaultsuffixdroppedtextunicodeutf16filename
+msgid "_DroppedUnicodeUTF16text"
+msgstr "_SläpptUnicodeUTF16text"
+
+#: ulng.rsdefaultsuffixdroppedtextunicodeutf8filename
+msgid "_DroppedUnicodeUTF8text"
+msgstr "_SläpptUnicodeUTF8text"
+
+#: ulng.rsdiffadds
+msgid " Adds: "
+msgstr " Lägger till: "
+
+#: ulng.rsdiffcomparing
+msgid "Comparing..."
+msgstr "Jämför..."
+
+#: ulng.rsdiffdeletes
+msgid " Deletes: "
+msgstr " Tar bort: "
+
+#: ulng.rsdifffilesidentical
+msgid "The two files are identical!"
+msgstr "De två filerna är identiska!"
+
+#: ulng.rsdiffmatches
+msgid " Matches: "
+msgstr " Matchar: "
+
+#: ulng.rsdiffmodifies
+msgid " Modifies: "
+msgstr " Ändrar: "
+
+#: ulng.rsdiffshow
+msgctxt "ulng.rsdiffshow"
+msgid "&Show"
+msgstr "&Visa"
+
+#: ulng.rsdifftextdifferenceencoding
+msgctxt "ulng.rsdifftextdifferenceencoding"
+msgid "Encoding"
+msgstr "Kodning"
+
+#: ulng.rsdifftextdifferencelineending
+msgid "Line-endings"
+msgstr "Radslut"
+
+#: ulng.rsdifftextidentical
+msgid "The text is identical, but the following options are used:"
+msgstr "Texten är identisk, men följande alternativ används:"
+
+#: ulng.rsdifftextidenticalnotmatch
+msgid ""
+"The text is identical, but the files do not match!\n"
+"The following differences were found:"
+msgstr ""
+"Texten är identisk, men filerna matchar inte!\n"
+"Följande skillnader hittades:"
+
+#: ulng.rsdlgbuttonabort
+msgid "Ab&ort"
+msgstr "Avb&ryt"
+
+#: ulng.rsdlgbuttonall
+msgctxt "ulng.rsdlgbuttonall"
+msgid "A&ll"
+msgstr "A&lla"
+
+#: ulng.rsdlgbuttonappend
+msgid "A&ppend"
+msgstr "Lägg t&ill"
+
+#: ulng.rsdlgbuttonautorenamesource
+msgid "A&uto-rename source files"
+msgstr "Byt automatiskt namn på &källfiler"
+
+#: ulng.rsdlgbuttonautorenametarget
+msgid "Auto-rename tar&get files"
+msgstr "Byt automatiskt namn på mål&filer"
+
+#: ulng.rsdlgbuttoncancel
+msgctxt "ulng.rsdlgbuttoncancel"
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: ulng.rsdlgbuttoncompare
+msgid "Compare &by content"
+msgstr "Jämför efter &innehåll"
+
+#: ulng.rsdlgbuttoncontinue
+msgid "&Continue"
+msgstr "&Fortsätt"
+
+#: ulng.rsdlgbuttoncopyinto
+msgid "&Merge"
+msgstr "&Slå samman"
+
+#: ulng.rsdlgbuttoncopyintoall
+msgid "Mer&ge All"
+msgstr "Slå samman &alla"
+
+#: ulng.rsdlgbuttonexitprogram
+msgid "E&xit program"
+msgstr "A&vsluta programmet"
+
+#: ulng.rsdlgbuttonignore
+msgid "Ig&nore"
+msgstr "Ig&norera"
+
+#: ulng.rsdlgbuttonignoreall
+msgid "I&gnore All"
+msgstr "I&gnorera alla"
+
+#: ulng.rsdlgbuttonno
+msgid "&No"
+msgstr "&Nej"
+
+#: ulng.rsdlgbuttonnone
+msgid "Non&e"
+msgstr "Ing&en"
+
+#: ulng.rsdlgbuttonok
+msgctxt "ulng.rsdlgbuttonok"
+msgid "&OK"
+msgstr "&OK"
+
+#: ulng.rsdlgbuttonother
+msgid "Ot&her"
+msgstr "A&nnat"
+
+#: ulng.rsdlgbuttonoverwrite
+msgid "&Overwrite"
+msgstr "&Skriv över"
+
+#: ulng.rsdlgbuttonoverwriteall
+msgid "Overwrite &All"
+msgstr "Skriv över &alla"
+
+#: ulng.rsdlgbuttonoverwritelarger
+msgid "Overwrite All &Larger"
+msgstr "Skriv över alla &större"
+
+#: ulng.rsdlgbuttonoverwriteolder
+msgid "Overwrite All Ol&der"
+msgstr "Skriv över alla &äldre"
+
+#: ulng.rsdlgbuttonoverwritesmaller
+msgid "Overwrite All S&maller"
+msgstr "Skriv över alla &mindre"
+
+#: ulng.rsdlgbuttonrename
+msgctxt "ulng.rsdlgbuttonrename"
+msgid "R&ename"
+msgstr "&Byt namn"
+
+#: ulng.rsdlgbuttonresume
+msgid "&Resume"
+msgstr "&Återuppta"
+
+#: ulng.rsdlgbuttonretry
+msgid "Re&try"
+msgstr "Försök i&gen"
+
+#: ulng.rsdlgbuttonretryadmin
+msgid "As Ad&ministrator"
+msgstr "Som ad&ministratör"
+
+#: ulng.rsdlgbuttonskip
+msgid "&Skip"
+msgstr "&Hoppa över"
+
+#: ulng.rsdlgbuttonskipall
+msgid "S&kip All"
+msgstr "H&oppa över alla"
+
+#: ulng.rsdlgbuttonunlock
+msgid "&Unlock"
+msgstr "&Lås upp"
+
+#: ulng.rsdlgbuttonyes
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ulng.rsdlgcp
+msgctxt "ulng.rsdlgcp"
+msgid "Copy file(s)"
+msgstr "Kopiera fil(er)"
+
+#: ulng.rsdlgmv
+msgid "Move file(s)"
+msgstr "Flytta fil(er)"
+
+#: ulng.rsdlgoppause
+msgid "Pau&se"
+msgstr "Pau&sa"
+
+#: ulng.rsdlgopstart
+msgctxt "ulng.rsdlgopstart"
+msgid "&Start"
+msgstr "&Starta"
+
+#: ulng.rsdlgqueue
+msgctxt "ulng.rsdlgqueue"
+msgid "Queue"
+msgstr "Kö"
+
+#: ulng.rsdlgspeed
+#, object-pascal-format
+msgid "Speed %s/s"
+msgstr "Hastighet %s/s"
+
+#: ulng.rsdlgspeedtime
+#, object-pascal-format
+msgid "Speed %s/s, time remaining %s"
+msgstr "Hastighet %s/s, återstående tid %s"
+
+#: ulng.rsdraganddroptextformat
+msgid "Rich Text Format;HTML Format;Unicode Format;Simple Text Format"
+msgstr "Rich Text-format;HTML-format;Unicode-format;Enkelt textformat"
+
+#: ulng.rsdrivefreespaceindicator
+msgid "Drive Free Space Indicator"
+msgstr "Indikator för ledigt utrymme på enhet"
+
+#: ulng.rsdrivenolabel
+msgid "<no label>"
+msgstr "<ingen etikett>"
+
+#: ulng.rsdrivenomedia
+msgid "<no media>"
+msgstr "<inget medium>"
+
+#: ulng.rseditabouttext
+msgid "Internal Editor of Double Commander."
+msgstr "Double Commanders interna redigerare."
+
+#: ulng.rseditgotolinequery
+msgid "Goto line:"
+msgstr "Gå till rad:"
+
+#: ulng.rseditgotolinetitle
+msgctxt "ulng.rseditgotolinetitle"
+msgid "Goto Line"
+msgstr "Gå till rad"
+
+#: ulng.rsedithintcursorpos
+msgid "Cursor Position"
+msgstr "Markörposition"
+
+#: ulng.rsedithintinsertmode
+msgid "Insert Mode"
+msgstr "Infogningsläge"
+
+#: ulng.rsedithintmodified
+msgid "Modified"
+msgstr "Ändrad"
+
+#: ulng.rsedithintselectionmode
+msgid "Selection Mode"
+msgstr "Markeringsläge"
+
+#: ulng.rseditnewfile
+msgid "new.txt"
+msgstr "ny.txt"
+
+#: ulng.rseditnewfilename
+msgid "Filename:"
+msgstr "Filnamn:"
+
+#: ulng.rseditnewopen
+msgid "Open file"
+msgstr "Öppna fil"
+
+#: ulng.rseditsearchback
+msgid "&Backward"
+msgstr "&Bakåt"
+
+#: ulng.rseditsearchcaption
+msgctxt "ulng.rseditsearchcaption"
+msgid "Search"
+msgstr "Sök"
+
+#: ulng.rseditsearchfrw
+msgid "&Forward"
+msgstr "&Framåt"
+
+#: ulng.rseditsearchreplace
+msgctxt "ulng.rseditsearchreplace"
+msgid "Replace"
+msgstr "Ersätt"
+
+#: ulng.rseditstatinsertmodeins
+msgid "INS"
+msgstr "INS"
+
+#: ulng.rseditstatinsertmodeovr
+msgid "OVR"
+msgstr "OVR"
+
+#: ulng.rseditstatselmodecol
+msgid "COL"
+msgstr "COL"
+
+#: ulng.rseditstatselmodeline
+msgid "LINE"
+msgstr "LINE"
+
+#: ulng.rseditstatselmodenorm
+msgid "NORM"
+msgstr "NORM"
+
+#: ulng.rseditwithexternaleditor
+msgid "with external editor"
+msgstr "med extern redigerare"
+
+#: ulng.rseditwithinternaleditor
+msgid "with internal editor"
+msgstr "med intern redigerare"
+
+#: ulng.rsexecuteviashell
+msgctxt "ulng.rsexecuteviashell"
+msgid "Execute via shell"
+msgstr "Kör via skal"
+
+#: ulng.rsexecuteviaterminalclose
+msgctxt "ulng.rsexecuteviaterminalclose"
+msgid "Execute via terminal and close"
+msgstr "Kör via terminal och stäng"
+
+#: ulng.rsexecuteviaterminalstayopen
+msgctxt "ulng.rsexecuteviaterminalstayopen"
+msgid "Execute via terminal and stay open"
+msgstr "Kör via terminal och håll öppen"
+
+#: ulng.rsextsclosedbracketnofound
+#, object-pascal-format
+msgid "\"]\" not found in line %s"
+msgstr "”]” hittades inte på rad %s"
+
+#: ulng.rsextscommandwithnoext
+#, object-pascal-format
+msgid "No extension defined before command \"%s\". It will be ignored."
+msgstr "Ingen filändelse har definierats före kommandot ”%s”. Det ignoreras."
+
+#: ulng.rsfavtabspanelsideselection
+msgid "Left;Right;Active;Inactive;Both;None"
+msgstr "Vänster;Höger;Aktiv;Inaktiv;Båda;Ingen"
+
+#: ulng.rsfavtabssavedirhistory
+msgid "No;Yes"
+msgstr "Nej;Ja"
+
+#: ulng.rsfilenameexportedtcbarprefix
+msgid "Exported_from_DC"
+msgstr "Exporterad_från_DC"
+
+#: ulng.rsfileopcopymovefileexistsoptions
+msgid "Ask;Overwrite;Skip"
+msgstr "Fråga;Skriv över;Hoppa över"
+
+#: ulng.rsfileopdirectoryexistsoptions
+msgid "Ask;Merge;Skip"
+msgstr "Fråga;Slå samman;Hoppa över"
+
+#: ulng.rsfileopfileexistsoptions
+msgid "Ask;Overwrite;Overwrite Older;Skip"
+msgstr "Fråga;Skriv över;Skriv över äldre;Hoppa över"
+
+#: ulng.rsfileopsetpropertyerroroptions
+msgid "Ask;Don't set anymore;Ignore errors"
+msgstr "Fråga;Ställ inte in längre;Ignorera fel"
+
+#: ulng.rsfilteranyfiles
+msgid "Any files"
+msgstr "Alla filer"
+
+#: ulng.rsfilterarchiverconfigfiles
+msgid "Archiver config files"
+msgstr "Konfigurationsfiler för arkiverare"
+
+#: ulng.rsfilterdctooltipfiles
+msgid "DC Tooltip files"
+msgstr "DC-verktygstipsfiler"
+
+#: ulng.rsfilterdirectoryhotlistfiles
+msgid "Directory Hotlist files"
+msgstr "Filer för katalogfavoriter"
+
+#: ulng.rsfilterexecutablefiles
+msgid "Executables files"
+msgstr "Körbara filer"
+
+#: ulng.rsfilteriniconfigfiles
+msgid ".ini Config files"
+msgstr ".ini-konfigurationsfiler"
+
+#: ulng.rsfilterlegacytabfiles
+msgid "Legacy DC .tab files"
+msgstr "Äldre DC .tab-filer"
+
+#: ulng.rsfilterlibraries
+msgid "Library files"
+msgstr "Biblioteksfiler"
+
+#: ulng.rsfilterpluginfiles
+msgid "Plugin files"
+msgstr "Insticksmodulfiler"
+
+#: ulng.rsfilterprogramslibraries
+msgid "Programs and Libraries"
+msgstr "Program och bibliotek"
+
+#: ulng.rsfilterstatus
+msgid "FILTER"
+msgstr "FILTER"
+
+#: ulng.rsfiltertctoolbarfiles
+msgid "TC Toolbar files"
+msgstr "TC-verktygsfältsfiler"
+
+#: ulng.rsfiltertoolbarfiles
+msgid "DC Toolbar files"
+msgstr "DC-verktygsfältsfiler"
+
+#: ulng.rsfilterxmlconfigfiles
+msgid ".xml Config files"
+msgstr ".xml-konfigurationsfiler"
+
+#: ulng.rsfinddefinetemplate
+msgid "Define template"
+msgstr "Definiera mall"
+
+#: ulng.rsfinddepth
+#, object-pascal-format
+msgid "%s level(s)"
+msgstr "%s nivå(er)"
+
+#: ulng.rsfinddepthall
+msgid "all (unlimited depth)"
+msgstr "alla (obegränsat djup)"
+
+#: ulng.rsfinddepthcurdir
+msgid "current dir only"
+msgstr "endast aktuell katalog"
+
+#: ulng.rsfinddirnoex
+#, object-pascal-format
+msgid "Directory %s does not exist!"
+msgstr "Katalogen %s finns inte!"
+
+#: ulng.rsfindfound
+#, object-pascal-format
+msgid "Found: %d"
+msgstr "Hittade: %d"
+
+#: ulng.rsfindsavetemplatecaption
+msgid "Save search template"
+msgstr "Spara sökning som mall"
+
+#: ulng.rsfindsavetemplatetitle
+msgid "Template name:"
+msgstr "Mallnamn:"
+
+#: ulng.rsfindscanned
+#, object-pascal-format
+msgid "Scanned: %d"
+msgstr "Genomsökta: %d"
+
+#: ulng.rsfindscanning
+msgid "Scanning"
+msgstr "Genomsöker"
+
+#: ulng.rsfindsearchfiles
+msgctxt "ulng.rsfindsearchfiles"
+msgid "Find files"
+msgstr "Sök filer"
+
+#: ulng.rsfindselectdrives
+msgid "Select drives"
+msgstr "Välj enheter"
+
+#: ulng.rsfindtimeofscan
+msgid "Time of scan: "
+msgstr "Genomsökningstid: "
+
+#: ulng.rsfindwherebeg
+msgid "Begin at"
+msgstr "Börja vid"
+
+#: ulng.rsfontusageconsole
+msgid "&Console Font"
+msgstr "&Konsolteckensnitt"
+
+#: ulng.rsfontusageeditor
+msgid "&Editor Font"
+msgstr "&Redigerarteckensnitt"
+
+#: ulng.rsfontusagefunctionbuttons
+msgid "Function Buttons Font"
+msgstr "Teckensnitt för funktionsknappar"
+
+#: ulng.rsfontusagelog
+msgid "&Log Font"
+msgstr "&Loggteckensnitt"
+
+#: ulng.rsfontusagemain
+msgid "Main &Font"
+msgstr "Huvud&teckensnitt"
+
+#: ulng.rsfontusagepathedit
+msgid "Path Font"
+msgstr "Teckensnitt för sökväg"
+
+#: ulng.rsfontusagesearchresults
+msgid "Search Results Font"
+msgstr "Teckensnitt för sökresultat"
+
+#: ulng.rsfontusagestatusbar
+msgid "Status Bar Font"
+msgstr "Teckensnitt för statusfält"
+
+#: ulng.rsfontusagetreeviewmenu
+msgid "Tree View Menu Font"
+msgstr "Teckensnitt för trädvymeny"
+
+#: ulng.rsfontusageviewer
+msgid "&Viewer Font"
+msgstr "&Visarteckensnitt"
+
+#: ulng.rsfontusageviewerbook
+msgctxt "ulng.rsfontusageviewerbook"
+msgid "Viewer&Book Font"
+msgstr "Teckensnitt för bok&visare"
+
+#: ulng.rsfreemsg
+#, object-pascal-format
+msgid "%s of %s free"
+msgstr "%s av %s ledigt"
+
+#: ulng.rsfreemsgshort
+#, object-pascal-format
+msgid "%s free"
+msgstr "%s ledigt"
+
+#: ulng.rsfuncatime
+msgid "Access date/time"
+msgstr "Åtkomstdatum/-tid"
+
+#: ulng.rsfuncattr
+msgctxt "ulng.rsfuncattr"
+msgid "Attributes"
+msgstr "Attribut"
+
+#: ulng.rsfunccomment
+msgid "Comment"
+msgstr "Kommentar"
+
+#: ulng.rsfunccompressedsize
+msgid "Compressed size"
+msgstr "Komprimerad storlek"
+
+#: ulng.rsfuncctime
+msgid "Creation date/time"
+msgstr "Skapelsedatum/-tid"
+
+#: ulng.rsfuncext
+msgctxt "ulng.rsfuncext"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: ulng.rsfuncgroup
+msgctxt "ulng.rsfuncgroup"
+msgid "Group"
+msgstr "Grupp"
+
+#: ulng.rsfunchtime
+msgid "Change date/time"
+msgstr "Ändringsdatum/-tid"
+
+#: ulng.rsfunclinkto
+msgid "Link to"
+msgstr "Länk till"
+
+#: ulng.rsfuncmtime
+msgid "Modification date/time"
+msgstr "Ändringsdatum/-tid"
+
+#: ulng.rsfuncname
+msgctxt "ulng.rsfuncname"
+msgid "Name"
+msgstr "Namn"
+
+#: ulng.rsfuncnamenoext
+msgid "Name without extension"
+msgstr "Namn utan filändelse"
+
+#: ulng.rsfuncowner
+msgctxt "ulng.rsfuncowner"
+msgid "Owner"
+msgstr "Ägare"
+
+#: ulng.rsfuncpath
+msgctxt "ulng.rsfuncpath"
+msgid "Path"
+msgstr "Sökväg"
+
+#: ulng.rsfuncsize
+msgctxt "ulng.rsfuncsize"
+msgid "Size"
+msgstr "Storlek"
+
+#: ulng.rsfunctrashorigpath
+msgid "Original path"
+msgstr "Ursprunglig sökväg"
+
+#: ulng.rsfunctype
+msgid "Type"
+msgstr "Typ"
+
+#: ulng.rsharderrcreate
+msgid "Error creating hardlink."
+msgstr "Fel när hård länk skapades."
+
+#: ulng.rshotdirforcesortingorderchoices
+msgid "none;Name, a-z;Name, z-a;Ext, a-z;Ext, z-a;Size 9-0;Size 0-9;Date 9-0;Date 0-9"
+msgstr "ingen;Namn, a–ö;Namn, ö–a;Änd, a–ö;Änd, ö–a;Storlek 9–0;Storlek 0–9;Datum 9–0;Datum 0–9"
+
+#: ulng.rshotdirwarningabortrestorebackup
+msgid ""
+"Warning! When restoring a .hotlist backup file, this will erase existing list to replace by the "
+"imported one.\n"
+"\n"
+"Are you sure you want to proceed?"
+msgstr ""
+"Varning! När en säkerhetskopia av en .hotlist-fil återställs raderas den befintliga listan och "
+"ersätts av den importerade.\n"
+"\n"
+"Är du säker på att du vill fortsätta?"
+
+#: ulng.rshotkeycategorycopymovedialog
+msgid "Copy/Move Dialog"
+msgstr "Dialogen Kopiera/Flytta"
+
+#: ulng.rshotkeycategorydiffer
+msgctxt "ulng.rshotkeycategorydiffer"
+msgid "Differ"
+msgstr "Jämförare"
+
+#: ulng.rshotkeycategoryeditcommentdialog
+msgid "Edit Comment Dialog"
+msgstr "Dialogen Redigera kommentar"
+
+#: ulng.rshotkeycategoryeditor
+msgctxt "ulng.rshotkeycategoryeditor"
+msgid "Editor"
+msgstr "Redigerare"
+
+#: ulng.rshotkeycategoryfindfiles
+msgctxt "ulng.rshotkeycategoryfindfiles"
+msgid "Find files"
+msgstr "Sök filer"
+
+#: ulng.rshotkeycategorymain
+msgid "Main"
+msgstr "Huvudfönster"
+
+#: ulng.rshotkeycategorymultirename
+msgctxt "ulng.rshotkeycategorymultirename"
+msgid "Multi-Rename Tool"
+msgstr "Verktyg för massomdöpning"
+
+#: ulng.rshotkeycategorysyncdirs
+msgid "Synchronize Directories"
+msgstr "Synkronisera kataloger"
+
+#: ulng.rshotkeycategoryviewer
+msgctxt "ulng.rshotkeycategoryviewer"
+msgid "Viewer"
+msgstr "Visare"
+
+#: ulng.rshotkeyfilealreadyexists
+msgid ""
+"A setup with that name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Det finns redan en konfiguration med det namnet.\n"
+"Vill du skriva över den?"
+
+#: ulng.rshotkeyfileconfirmdefault
+msgid "Are you sure you want to restore default?"
+msgstr "Är du säker på att du vill återställa standardvärdena?"
+
+#: ulng.rshotkeyfileconfirmerasure
+#, object-pascal-format
+msgid "Are you sure you want to erase setup \"%s\"?"
+msgstr "Är du säker på att du vill ta bort konfigurationen ”%s”?"
+
+#: ulng.rshotkeyfilecopyof
+#, object-pascal-format
+msgid "Copy of %s"
+msgstr "Kopia av %s"
+
+#: ulng.rshotkeyfileinputnewname
+msgid "Input your new name"
+msgstr "Ange det nya namnet"
+
+#: ulng.rshotkeyfilemustkeepone
+msgid "You must keep at least one shortcut file."
+msgstr "Du måste behålla minst en kortkommandofil."
+
+#: ulng.rshotkeyfilenewname
+msgid "New name"
+msgstr "Nytt namn"
+
+#: ulng.rshotkeyfilesavemodified
+#, object-pascal-format
+msgid ""
+"\"%s\" setup has been modified.\n"
+"Do you want to save it now?"
+msgstr ""
+"Konfigurationen ”%s” har ändrats.\n"
+"Vill du spara den nu?"
+
+#: ulng.rshotkeynoscenter
+msgid "No shortcut with \"ENTER\""
+msgstr "Inget kortkommando med ”ENTER”"
+
+#: ulng.rshotkeysortorder
+msgid "By command name;By shortcut key (grouped);By shortcut key (one per row)"
+msgstr "Efter kommandonamn;Efter kortkommando (grupperat);Efter kortkommando (ett per rad)"
+
+#: ulng.rsiclouddrivecopyseedfileconfirmdlgmessage
+msgctxt "ulng.rsiclouddrivecopyseedfileconfirmdlgmessage"
+msgid ""
+"It is recommended to download the files first. Otherwise, what is copied is not the content of "
+"the files, but the corresponding placeholder files, which will result in hidden files with the "
+".iCloud extension."
+msgstr ""
+"Det rekommenderas att hämta filerna först. Annars kopieras inte filernas innehåll, utan "
+"motsvarande platshållarfiler, vilket resulterar i dolda filer med filändelsen .iCloud."
+
+#: ulng.rsiclouddrivecopyseedfileconfirmdlgtitle
+msgctxt "ulng.rsiclouddrivecopyseedfileconfirmdlgtitle"
+msgid "The operation may contain files that were not downloaded, continue anyway?"
+msgstr "Åtgärden kan innehålla filer som inte har hämtats. Fortsätta ändå?"
+
+#: ulng.rsimporttoolbarproblem
+msgid "Cannot find reference to default bar file"
+msgstr "Kan inte hitta referens till standardfilen för verktygsfältet"
+
+#: ulng.rslegacydisplaysizesinglelettergiga
+msgid "G"
+msgstr "G"
+
+#: ulng.rslegacydisplaysizesingleletterkilo
+msgid "K"
+msgstr "K"
+
+#: ulng.rslegacydisplaysizesinglelettermega
+msgid "M"
+msgstr "M"
+
+#: ulng.rslegacydisplaysizesinglelettertera
+msgid "T"
+msgstr "T"
+
+#: ulng.rslegacyoperationbytesuffixletter
+msgctxt "ulng.rslegacyoperationbytesuffixletter"
+msgid "B"
+msgstr "B"
+
+#: ulng.rslistoffindfileswindows
+msgid "List of \"Find files\" windows"
+msgstr "Lista över fönster för ”Sök filer”"
+
+#: ulng.rsmacosassignfindertagstomultiitems
+#, object-pascal-format
+msgid "Assign tags to %d items"
+msgstr "Tilldela taggar till %d objekt"
+
+#: ulng.rsmacosconnectserverprompt
+msgid ""
+"URL:\n"
+"(eg. smb://server/share; https://dav.server.com; nfs://server/path)\n"
+" "
+msgstr ""
+"URL:\n"
+"(t.ex. smb://server/share; https://dav.server.com; nfs://server/path)\n"
+" "
+
+#: ulng.rsmacosconnectservertitle
+msgid "SMB / Samba / WebDAV / NFS ..."
+msgstr "SMB / Samba / WebDAV / NFS ..."
+
+#: ulng.rsmarkminus
+msgid "Unselect mask"
+msgstr "Avmarkeringsmask"
+
+#: ulng.rsmarkplus
+msgid "Select mask"
+msgstr "Markeringsmask"
+
+#: ulng.rsmaskinput
+msgid "Input mask:"
+msgstr "Indatamask:"
+
+#: ulng.rsmenuconfigurecolumnsalreadyexists
+msgid "A columns view with that name already exists."
+msgstr "Det finns redan en kolumnvy med det namnet."
+
+#: ulng.rsmenuconfigurecolumnssavetochange
+msgid "To change current editing colmuns view, either SAVE, COPY or DELETE current editing one"
+msgstr ""
+"För att ändra den kolumnvy som redigeras måste du antingen SPARA, KOPIERA eller TA BORT den "
+"aktuella."
+
+#: ulng.rsmenuconfigurecustomcolumns
+msgid "Configure custom columns"
+msgstr "Konfigurera anpassade kolumner"
+
+#: ulng.rsmenuconfigureentercustomcolumnname
+msgid "Enter new custom columns name"
+msgstr "Ange namn för nya anpassade kolumner"
+
+#: ulng.rsmenumacosaddfindertag
+#, object-pascal-format
+msgid "Add \"%s\""
+msgstr "Lägg till ”%s”"
+
+#: ulng.rsmenumacoseditfindertags
+msgctxt "ulng.rsmenumacoseditfindertags"
+msgid "Edit Finder Tags..."
+msgstr "Redigera Finder-taggar..."
+
+#: ulng.rsmenumacosgrantpermissiontosupportfindertags
+msgid "Grant \"Full Disk Access\" permission to support Finder Tags..."
+msgstr "Ge behörigheten ”Fullständig skivåtkomst” för stöd för Finder-taggar..."
+
+#: ulng.rsmenumacosremovefindertag
+#, object-pascal-format
+msgid "Remove \"%s\""
+msgstr "Ta bort ”%s”"
+
+#: ulng.rsmenumacosshare
+msgid "Share..."
+msgstr "Dela..."
+
+#: ulng.rsmfstbiairdroptips
+msgctxt "ulng.rsmfstbiairdroptips"
+msgid "AirDrop"
+msgstr "AirDrop"
+
+#: ulng.rsmfstbiairdroptitle
+msgctxt "ulng.rsmfstbiairdroptitle"
+msgid "AirDrop"
+msgstr "AirDrop"
+
+#: ulng.rsmfstbicommandmenudirectoryhotlist
+msgctxt "ulng.rsmfstbicommandmenudirectoryhotlist"
+msgid "Directory Hotlist"
+msgstr "Katalogfavoriter"
+
+#: ulng.rsmfstbicommandmenufavoritetabs
+msgctxt "ulng.rsmfstbicommandmenufavoritetabs"
+msgid "Favorite Tabs"
+msgstr "Favoritflikar"
+
+#: ulng.rsmfstbicommandmenuquicklook
+msgid "macOS QuickLook"
+msgstr "macOS QuickLook"
+
+#: ulng.rsmfstbicommandtitle
+msgctxt "ulng.rsmfstbicommandtitle"
+msgid "Command"
+msgstr "Kommando"
+
+#: ulng.rsmfstbicomparetips
+msgid "Compare by Contents..."
+msgstr "Jämför efter innehåll..."
+
+#: ulng.rsmfstbicomparetitle
+msgctxt "ulng.rsmfstbicomparetitle"
+msgid "Compare"
+msgstr "Jämför"
+
+#: ulng.rsmfstbieditfindertagtips
+msgctxt "ulng.rsmfstbieditfindertagtips"
+msgid "Edit Finder Tags..."
+msgstr "Redigera Finder-taggar..."
+
+#: ulng.rsmfstbieditfindertagtitle
+msgid "EditTag"
+msgstr "Redigera tagg"
+
+#: ulng.rsmfstbiedittips
+msgid "Edit..."
+msgstr "Redigera..."
+
+#: ulng.rsmfstbiedittitle
+msgctxt "ulng.rsmfstbiedittitle"
+msgid "Edit"
+msgstr "Redigera"
+
+#: ulng.rsmfstbifinderrevealtips
+msgid "Reveal in Finder"
+msgstr "Visa i Finder"
+
+#: ulng.rsmfstbifinderrevealtitle
+msgid "Finder"
+msgstr "Finder"
+
+#: ulng.rsmfstbigobackwardtips
+msgctxt "ulng.rsmfstbigobackwardtips"
+msgid "Backward"
+msgstr "Bakåt"
+
+#: ulng.rsmfstbigobackwardtitle
+msgctxt "ulng.rsmfstbigobackwardtitle"
+msgid "Backward"
+msgstr "Bakåt"
+
+#: ulng.rsmfstbigoforwardtips
+msgctxt "ulng.rsmfstbigoforwardtips"
+msgid "Forward"
+msgstr "Framåt"
+
+#: ulng.rsmfstbigoforwardtitle
+msgctxt "ulng.rsmfstbigoforwardtitle"
+msgid "Forward"
+msgstr "Framåt"
+
+#: ulng.rsmfstbigotips
+msgctxt "ulng.rsmfstbigotips"
+msgid "Go"
+msgstr "Gå"
+
+#: ulng.rsmfstbigotitle
+msgctxt "ulng.rsmfstbigotitle"
+msgid "Go"
+msgstr "Gå"
+
+#: ulng.rsmfstbihorzsplittips
+msgid "Toggle Horizontal Split Mode"
+msgstr "Växla horisontellt delningsläge"
+
+#: ulng.rsmfstbihorzsplittitle
+msgid "HorzSplit"
+msgstr "Horisontell delning"
+
+#: ulng.rsmfstbiiclouddrivetips
+msgctxt "ulng.rsmfstbiiclouddrivetips"
+msgid "iCloud Drive"
+msgstr "iCloud Drive"
+
+#: ulng.rsmfstbiiclouddrivetitle
+msgctxt "ulng.rsmfstbiiclouddrivetitle"
+msgid "iCloud Drive"
+msgstr "iCloud Drive"
+
+#: ulng.rsmfstbinetworktips
+msgctxt "ulng.rsmfstbinetworktips"
+msgid "network"
+msgstr "nätverk"
+
+#: ulng.rsmfstbinetworktitle
+msgctxt "ulng.rsmfstbinetworktitle"
+msgid "network"
+msgstr "nätverk"
+
+#: ulng.rsmfstbiprivilegetips
+msgid ""
+"As a file manager, Double Command requires full disk access permissions. Clicking this button "
+"will pop up the macOS system settings page. Please add \"Double Commander.app\" to the \"Full "
+"Disk Access\" list to complete the authorization."
+msgstr ""
+"Som filhanterare kräver Double Commander behörigheten Fullständig skivåtkomst. När du klickar på "
+"den här knappen öppnas sidan med macOS-systeminställningar. Lägg till ”Double Commander.app” i "
+"listan ”Fullständig skivåtkomst” för att slutföra auktoriseringen."
+
+#: ulng.rsmfstbiprivilegetips2
+msgid "If you can see me, it means DC has not been authorized yet. DC will hide me once it is complete."
+msgstr ""
+"Om du kan se det här betyder det att DC ännu inte har auktoriserats. DC döljer detta när "
+"auktoriseringen är klar."
+
+#: ulng.rsmfstbiprivilegetips3
+msgid ""
+"You must re-authorize every time you install a new version. In this case you need to remove DC "
+"from the list first and then add DC back again. Because the new version has different "
+"fingerprints, simply enabling the checkboxes will not work."
+msgstr ""
+"Du måste auktorisera på nytt varje gång du installerar en ny version. Då måste du först ta bort "
+"DC från listan och sedan lägga till DC igen. Eftersom den nya versionen har andra fingeravtryck "
+"räcker det inte att bara aktivera kryssrutorna."
+
+#: ulng.rsmfstbiprivilegetitle
+msgid "Privilege"
+msgstr "Behörighet"
+
+#: ulng.rsmfstbiquicklooktips
+msgid "macOS Quick Look Panel"
+msgstr "macOS Quick Look-panel"
+
+#: ulng.rsmfstbiquicklooktitle
+msgid "QuickLook"
+msgstr "QuickLook"
+
+#: ulng.rsmfstbirefreshtips
+msgid "Refresh File List"
+msgstr "Uppdatera fillista"
+
+#: ulng.rsmfstbirefreshtitle
+msgid "Refresh"
+msgstr "Uppdatera"
+
+#: ulng.rsmfstbisearchcombinedtags
+msgid "Search for combined tags..."
+msgstr "Sök efter kombinerade taggar..."
+
+#: ulng.rsmfstbisearchtips
+msgid "Search Files..."
+msgstr "Sök filer..."
+
+#: ulng.rsmfstbisearchtitle
+msgctxt "ulng.rsmfstbisearchtitle"
+msgid "Search"
+msgstr "Sök"
+
+#: ulng.rsmfstbisharetitle
+msgid "Share"
+msgstr "Dela"
+
+#: ulng.rsmfstbishowbrieftitle
+msgid "as Brief"
+msgstr "som kompakt"
+
+#: ulng.rsmfstbishowfulltitle
+msgid "as Full"
+msgstr "som detaljerad"
+
+#: ulng.rsmfstbishowinfotips
+msgid "Show Info in Finder"
+msgstr "Visa info i Finder"
+
+#: ulng.rsmfstbishowinfotitle
+msgid "ShowInfo"
+msgstr "Visa info"
+
+#: ulng.rsmfstbishowmodetips
+msgid "Show as Brief, Full or Thumbnails"
+msgstr "Visa som kompakt, detaljerad eller miniatyrer"
+
+#: ulng.rsmfstbishowmodetitle
+msgid "ShowMode"
+msgstr "Visningsläge"
+
+#: ulng.rsmfstbishowthumbnailstitle
+msgid "as Thumbnails"
+msgstr "som miniatyrer"
+
+#: ulng.rsmfstbiswappanelstips
+msgid "Swap Panels"
+msgstr "Byt paneler"
+
+#: ulng.rsmfstbiswappanelstitle
+msgid "SwapPanels"
+msgstr "Byt paneler"
+
+#: ulng.rsmfstbisynctips
+msgid "Synchronize Dirs..."
+msgstr "Synkronisera kataloger..."
+
+#: ulng.rsmfstbisynctitle
+msgid "Sync"
+msgstr "Synkronisera"
+
+#: ulng.rsmfstbiterminaltips
+msgid "Open in Terminal"
+msgstr "Öppna i terminal"
+
+#: ulng.rsmfstbiterminaltitle
+msgctxt "ulng.rsmfstbiterminaltitle"
+msgid "Terminal"
+msgstr "Terminal"
+
+#: ulng.rsmfstbitreeviewtips
+msgid "Show Tree View Panel"
+msgstr "Visa trädvypanel"
+
+#: ulng.rsmfstbitreeviewtitle
+msgid "TreeView"
+msgstr "Trädvy"
+
+#: ulng.rsmnuactions
+msgctxt "ulng.rsmnuactions"
+msgid "Actions"
+msgstr "Åtgärder"
+
+#: ulng.rsmnucontentdefault
+msgid "<Default>"
+msgstr "<Standard>"
+
+#: ulng.rsmnucontentoctal
+msgid "Octal"
+msgstr "Oktalt"
+
+#: ulng.rsmnucreateshortcut
+msgid "Create Shortcut..."
+msgstr "Skapa genväg..."
+
+#: ulng.rsmnudisconnectnetworkdrive
+msgid "Disconnect Network Drive..."
+msgstr "Koppla från nätverksenhet..."
+
+#: ulng.rsmnuedit
+msgctxt "ulng.rsmnuedit"
+msgid "Edit"
+msgstr "Redigera"
+
+#: ulng.rsmnueject
+msgid "Eject"
+msgstr "Mata ut"
+
+#: ulng.rsmnuextracthere
+msgid "Extract here..."
+msgstr "Packa upp här..."
+
+#: ulng.rsmnuiclouddrivedownloadnow
+msgctxt "ulng.rsmnuiclouddrivedownloadnow"
+msgid "Download Now"
+msgstr "Hämta nu"
+
+#: ulng.rsmnuiclouddriveremovedownload
+msgctxt "ulng.rsmnuiclouddriveremovedownload"
+msgid "Remove Download"
+msgstr "Ta bort hämtning"
+
+#: ulng.rsmnumount
+msgid "Mount"
+msgstr "Montera"
+
+#: ulng.rsmnunew
+msgctxt "ulng.rsmnunew"
+msgid "New"
+msgstr "Ny"
+
+#: ulng.rsmnunewwindow
+msgid "New Window"
+msgstr "Nytt fönster"
+
+#: ulng.rsmnunomedia
+msgid "No media available"
+msgstr "Inget medium tillgängligt"
+
+#: ulng.rsmnuopen
+msgctxt "ulng.rsmnuopen"
+msgid "Open"
+msgstr "Öppna"
+
+#: ulng.rsmnuopenwith
+msgctxt "ulng.rsmnuopenwith"
+msgid "Open with"
+msgstr "Öppna med"
+
+#: ulng.rsmnuopenwithother
+msgctxt "ulng.rsmnuopenwithother"
+msgid "Other..."
+msgstr "Annat..."
+
+#: ulng.rsmnupackhere
+msgid "Pack here..."
+msgstr "Packa här..."
+
+#: ulng.rsmnurestore
+msgctxt "ulng.rsmnurestore"
+msgid "Restore"
+msgstr "Återställ"
+
+#: ulng.rsmnusortby
+msgid "Sort by"
+msgstr "Sortera efter"
+
+#: ulng.rsmnuumount
+msgid "Unmount"
+msgstr "Avmontera"
+
+#: ulng.rsmnuview
+msgctxt "ulng.rsmnuview"
+msgid "View"
+msgstr "Visa"
+
+#: ulng.rsmountedfilesourcecopymultifilestowcxdlgmessage
+msgid ""
+"Some virtual filesystem contain specific directory structures. When copying from it to a "
+"compressed archive, only one directory can be selected at a time, unless the actual locations of "
+"the selected directories are all located under the same parent directory.\n"
+"\n"
+"For example, for iCloud Drive, when copying directory from the root to a compressed archive, "
+"maybe only one directory should be selected.\n"
+"\n"
+"It is recommended that you follow your usual practice and try to select only one directory when "
+"you receive this prompt."
+msgstr ""
+"Vissa virtuella filsystem innehåller särskilda katalogstrukturer. När du kopierar från ett sådant"
+" till ett komprimerat arkiv kan endast en katalog väljas åt gången, om inte de markerade "
+"katalogernas faktiska platser ligger under samma överordnade katalog.\n"
+"\n"
+"För iCloud Drive kan du till exempel behöva välja endast en katalog när du kopierar en katalog "
+"från roten till ett komprimerat arkiv.\n"
+"\n"
+"Vi rekommenderar att du följer ditt vanliga arbetssätt och försöker välja endast en katalog när "
+"den här uppmaningen visas."
+
+#: ulng.rsmountedfilesourcecopymultifilestowcxdlgtitle
+msgid "The operation is not supported"
+msgstr "Åtgärden stöds inte"
+
+#: ulng.rsmsgaccount
+msgid "Account:"
+msgstr "Konto:"
+
+#: ulng.rsmsgalldcintcmds
+msgid "All Double Commander internal commands"
+msgstr "Alla interna Double Commander-kommandon"
+
+#: ulng.rsmsgapplicationname
+#, object-pascal-format
+msgid "Description: %s"
+msgstr "Beskrivning: %s"
+
+#: ulng.rsmsgarchivercustomparams
+msgid "Additional parameters for archiver command-line:"
+msgstr "Ytterligare parametrar för arkiverarens kommandorad:"
+
+#: ulng.rsmsgaskquoteornot
+msgid "Do you want to enclose between quotes?"
+msgstr "Vill du omge det med citattecken?"
+
+#: ulng.rsmsgbadcrc32
+#, object-pascal-format
+msgid ""
+"Bad CRC32 for resulting file:\n"
+"\"%s\"\n"
+"\n"
+"Do you want to keep the resulting corrupted file anyway?"
+msgstr ""
+"Felaktig CRC32 för den resulterande filen:\n"
+"”%s”\n"
+"\n"
+"Vill du ändå behålla den skadade filen?"
+
+#: ulng.rsmsgcanceloperation
+msgid "Are you sure that you want to cancel this operation?"
+msgstr "Är du säker på att du vill avbryta den här åtgärden?"
+
+#: ulng.rsmsgcannotchangetarget
+msgid "You cannot change a target location!"
+msgstr "Du kan inte ändra målplatsen!"
+
+#: ulng.rsmsgcannotcopymoveitself
+#, object-pascal-format
+msgid "You can not copy/move a file \"%s\" to itself!"
+msgstr "Du kan inte kopiera/flytta filen ”%s” till sig själv!"
+
+#: ulng.rsmsgcannotcopyspecialfile
+#, object-pascal-format
+msgid "Cannot copy special file %s"
+msgstr "Kan inte kopiera specialfilen %s"
+
+#: ulng.rsmsgcannotdeletedirectory
+#, object-pascal-format
+msgid "Cannot delete directory %s"
+msgstr "Kan inte ta bort katalogen %s"
+
+#: ulng.rsmsgcannotoverwritedirectory
+#, object-pascal-format
+msgid "Cannot overwrite directory \"%s\" with non-directory \"%s\""
+msgstr "Kan inte skriva över katalogen ”%s” med ”%s” som inte är en katalog"
+
+#: ulng.rsmsgchdirfailed
+#, object-pascal-format
+msgid "Change current directory to \"%s\" failed!"
+msgstr "Det gick inte att byta aktuell katalog till ”%s”!"
+
+#: ulng.rsmsgcloseallinactivetabs
+msgid "Remove all inactive tabs?"
+msgstr "Ta bort alla inaktiva flikar?"
+
+#: ulng.rsmsgcloselockedtab
+#, object-pascal-format
+msgid "This tab (%s) is locked! Close anyway?"
+msgstr "Den här fliken (%s) är låst! Stäng ändå?"
+
+#: ulng.rsmsgcofirmuserparam
+msgid "Confirmation of parameter"
+msgstr "Bekräftelse av parameter"
+
+#: ulng.rsmsgcommandnotfound
+#, object-pascal-format
+msgid "Command not found! (%s)"
+msgstr "Kommandot hittades inte! (%s)"
+
+#: ulng.rsmsgconfirmquit
+msgid "Are you sure you want to quit?"
+msgstr "Är du säker på att du vill avsluta?"
+
+#: ulng.rsmsgcopybackward
+#, object-pascal-format
+msgid "The file %s has changed. Do you want to copy it backward?"
+msgstr "Filen %s har ändrats. Vill du kopiera tillbaka den?"
+
+#: ulng.rsmsgcouldnotcopybackward
+msgid "Could not copy backward - do you want to keep the changed file?"
+msgstr "Det gick inte att kopiera tillbaka. Vill du behålla den ändrade filen?"
+
+#: ulng.rsmsgcpfldr
+#, object-pascal-format
+msgid "Copy %d selected files/directories?"
+msgstr "Kopiera %d markerade filer/kataloger?"
+
+#: ulng.rsmsgcpsel
+#, object-pascal-format
+msgid "Copy selected \"%s\"?"
+msgstr "Kopiera markerade ”%s”?"
+
+#: ulng.rsmsgcreateanewfiletype
+#, object-pascal-format
+msgid "< Create a new file type \"%s files\" >"
+msgstr "< Skapa en ny filtyp ”%s-filer” >"
+
+#: ulng.rsmsgdctoolbarwheretosave
+msgid "Enter location and filename where to save a DC Toolbar file"
+msgstr "Ange plats och filnamn där DC-verktygsfältsfilen ska sparas"
+
+#: ulng.rsmsgdefaultcustomactionname
+msgid "Custom action"
+msgstr "Anpassad åtgärd"
+
+#: ulng.rsmsgdeletepartiallycopied
+msgid "Delete the partially copied file ?"
+msgstr "Ta bort den delvis kopierade filen?"
+
+#: ulng.rsmsgdelfldr
+#, object-pascal-format
+msgid "Delete %d selected files/directories?"
+msgstr "Ta bort %d markerade filer/kataloger?"
+
+#: ulng.rsmsgdelfldrt
+#, object-pascal-format
+msgid "Delete %d selected files/directories into trash can?"
+msgstr "Flytta %d markerade filer/kataloger till papperskorgen?"
+
+#: ulng.rsmsgdelsel
+#, object-pascal-format
+msgid "Delete selected \"%s\"?"
+msgstr "Ta bort markerade ”%s”?"
+
+#: ulng.rsmsgdelselt
+#, object-pascal-format
+msgid "Delete selected \"%s\" into trash can?"
+msgstr "Flytta markerade ”%s” till papperskorgen?"
+
+#: ulng.rsmsgdeltotrashforce
+#, object-pascal-format
+msgid "Can not delete \"%s\" to trash! Delete directly?"
+msgstr "Kan inte flytta ”%s” till papperskorgen! Ta bort direkt?"
+
+#: ulng.rsmsgdisknotavail
+msgid "Disk is not available"
+msgstr "Disken är inte tillgänglig"
+
+#: ulng.rsmsgentercustomaction
+msgid "Enter custom action name:"
+msgstr "Ange namn för anpassad åtgärd:"
+
+#: ulng.rsmsgenterfileext
+msgid "Enter file extension:"
+msgstr "Ange filändelse:"
+
+#: ulng.rsmsgentername
+msgid "Enter name:"
+msgstr "Ange namn:"
+
+#: ulng.rsmsgenternewfiletypename
+#, object-pascal-format
+msgid "Enter name of new file type to create for extension \"%s\""
+msgstr "Ange namnet på den nya filtypen som ska skapas för filändelsen ”%s”"
+
+#: ulng.rsmsgerrbadarchive
+msgid "CRC error in archive data"
+msgstr "CRC-fel i arkivdata"
+
+#: ulng.rsmsgerrbaddata
+msgid "Data is bad"
+msgstr "Data är skadade"
+
+#: ulng.rsmsgerrcannotconnect
+#, object-pascal-format
+msgid "Can not connect to server: \"%s\""
+msgstr "Kan inte ansluta till servern: ”%s”"
+
+#: ulng.rsmsgerrcannotcopyfile
+#, object-pascal-format
+msgid "Cannot copy file %s to %s"
+msgstr "Kan inte kopiera filen %s till %s"
+
+#: ulng.rsmsgerrcannotmovedirectory
+#, object-pascal-format
+msgid "Cannot move directory %s"
+msgstr "Kan inte flytta katalogen %s"
+
+#: ulng.rsmsgerrcannotmovefile
+#, object-pascal-format
+msgid "Cannot move file %s"
+msgstr "Kan inte flytta filen %s"
+
+#: ulng.rsmsgerrcreatefiledirectoryexists
+#, object-pascal-format
+msgid "There already exists a directory named \"%s\"."
+msgstr "Det finns redan en katalog med namnet ”%s”."
+
+#: ulng.rsmsgerrdatenotsupported
+#, object-pascal-format
+msgid "Date %s is not supported"
+msgstr "Datumet %s stöds inte"
+
+#: ulng.rsmsgerrdirexists
+#, object-pascal-format
+msgid "Directory %s exists!"
+msgstr "Katalogen %s finns redan!"
+
+#: ulng.rsmsgerreaborted
+msgid "Function aborted by user"
+msgstr "Funktionen avbröts av användaren"
+
+#: ulng.rsmsgerreclose
+msgid "Error closing file"
+msgstr "Fel när filen stängdes"
+
+#: ulng.rsmsgerrecreate
+msgid "Cannot create file"
+msgstr "Kan inte skapa fil"
+
+#: ulng.rsmsgerrendarchive
+msgid "No more files in archive"
+msgstr "Inga fler filer i arkivet"
+
+#: ulng.rsmsgerreopen
+msgid "Cannot open existing file"
+msgstr "Kan inte öppna befintlig fil"
+
+#: ulng.rsmsgerreread
+msgid "Error reading from file"
+msgstr "Fel vid läsning från fil"
+
+#: ulng.rsmsgerrewrite
+msgid "Error writing to file"
+msgstr "Fel vid skrivning till fil"
+
+#: ulng.rsmsgerrforcedir
+#, object-pascal-format
+msgid "Can not create directory %s!"
+msgstr "Kan inte skapa katalogen %s!"
+
+#: ulng.rsmsgerrinvalidlink
+msgid "Invalid link"
+msgstr "Ogiltig länk"
+
+#: ulng.rsmsgerrnofiles
+msgid "No files found"
+msgstr "Inga filer hittades"
+
+#: ulng.rsmsgerrnomemory
+msgid "Not enough memory"
+msgstr "Otillräckligt minne"
+
+#: ulng.rsmsgerrnotsupported
+msgid "Function not supported!"
+msgstr "Funktionen stöds inte!"
+
+#: ulng.rsmsgerrorincontextmenucommand
+msgid "Error in context menu command"
+msgstr "Fel i snabbmenykommandot"
+
+#: ulng.rsmsgerrorloadingconfiguration
+msgid "Error when loading configuration"
+msgstr "Fel när konfigurationen lästes in"
+
+#: ulng.rsmsgerrregexpsyntax
+msgid "Syntax error in regular expression!"
+msgstr "Syntaxfel i reguljärt uttryck!"
+
+#: ulng.rsmsgerrrename
+#, object-pascal-format
+msgid "Cannot rename file %s to %s"
+msgstr "Kan inte byta namn på filen %s till %s"
+
+#: ulng.rsmsgerrsaveassociation
+msgid "Can not save association!"
+msgstr "Kan inte spara associationen!"
+
+#: ulng.rsmsgerrsavefile
+msgid "Cannot save file"
+msgstr "Kan inte spara fil"
+
+#: ulng.rsmsgerrsetattribute
+#, object-pascal-format
+msgid "Can not set attributes for \"%s\""
+msgstr "Kan inte ställa in attribut för ”%s”"
+
+#: ulng.rsmsgerrsetdatetime
+#, object-pascal-format
+msgid "Can not set date/time for \"%s\""
+msgstr "Kan inte ställa in datum/tid för ”%s”"
+
+#: ulng.rsmsgerrsetownership
+#, object-pascal-format
+msgid "Can not set owner/group for \"%s\""
+msgstr "Kan inte ställa in ägare/grupp för ”%s”"
+
+#: ulng.rsmsgerrsetpermissions
+#, object-pascal-format
+msgid "Can not set permissions for \"%s\""
+msgstr "Kan inte ställa in behörigheter för ”%s”"
+
+#: ulng.rsmsgerrsetxattribute
+#, object-pascal-format
+msgid "Can not set extended attributes for \"%s\""
+msgstr "Kan inte ställa in utökade attribut för ”%s”"
+
+#: ulng.rsmsgerrsmallbuf
+msgid "Buffer too small"
+msgstr "Bufferten är för liten"
+
+#: ulng.rsmsgerrtoomanyfiles
+msgid "Too many files to pack"
+msgstr "För många filer att packa"
+
+#: ulng.rsmsgerrunknownformat
+msgid "Archive format unknown"
+msgstr "Okänt arkivformat"
+
+#: ulng.rsmsgexecutablepath
+#, object-pascal-format
+msgid "Executable: %s"
+msgstr "Körbar fil: %s"
+
+#: ulng.rsmsgexitstatuscode
+msgid "Exit status:"
+msgstr "Avslutningsstatus:"
+
+#: ulng.rsmsgfavoritetabsdeleteallentries
+msgid ""
+"Are you sure you want to remove all entries of your Favorite Tabs? (There is no \"undo\" to this "
+"action!)"
+msgstr ""
+"Är du säker på att du vill ta bort alla poster i dina favoritflikar? (Den här åtgärden kan inte "
+"ångras!)"
+
+#: ulng.rsmsgfavoritetabsdraghereentry
+msgid "Drag here other entries"
+msgstr "Dra andra poster hit"
+
+#: ulng.rsmsgfavoritetabsentername
+msgid "Enter a name for this new Favorite Tabs entry:"
+msgstr "Ange ett namn för den här nya posten i favoritflikar:"
+
+#: ulng.rsmsgfavoritetabsenternametitle
+msgid "Saving a new Favorite Tabs entry"
+msgstr "Sparar en ny post i favoritflikar"
+
+#: ulng.rsmsgfavoritetabsexportedsuccessfully
+#, object-pascal-format
+msgid "Number of Favorite Tabs exported successfully: %d on %d"
+msgstr "Antal favoritflikar som exporterades: %d av %d"
+
+#: ulng.rsmsgfavoritetabsextramode
+msgid "Default extra setting for save dir history for new Favorite Tabs:"
+msgstr "Extra standardinställning för att spara kataloghistorik med nya favoritflikar:"
+
+#: ulng.rsmsgfavoritetabsimportedsuccessfully
+#, object-pascal-format
+msgid "Number of file(s) imported successfully: %d on %d"
+msgstr "Antal filer som importerades: %d av %d"
+
+#: ulng.rsmsgfavoritetabsimportsubmenuname
+msgid "Legacy tabs imported"
+msgstr "Äldre flikar importerade"
+
+#: ulng.rsmsgfavoritetabsimporttitle
+msgid "Select .tab file(s) to import (could be more than one at the time!)"
+msgstr "Välj .tab-fil(er) att importera (du kan välja flera samtidigt!)"
+
+#: ulng.rsmsgfavoritetabsmodifiednoimport
+msgid "Last Favorite Tabs modification have been saved yet. Do you want to save them prior to continue?"
+msgstr ""
+"De senaste ändringarna i favoritflikarna har ännu inte sparats. Vill du spara dem innan du "
+"fortsätter?"
+
+#: ulng.rsmsgfavoritetabssimplemode
+msgctxt "ulng.rsmsgfavoritetabssimplemode"
+msgid "Keep saving dir history with Favorite Tabs:"
+msgstr "Fortsätt spara kataloghistorik med favoritflikar:"
+
+#: ulng.rsmsgfavoritetabssubmenuname
+msgctxt "ulng.rsmsgfavoritetabssubmenuname"
+msgid "Submenu name"
+msgstr "Undermenynamn"
+
+#: ulng.rsmsgfavoritetabsthiswillloadfavtabs
+#, object-pascal-format
+msgid "This will load the Favorite Tabs: \"%s\""
+msgstr "Detta läser in favoritflikarna: ”%s”"
+
+#: ulng.rsmsgfavortietabssaveoverexisting
+msgid "Save current tabs over existing Favorite Tabs entry"
+msgstr "Spara aktuella flikar över en befintlig post i favoritflikar"
+
+#: ulng.rsmsgfilechangedsave
+#, object-pascal-format
+msgid "File %s changed, save?"
+msgstr "Filen %s har ändrats. Spara?"
+
+#: ulng.rsmsgfileexistsfileinfo
+#, object-pascal-format
+msgid "%s bytes, %s"
+msgstr "%s byte, %s"
+
+#: ulng.rsmsgfileexistsoverwrite
+msgid "Overwrite:"
+msgstr "Skriv över:"
+
+#: ulng.rsmsgfileexistsrwrt
+#, object-pascal-format
+msgid "File %s exists, overwrite?"
+msgstr "Filen %s finns redan. Skriva över?"
+
+#: ulng.rsmsgfileexistswithfile
+msgid "With file:"
+msgstr "Med fil:"
+
+#: ulng.rsmsgfilenotfound
+#, object-pascal-format
+msgid "File \"%s\" not found."
+msgstr "Filen ”%s” hittades inte."
+
+#: ulng.rsmsgfileoperationsactive
+msgid "File operations active"
+msgstr "Filåtgärder pågår"
+
+#: ulng.rsmsgfileoperationsactivelong
+msgid "Some file operations have not yet finished. Closing Double Commander may result in data loss."
+msgstr "Vissa filåtgärder har ännu inte slutförts. Om Double Commander stängs kan data gå förlorade."
+
+#: ulng.rsmsgfilepathovermaxpath
+#, object-pascal-format
+msgid ""
+"The target name length (%d) is more than %d characters!\n"
+"%s\n"
+"Most programs will not be able to access a file/directory with such a long name!"
+msgstr ""
+"Målnamnets längd (%d) är mer än %d tecken!\n"
+"%s\n"
+"De flesta program kommer inte att kunna komma åt en fil/katalog med ett så långt namn!"
+
+#: ulng.rsmsgfilereadonly
+#, object-pascal-format
+msgid "File %s is marked as read-only/hidden/system. Delete it?"
+msgstr "Filen %s är markerad som skrivskyddad/dold/systemfil. Ta bort den?"
+
+#: ulng.rsmsgfilereloadwarning
+msgid "Are you sure you want to reload the current file and lose the changes?"
+msgstr "Är du säker på att du vill läsa om den aktuella filen och förlora ändringarna?"
+
+#: ulng.rsmsgfilesizetoobig
+#, object-pascal-format
+msgid "The file size of \"%s\" is too big for destination file system!"
+msgstr "Filen ”%s” är för stor för målfilsystemet!"
+
+#: ulng.rsmsgfolderexistsrwrt
+#, object-pascal-format
+msgid "Folder %s exists, merge?"
+msgstr "Mappen %s finns redan. Slå samman?"
+
+#: ulng.rsmsgfollowsymlink
+#, object-pascal-format
+msgid "Follow symlink \"%s\"?"
+msgstr "Följ den symboliska länken ”%s”?"
+
+#: ulng.rsmsgfortextformattoimport
+msgid "Select the text format to import"
+msgstr "Välj textformat att importera"
+
+#: ulng.rsmsghotdiraddselecteddirectories
+#, object-pascal-format
+msgid "Add %d selected dirs"
+msgstr "Lägg till %d markerade kataloger"
+
+#: ulng.rsmsghotdiraddselecteddirectory
+msgid "Add selected dir: "
+msgstr "Lägg till markerad katalog: "
+
+#: ulng.rsmsghotdiraddthisdirectory
+msgid "Add current dir: "
+msgstr "Lägg till aktuell katalog: "
+
+#: ulng.rsmsghotdircommandname
+msgid "Do command"
+msgstr "Kör kommando"
+
+#: ulng.rsmsghotdircommandsample
+msgid "cm_somthing"
+msgstr "cm_somthing"
+
+#: ulng.rsmsghotdirconfighotlist
+msgctxt "ulng.rsmsghotdirconfighotlist"
+msgid "Configuration of Directory Hotlist"
+msgstr "Konfiguration av katalogfavoriter"
+
+#: ulng.rsmsghotdirdeleteallentries
+msgid ""
+"Are you sure you want to remove all entries of your Directory Hotlist? (There is no \"undo\" to "
+"this action!)"
+msgstr ""
+"Är du säker på att du vill ta bort alla poster i dina katalogfavoriter? (Den här åtgärden kan "
+"inte ångras!)"
+
+#: ulng.rsmsghotdirdemocommand
+msgid "This will execute the following command:"
+msgstr "Detta kör följande kommando:"
+
+#: ulng.rsmsghotdirdemoname
+msgid "This is hot dir named "
+msgstr "Det här är katalogfavoriten med namnet "
+
+#: ulng.rsmsghotdirdemopath
+msgid "This will change active frame to the following path:"
+msgstr "Detta byter den aktiva panelen till följande sökväg:"
+
+#: ulng.rsmsghotdirdemotarget
+msgid "And inactive frame would change to the following path:"
+msgstr "Och den inaktiva panelen byter till följande sökväg:"
+
+#: ulng.rsmsghotdirerrorbackuping
+msgid "Error backuping entries..."
+msgstr "Fel vid säkerhetskopiering av poster..."
+
+#: ulng.rsmsghotdirerrorexporting
+msgid "Error exporting entries..."
+msgstr "Fel vid export av poster..."
+
+#: ulng.rsmsghotdirexportall
+msgid "Export all!"
+msgstr "Exportera alla!"
+
+#: ulng.rsmsghotdirexporthotlist
+msgid "Export Directory Hotlist - Select the entries you want to export"
+msgstr "Exportera katalogfavoriter – välj de poster du vill exportera"
+
+#: ulng.rsmsghotdirexportsel
+msgid "Export selected"
+msgstr "Exportera markerade"
+
+#: ulng.rsmsghotdirimportall
+msgctxt "ulng.rsmsghotdirimportall"
+msgid "Import all!"
+msgstr "Importera alla!"
+
+#: ulng.rsmsghotdirimporthotlist
+msgid "Import Directory Hotlist - Select the entries you want to import"
+msgstr "Importera katalogfavoriter – välj de poster du vill importera"
+
+#: ulng.rsmsghotdirimportsel
+msgctxt "ulng.rsmsghotdirimportsel"
+msgid "Import selected"
+msgstr "Importera markerade"
+
+#: ulng.rsmsghotdirjustpath
+msgctxt "ulng.rsmsghotdirjustpath"
+msgid "&Path:"
+msgstr "&Sökväg:"
+
+#: ulng.rsmsghotdirlocatehotlistfile
+msgid "Locate \".hotlist\" file to import"
+msgstr "Välj ”.hotlist”-fil att importera"
+
+#: ulng.rsmsghotdirname
+msgid "Hotdir name"
+msgstr "Katalogfavoritens namn"
+
+#: ulng.rsmsghotdirnbnewentries
+#, object-pascal-format
+msgid "Number of new entries: %d"
+msgstr "Antal nya poster: %d"
+
+#: ulng.rsmsghotdirnothingtoexport
+msgid "Nothing selected to export!"
+msgstr "Inget markerat att exportera!"
+
+#: ulng.rsmsghotdirpath
+msgid "Hotdir path"
+msgstr "Katalogfavoritens sökväg"
+
+#: ulng.rsmsghotdirreaddselecteddirectory
+msgid "Re-Add selected dir: "
+msgstr "Lägg till markerad katalog igen: "
+
+#: ulng.rsmsghotdirreaddthisdirectory
+msgid "Re-Add current dir: "
+msgstr "Lägg till aktuell katalog igen: "
+
+#: ulng.rsmsghotdirrestorewhat
+msgid "Enter location and filename of Directory Hotlist to restore"
+msgstr "Ange plats och filnamn för katalogfavoriterna som ska återställas"
+
+#: ulng.rsmsghotdirsimplecommand
+msgctxt "ulng.rsmsghotdirsimplecommand"
+msgid "Command:"
+msgstr "Kommando:"
+
+#: ulng.rsmsghotdirsimpleendofmenu
+msgctxt "ulng.rsmsghotdirsimpleendofmenu"
+msgid "(end of sub menu)"
+msgstr "(slut på undermeny)"
+
+#: ulng.rsmsghotdirsimplemenu
+msgctxt "ulng.rsmsghotdirsimplemenu"
+msgid "Menu &name:"
+msgstr "Meny&namn:"
+
+#: ulng.rsmsghotdirsimplename
+msgctxt "ulng.rsmsghotdirsimplename"
+msgid "&Name:"
+msgstr "&Namn:"
+
+#: ulng.rsmsghotdirsimpleseparator
+msgctxt "ulng.rsmsghotdirsimpleseparator"
+msgid "(separator)"
+msgstr "(avgränsare)"
+
+#: ulng.rsmsghotdirsubmenuname
+msgctxt "ulng.rsmsghotdirsubmenuname"
+msgid "Submenu name"
+msgstr "Undermenynamn"
+
+#: ulng.rsmsghotdirtarget
+msgid "Hotdir target"
+msgstr "Katalogfavoritens mål"
+
+#: ulng.rsmsghotdirtiporderpath
+msgid "Determine if you want the active frame to be sorted in a specified order after changing directory"
+msgstr "Ange om den aktiva panelen ska sorteras i en viss ordning efter katalogbyte"
+
+#: ulng.rsmsghotdirtipordertarget
+msgid ""
+"Determine if you want the not active frame to be sorted in a specified order after changing "
+"directory"
+msgstr "Ange om den inaktiva panelen ska sorteras i en viss ordning efter katalogbyte"
+
+#: ulng.rsmsghotdirtipspecialdirbut
+msgid "Some functions to select appropriate path relative, absolute, windows special folders, etc."
+msgstr "Funktioner för att välja lämplig sökväg: relativ, absolut, särskilda Windows-mappar osv."
+
+#: ulng.rsmsghotdirtotalbackuped
+#, object-pascal-format
+msgid ""
+"Total entries saved: %d\n"
+"\n"
+"Backup filename: %s"
+msgstr ""
+"Totalt antal sparade poster: %d\n"
+"\n"
+"Säkerhetskopians filnamn: %s"
+
+#: ulng.rsmsghotdirtotalexported
+msgid "Total entries exported: "
+msgstr "Totalt antal exporterade poster: "
+
+#: ulng.rsmsghotdirwhattodelete
+#, object-pascal-format
+msgid ""
+"Do you want to delete all elements inside the sub-menu [%s]?\n"
+"Answering NO will delete only menu delimiters but will keep element inside sub-menu."
+msgstr ""
+"Vill du ta bort alla objekt i undermenyn [%s]?\n"
+"Om du svarar NEJ tas endast menyavgränsarna bort, medan objekten i undermenyn behålls."
+
+#: ulng.rsmsghotdirwheretosave
+msgid "Enter location and filename where to save a Directory Hotlist file"
+msgstr "Ange plats och filnamn där katalogfavoritfilen ska sparas"
+
+#: ulng.rsmsgincorrectfilelength
+#, object-pascal-format
+msgid "Incorrect resulting filelength for file : \"%s\""
+msgstr "Felaktig resulterande fillängd för filen: ”%s”"
+
+#: ulng.rsmsginsertnextdisk
+#, object-pascal-format
+msgid ""
+"Please insert next disk or something similar.\n"
+"\n"
+"It is to allow writing this file:\n"
+"\"%s\"\n"
+"\n"
+"Number of bytes still to write: %d"
+msgstr ""
+"Sätt in nästa disk eller motsvarande.\n"
+"\n"
+"Det behövs för att kunna skriva den här filen:\n"
+"”%s”\n"
+"\n"
+"Antal byte som återstår att skriva: %d"
+
+#: ulng.rsmsginvalidcommandline
+msgid "Error in command line"
+msgstr "Fel i kommandoraden"
+
+#: ulng.rsmsginvalidfilename
+msgid "Invalid filename"
+msgstr "Ogiltigt filnamn"
+
+#: ulng.rsmsginvalidformatofconfigurationfile
+msgid "Invalid format of configuration file"
+msgstr "Ogiltigt format på konfigurationsfilen"
+
+#: ulng.rsmsginvalidhexnumber
+#, object-pascal-format
+msgid "Invalid hexadecimal number: \"%s\""
+msgstr "Ogiltigt hexadecimalt tal: ”%s”"
+
+#: ulng.rsmsginvalidpath
+msgid "Invalid path"
+msgstr "Ogiltig sökväg"
+
+#: ulng.rsmsginvalidpathlong
+#, object-pascal-format
+msgid "Path %s contains forbidden characters."
+msgstr "Sökvägen %s innehåller förbjudna tecken."
+
+#: ulng.rsmsginvalidplugin
+msgid "This is not a valid plugin!"
+msgstr "Det här är inte en giltig insticksmodul!"
+
+#: ulng.rsmsginvalidpluginarchitecture
+#, object-pascal-format
+msgid "This plugin is built for Double Commander for %s.%sIt can not work with Double Commander for %s!"
+msgstr ""
+"Den här insticksmodulen är byggd för Double Commander för %s.%sDen kan inte fungera med Double "
+"Commander för %s!"
+
+#: ulng.rsmsginvalidquoting
+msgid "Invalid quoting"
+msgstr "Ogiltig citering"
+
+#: ulng.rsmsginvalidselection
+msgid "Invalid selection."
+msgstr "Ogiltig markering."
+
+#: ulng.rsmsgkeytransformerror
+#, object-pascal-format
+msgid "The key transformation failed (error code %d)!"
+msgstr "Nyckeltransformeringen misslyckades (felkod %d)!"
+
+#: ulng.rsmsgkeytransformtime
+#, object-pascal-format
+msgid "The key transformation took %f seconds."
+msgstr "Nyckeltransformeringen tog %f sekunder."
+
+#: ulng.rsmsgloadingfilelist
+msgid "Loading file list..."
+msgstr "Läser in fillista..."
+
+#: ulng.rsmsglocatetcconfiguation
+msgid "Locate TC configuration file (wincmd.ini)"
+msgstr "Välj TC:s konfigurationsfil (wincmd.ini)"
+
+#: ulng.rsmsglocatetcexecutable
+msgid "Locate TC executable file (totalcmd.exe or totalcmd64.exe)"
+msgstr "Välj TC:s körbara fil (totalcmd.exe eller totalcmd64.exe)"
+
+#: ulng.rsmsglogcopy
+#, object-pascal-format
+msgid "Copy file %s"
+msgstr "Kopiera fil %s"
+
+#: ulng.rsmsglogdelete
+#, object-pascal-format
+msgid "Delete file %s"
+msgstr "Ta bort fil %s"
+
+#: ulng.rsmsglogerror
+msgid "Error: "
+msgstr "Fel: "
+
+#: ulng.rsmsglogextcmdlaunch
+msgid "Launch external"
+msgstr "Starta externt"
+
+#: ulng.rsmsglogextcmdresult
+msgid "Result external"
+msgstr "Externt resultat"
+
+#: ulng.rsmsglogextract
+#, object-pascal-format
+msgid "Extract file %s"
+msgstr "Packa upp fil %s"
+
+#: ulng.rsmsgloginfo
+msgid "Info: "
+msgstr "Info: "
+
+#: ulng.rsmsgloglink
+#, object-pascal-format
+msgid "Create link %s"
+msgstr "Skapa länk %s"
+
+#: ulng.rsmsglogmkdir
+#, object-pascal-format
+msgid "Create directory %s"
+msgstr "Skapa katalog %s"
+
+#: ulng.rsmsglogmove
+#, object-pascal-format
+msgid "Move file %s"
+msgstr "Flytta fil %s"
+
+#: ulng.rsmsglogpack
+#, object-pascal-format
+msgid "Pack to file %s"
+msgstr "Packa till fil %s"
+
+#: ulng.rsmsglogprogramshutdown
+msgid "Program shutdown"
+msgstr "Programavslut"
+
+#: ulng.rsmsglogprogramstart
+msgid "Program start"
+msgstr "Programstart"
+
+#: ulng.rsmsglogrmdir
+#, object-pascal-format
+msgid "Remove directory %s"
+msgstr "Ta bort katalog %s"
+
+#: ulng.rsmsglogsuccess
+msgid "Done: "
+msgstr "Klart: "
+
+#: ulng.rsmsglogsymlink
+#, object-pascal-format
+msgid "Create symlink %s"
+msgstr "Skapa symbolisk länk %s"
+
+#: ulng.rsmsglogtest
+#, object-pascal-format
+msgid "Test file integrity %s"
+msgstr "Testa filintegritet %s"
+
+#: ulng.rsmsglogwipe
+#, object-pascal-format
+msgid "Wipe file %s"
+msgstr "Säker radering av fil %s"
+
+#: ulng.rsmsglogwipedir
+#, object-pascal-format
+msgid "Wipe directory %s"
+msgstr "Säker radering av katalog %s"
+
+#: ulng.rsmsgmasterpassword
+msgctxt "ulng.rsmsgmasterpassword"
+msgid "Main Password"
+msgstr "Huvudlösenord"
+
+#: ulng.rsmsgmasterpasswordenter
+msgid "Please enter the main password:"
+msgstr "Ange huvudlösenordet:"
+
+#: ulng.rsmsgnewfile
+msgid "New file"
+msgstr "Ny fil"
+
+#: ulng.rsmsgnextvolunpack
+msgid "Next volume will be unpacked"
+msgstr "Nästa volym kommer att packas upp"
+
+#: ulng.rsmsgnofiles
+msgid "No files"
+msgstr "Inga filer"
+
+#: ulng.rsmsgnofilesselected
+msgid "No files selected."
+msgstr "Inga filer valda."
+
+#: ulng.rsmsgnofreespacecont
+msgid "No enough free space on target drive, Continue?"
+msgstr "Det finns inte tillräckligt med ledigt utrymme på målenheten. Fortsätta?"
+
+#: ulng.rsmsgnofreespaceretry
+msgid "No enough free space on target drive, Retry?"
+msgstr "Det finns inte tillräckligt med ledigt utrymme på målenheten. Försöka igen?"
+
+#: ulng.rsmsgnotdelete
+#, object-pascal-format
+msgid "Can not delete file %s"
+msgstr "Det går inte att ta bort filen %s"
+
+#: ulng.rsmsgnotimplemented
+msgid "Not implemented."
+msgstr "Inte implementerat."
+
+#: ulng.rsmsgobjectnotexists
+msgid "Object does not exist!"
+msgstr "Objektet finns inte!"
+
+#: ulng.rsmsgopeninanotherprogram
+msgid "The action cannot be completed because the file is open in another program:"
+msgstr "Åtgärden kan inte slutföras eftersom filen är öppen i ett annat program:"
+
+#: ulng.rsmsgpanelpreview
+msgctxt "ulng.rsmsgpanelpreview"
+msgid ""
+"Below is a preview. You may move cursor and select files to get immediately an actual look and "
+"feel of the various settings."
+msgstr ""
+"Nedan visas en förhandsgranskning. Du kan flytta markören och välja filer för att direkt se hur "
+"de olika inställningarna påverkar utseendet."
+
+#: ulng.rsmsgpassword
+msgctxt "ulng.rsmsgpassword"
+msgid "Password:"
+msgstr "Lösenord:"
+
+#: ulng.rsmsgpassworddiff
+msgid "Passwords are different!"
+msgstr "Lösenorden är olika!"
+
+#: ulng.rsmsgpasswordenter
+msgid "Please enter the password:"
+msgstr "Ange lösenordet:"
+
+#: ulng.rsmsgpasswordfirewall
+msgid "Password (Firewall):"
+msgstr "Lösenord (brandvägg):"
+
+#: ulng.rsmsgpasswordverify
+msgid "Please re-enter the password for verification:"
+msgstr "Ange lösenordet igen för verifiering:"
+
+#: ulng.rsmsgpopuphotdelete
+#, object-pascal-format
+msgid "&Delete %s"
+msgstr "&Ta bort %s"
+
+#: ulng.rsmsgpresetalreadyexists
+#, object-pascal-format
+msgid "Preset \"%s\" already exists. Overwrite?"
+msgstr "Förinställningen ”%s” finns redan. Skriva över?"
+
+#: ulng.rsmsgpresetconfigdelete
+#, object-pascal-format
+msgid "Are you sure you want to delete preset \"%s\"?"
+msgstr "Är du säker på att du vill ta bort förinställningen ”%s”?"
+
+#: ulng.rsmsgproblemexecutingcommand
+#, object-pascal-format
+msgid "Problem executing command (%s)"
+msgstr "Problem vid körning av kommandot (%s)"
+
+#: ulng.rsmsgprocessid
+#, object-pascal-format
+msgid "PID: %d"
+msgstr "PID: %d"
+
+#: ulng.rsmsgpromptaskingfilename
+msgid "Filename for dropped text:"
+msgstr "Filnamn för släppt text:"
+
+#: ulng.rsmsgprovidethisfile
+msgid "Please, make this file available. Retry?"
+msgstr "Gör den här filen tillgänglig. Försöka igen?"
+
+#: ulng.rsmsgrenamefavtabs
+msgid "Enter new friendly name for this Favorite Tabs"
+msgstr "Ange ett nytt visningsnamn för den här Favoritfliken"
+
+#: ulng.rsmsgrenamefavtabsmenu
+msgid "Enter new name for this menu"
+msgstr "Ange ett nytt namn för den här menyn"
+
+#: ulng.rsmsgrenfldr
+#, object-pascal-format
+msgid "Rename/move %d selected files/directories?"
+msgstr "Byta namn på/flytta %d valda filer/kataloger?"
+
+#: ulng.rsmsgrensel
+#, object-pascal-format
+msgid "Rename/move selected \"%s\"?"
+msgstr "Byta namn på/flytta det valda objektet ”%s”?"
+
+#: ulng.rsmsgreplacethistext
+msgid "Do you want to replace this text?"
+msgstr "Vill du ersätta den här texten?"
+
+#: ulng.rsmsgrestartforapplychanges
+msgid "Please, restart Double Commander in order to apply changes"
+msgstr "Starta om Double Commander för att tillämpa ändringarna"
+
+#: ulng.rsmsgscriptcantfindlibrary
+#, object-pascal-format
+msgid "ERROR: Problem loading Lua library file \"%s\""
+msgstr "FEL: Problem vid inläsning av Lua-biblioteksfilen ”%s”"
+
+#: ulng.rsmsgsekectfiletype
+#, object-pascal-format
+msgid "Select to which file type to add extension \"%s\""
+msgstr "Välj vilken filtyp filändelsen ”%s” ska läggas till i"
+
+#: ulng.rsmsgselectedinfo
+#, object-pascal-format
+msgid "Selected: %s of %s, files: %d of %d, folders: %d of %d"
+msgstr "Valt: %s av %s, filer: %d av %d, mappar: %d av %d"
+
+#: ulng.rsmsgselectexecutablefile
+msgid "Select executable file for"
+msgstr "Välj körbar fil för"
+
+#: ulng.rsmsgselectonlychecksumfiles
+msgid "Please select only checksum files!"
+msgstr "Välj endast kontrollsummefiler!"
+
+#: ulng.rsmsgsellocnextvol
+msgid "Please select location of next volume"
+msgstr "Välj platsen för nästa volym"
+
+#: ulng.rsmsgsetvolumelabel
+msgid "Set volume label"
+msgstr "Ange volymetikett"
+
+#: ulng.rsmsgspecialdir
+msgid "Special Dirs"
+msgstr "Specialkataloger"
+
+#: ulng.rsmsgspecialdiraddacti
+msgid "Add path from active frame"
+msgstr "Lägg till sökväg från den aktiva panelen"
+
+#: ulng.rsmsgspecialdiraddnonacti
+msgid "Add path from inactive frame"
+msgstr "Lägg till sökväg från den inaktiva panelen"
+
+#: ulng.rsmsgspecialdirbrowssel
+msgid "Browse and use selected path"
+msgstr "Bläddra och använd vald sökväg"
+
+#: ulng.rsmsgspecialdirenvvar
+msgid "Use environment variable..."
+msgstr "Använd miljövariabel..."
+
+#: ulng.rsmsgspecialdirgotodc
+msgid "Go to Double Commander special path..."
+msgstr "Gå till särskild Double Commander-sökväg..."
+
+#: ulng.rsmsgspecialdirgotoenvvar
+msgid "Go to environment variable..."
+msgstr "Gå till miljövariabel..."
+
+#: ulng.rsmsgspecialdirgotoother
+msgid "Go to other Windows special folder..."
+msgstr "Gå till annan särskild Windows-mapp..."
+
+#: ulng.rsmsgspecialdirgototc
+msgid "Go to Windows special folder (TC)..."
+msgstr "Gå till särskild Windows-mapp (TC)..."
+
+#: ulng.rsmsgspecialdirmakereltohotdir
+msgid "Make relative to hotdir path"
+msgstr "Gör relativ till sökvägen för katalogfavoriten"
+
+#: ulng.rsmsgspecialdirmkabso
+msgid "Make path absolute"
+msgstr "Gör sökvägen absolut"
+
+#: ulng.rsmsgspecialdirmkdcrel
+msgid "Make relative to Double Commander special path..."
+msgstr "Gör relativ till särskild Double Commander-sökväg..."
+
+#: ulng.rsmsgspecialdirmkenvrel
+msgid "Make relative to environment variable..."
+msgstr "Gör relativ till miljövariabel..."
+
+#: ulng.rsmsgspecialdirmktctel
+msgid "Make relative to Windows special folder (TC)..."
+msgstr "Gör relativ till särskild Windows-mapp (TC)..."
+
+#: ulng.rsmsgspecialdirmkwnrel
+msgid "Make relative to other Windows special folder..."
+msgstr "Gör relativ till annan särskild Windows-mapp..."
+
+#: ulng.rsmsgspecialdirusedc
+msgid "Use Double Commander special path..."
+msgstr "Använd särskild Double Commander-sökväg..."
+
+#: ulng.rsmsgspecialdirusehotdir
+msgid "Use hotdir path"
+msgstr "Använd sökvägen för katalogfavoriten"
+
+#: ulng.rsmsgspecialdiruseother
+msgid "Use other Windows special folder..."
+msgstr "Använd annan särskild Windows-mapp..."
+
+#: ulng.rsmsgspecialdirusetc
+msgid "Use Windows special folder (TC)..."
+msgstr "Använd särskild Windows-mapp (TC)..."
+
+#: ulng.rsmsgtabforopeninginnewtab
+#, object-pascal-format
+msgid "This tab (%s) is locked! Open directory in another tab?"
+msgstr "Den här fliken (%s) är låst! Öppna katalogen i en annan flik?"
+
+#: ulng.rsmsgtabrenamecaption
+msgid "Rename tab"
+msgstr "Byt namn på flik"
+
+#: ulng.rsmsgtabrenameprompt
+msgid "New tab name:"
+msgstr "Nytt fliknamn:"
+
+#: ulng.rsmsgtargetdir
+msgid "Target path:"
+msgstr "Målsökväg:"
+
+#: ulng.rsmsgtcconfignotfound
+#, object-pascal-format
+msgid ""
+"Error! Cannot find the TC configuration file:\n"
+"%s"
+msgstr ""
+"Fel! Det går inte att hitta TC-konfigurationsfilen:\n"
+"%s"
+
+#: ulng.rsmsgtcexecutablenotfound
+#, object-pascal-format
+msgid ""
+"Error! Cannot find the TC configuration executable:\n"
+"%s"
+msgstr ""
+"Fel! Det går inte att hitta det körbara TC-konfigurationsprogrammet:\n"
+"%s"
+
+#: ulng.rsmsgtcisrunning
+msgid ""
+"Error! TC is still running but it should be closed for this operation.\n"
+"Close it and press OK or press CANCEL to abort."
+msgstr ""
+"Fel! TC körs fortfarande men måste vara stängt för den här åtgärden.\n"
+"Stäng TC och tryck på OK eller tryck på AVBRYT för att avbryta."
+
+#: ulng.rsmsgtctoolbarnotfound
+#, object-pascal-format
+msgid ""
+"Error! Cannot find the desired wanted TC toolbar output folder:\n"
+"%s"
+msgstr ""
+"Fel! Det går inte att hitta den önskade utdatamappen för TC-verktygsfältet:\n"
+"%s"
+
+#: ulng.rsmsgtctoolbarwheretosave
+msgid "Enter location and filename where to save a TC Toolbar file"
+msgstr "Ange plats och filnamn där TC-verktygsfältsfilen ska sparas"
+
+#: ulng.rsmsgterminaldisabled
+msgid "Built-in terminal window disabled. Do you want to enable it?"
+msgstr "Det inbyggda terminalfönstret är inaktiverat. Vill du aktivera det?"
+
+#: ulng.rsmsgterminateprocess
+msgid ""
+"WARNING: Terminating a process can cause undesired results including loss of data and system "
+"instability. The process will not be given the chance to save its state or data before it is "
+"terminated. Are you sure you want to terminate the process?"
+msgstr ""
+"VARNING: Att avsluta en process kan få oönskade följder, bland annat dataförlust och "
+"systeminstabilitet. Processen får inte möjlighet att spara sitt tillstånd eller sina data innan "
+"den avslutas. Är du säker på att du vill avsluta processen?"
+
+#: ulng.rsmsgtestarchive
+msgid "Do you want to test selected archives?"
+msgstr "Vill du testa de valda arkiven?"
+
+#: ulng.rsmsgthisisnowinclipboard
+#, object-pascal-format
+msgid "\"%s\" is now in the clipboard"
+msgstr "”%s” finns nu i urklipp"
+
+#: ulng.rsmsgtitleextnotinfiletype
+msgid "Extension of selected file is not in any recognized file types"
+msgstr "Filändelsen för den valda filen tillhör ingen identifierad filtyp"
+
+#: ulng.rsmsgtoolbarlocatedctoolbarfile
+msgid "Locate \".toolbar\" file to import"
+msgstr "Leta upp ”.toolbar”-filen som ska importeras"
+
+#: ulng.rsmsgtoolbarlocatetctoolbarfile
+msgid "Locate \".BAR\" file to import"
+msgstr "Leta upp ”.BAR”-filen som ska importeras"
+
+#: ulng.rsmsgtoolbarrestorewhat
+msgid "Enter location and filename of Toolbar to restore"
+msgstr "Ange plats och filnamn för verktygsfältet som ska återställas"
+
+#: ulng.rsmsgtoolbarsaved
+#, object-pascal-format
+msgid ""
+"Saved!\n"
+"Toolbar filename: %s"
+msgstr ""
+"Sparat!\n"
+"Verktygsfältets filnamn: %s"
+
+#: ulng.rsmsgtoomanyfilesselected
+msgid "Too many files selected."
+msgstr "För många filer är valda."
+
+#: ulng.rsmsgundeterminednumberoffile
+msgid "Undetermined"
+msgstr "Obestämt"
+
+#: ulng.rsmsgunexpectedusagetreeviewmenu
+msgid "ERROR: Unexpected Tree View Menu usage!"
+msgstr "FEL: Oväntad användning av trädvymenyn!"
+
+#: ulng.rsmsgurl
+msgid "URL:"
+msgstr "URL:"
+
+#: ulng.rsmsguserdidnotsetextension
+msgid "<NO EXT>"
+msgstr "<INGEN FILÄNDELSE>"
+
+#: ulng.rsmsguserdidnotsetname
+msgid "<NO NAME>"
+msgstr "<INGET NAMN>"
+
+#: ulng.rsmsgusername
+msgctxt "ulng.rsmsgusername"
+msgid "User name:"
+msgstr "Användarnamn:"
+
+#: ulng.rsmsgusernamefirewall
+msgid "User name (Firewall):"
+msgstr "Användarnamn (brandvägg):"
+
+#: ulng.rsmsgverify
+msgid "VERIFICATION:"
+msgstr "VERIFIERING:"
+
+#: ulng.rsmsgverifychecksum
+msgid "Do you want to verify selected checksums?"
+msgstr "Vill du verifiera de valda kontrollsummorna?"
+
+#: ulng.rsmsgverifywrong
+msgid "The target file is corrupted, checksum mismatch!"
+msgstr "Målfilen är skadad, kontrollsumman stämmer inte!"
+
+#: ulng.rsmsgvolumelabel
+msgid "Volume label:"
+msgstr "Volymetikett:"
+
+#: ulng.rsmsgvolumesizeenter
+msgid "Please enter the volume size:"
+msgstr "Ange volymstorleken:"
+
+#: ulng.rsmsgwanttoconfigurelibrarylocation
+msgid "Do you want to configure Lua library location?"
+msgstr "Vill du konfigurera platsen för Lua-biblioteket?"
+
+#: ulng.rsmsgwipefldr
+#, object-pascal-format
+msgid "Wipe %d selected files/directories?"
+msgstr "Säkerhetsradera %d valda filer/kataloger?"
+
+#: ulng.rsmsgwipesel
+#, object-pascal-format
+msgid "Wipe selected \"%s\"?"
+msgstr "Säkerhetsradera det valda objektet ”%s”?"
+
+#: ulng.rsmsgwithactionwith
+msgid "with"
+msgstr "med"
+
+#: ulng.rsmsgwrongpasswordtryagain
+msgid ""
+"Wrong password!\n"
+"Please try again!"
+msgstr ""
+"Fel lösenord!\n"
+"Försök igen!"
+
+#: ulng.rsmulrenautorename
+msgid "Do auto-rename to \"name (1).ext\", \"name (2).ext\" etc.?"
+msgstr "Vill du automatiskt byta namn till ”namn (1).ext”, ”namn (2).ext” osv.?"
+
+#: ulng.rsmulrencounter
+msgctxt "ulng.rsmulrencounter"
+msgid "Counter"
+msgstr "Räknare"
+
+#: ulng.rsmulrendate
+msgctxt "ulng.rsmulrendate"
+msgid "Date"
+msgstr "Datum"
+
+#: ulng.rsmulrendefaultpresetname
+msgid "Preset name"
+msgstr "Förinställningens namn"
+
+#: ulng.rsmulrendefinevariablename
+msgid "Define variable name"
+msgstr "Definiera variabelnamn"
+
+#: ulng.rsmulrendefinevariablevalue
+msgid "Define variable value"
+msgstr "Definiera variabelvärde"
+
+#: ulng.rsmulrenenternameforvar
+msgid "Enter variable name"
+msgstr "Ange variabelnamn"
+
+#: ulng.rsmulrenentervalueforvar
+#, object-pascal-format
+msgid "Enter value for variable \"%s\""
+msgstr "Ange värde för variabeln ”%s”"
+
+#: ulng.rsmulrenexitmodifiedpresetoptions
+msgid "Ignore, just save as the [Last One];Prompt user to confirm if we save it;Save automatically"
+msgstr "Ignorera, spara bara som [Senaste];Fråga användaren om den ska sparas;Spara automatiskt"
+
+#: ulng.rsmulrenextension
+msgctxt "ulng.rsmulrenextension"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: ulng.rsmulrenfilename
+msgctxt "ulng.rsmulrenfilename"
+msgid "Name"
+msgstr "Namn"
+
+#: ulng.rsmulrenfilenamestylelist
+msgid "No change;UPPERCASE;lowercase;First char uppercase;First Char Of Every Word Uppercase;"
+msgstr "Ingen ändring;VERSALER;gemener;Första tecknet versalt;Första Tecknet I Varje Ord Versalt;"
+
+#: ulng.rsmulrenlastpreset
+msgid "[The last used]"
+msgstr "[Senast använda]"
+
+#: ulng.rsmulrenlaunchbehavioroptions
+msgid "Last masks under [Last One] preset;Last preset;New fresh masks"
+msgstr "Senaste masker under förinställningen [Senaste];Senaste förinställning;Nya tomma masker"
+
+#: ulng.rsmulrenlogstart
+msgctxt "ulng.rsmulrenlogstart"
+msgid "Multi-Rename Tool"
+msgstr "Verktyg för massomdöpning"
+
+#: ulng.rsmulrenmaskcharatposx
+msgid "Character at position x"
+msgstr "Tecken vid position x"
+
+#: ulng.rsmulrenmaskcharatposxtoy
+msgid "Characters from position x to y"
+msgstr "Tecken från position x till y"
+
+#: ulng.rsmulrenmaskcompletedate
+msgid "Complete date"
+msgstr "Fullständigt datum"
+
+#: ulng.rsmulrenmaskcompletetime
+msgid "Complete time"
+msgstr "Fullständig tid"
+
+#: ulng.rsmulrenmaskcounter
+msgctxt "ulng.rsmulrenmaskcounter"
+msgid "Counter"
+msgstr "Räknare"
+
+#: ulng.rsmulrenmaskday
+msgid "Day"
+msgstr "Dag"
+
+#: ulng.rsmulrenmaskday2digits
+msgid "Day (2 digits)"
+msgstr "Dag (2 siffror)"
+
+#: ulng.rsmulrenmaskdowabrev
+msgid "Day of the week (short, e.g., \"mon\")"
+msgstr "Veckodag (kort, t.ex. ”mån”)"
+
+#: ulng.rsmulrenmaskdowcomplete
+msgid "Day of the week (long, e.g., \"monday\")"
+msgstr "Veckodag (lång, t.ex. ”måndag”)"
+
+#: ulng.rsmulrenmaskextension
+msgctxt "ulng.rsmulrenmaskextension"
+msgid "Extension"
+msgstr "Filändelse"
+
+#: ulng.rsmulrenmaskfullname
+msgid "Complete filename with path and extension"
+msgstr "Fullständigt filnamn med sökväg och filändelse"
+
+#: ulng.rsmulrenmaskfullnamecharatposxtoy
+msgid "Complete filename, char from pos x to y"
+msgstr "Fullständigt filnamn, tecken från position x till y"
+
+#: ulng.rsmulrenmaskguid
+msgid "GUID"
+msgstr "GUID"
+
+#: ulng.rsmulrenmaskhour
+msgid "Hour"
+msgstr "Timme"
+
+#: ulng.rsmulrenmaskhour2digits
+msgid "Hour (2 digits)"
+msgstr "Timme (2 siffror)"
+
+#: ulng.rsmulrenmaskmin
+msgid "Minute"
+msgstr "Minut"
+
+#: ulng.rsmulrenmaskmin2digits
+msgid "Minute (2 digits)"
+msgstr "Minut (2 siffror)"
+
+#: ulng.rsmulrenmaskmonth
+msgid "Month"
+msgstr "Månad"
+
+#: ulng.rsmulrenmaskmonth2digits
+msgid "Month (2 digits)"
+msgstr "Månad (2 siffror)"
+
+#: ulng.rsmulrenmaskmonthabrev
+msgid "Month name (short, e.g., \"jan\")"
+msgstr "Månadsnamn (kort, t.ex. ”jan”)"
+
+#: ulng.rsmulrenmaskmonthcomplete
+msgid "Month name (long, e.g., \"january\")"
+msgstr "Månadsnamn (långt, t.ex. ”januari”)"
+
+#: ulng.rsmulrenmaskname
+msgctxt "ulng.rsmulrenmaskname"
+msgid "Name"
+msgstr "Namn"
+
+#: ulng.rsmulrenmaskparent
+msgid "Parent folder(s)"
+msgstr "Överordnad(e) mapp(ar)"
+
+#: ulng.rsmulrenmasksec
+msgid "Second"
+msgstr "Sekund"
+
+#: ulng.rsmulrenmasksec2digits
+msgid "Second (2 digits)"
+msgstr "Sekund (2 siffror)"
+
+#: ulng.rsmulrenmaskvaronthefly
+msgid "Variable on the fly"
+msgstr "Variabel i farten"
+
+#: ulng.rsmulrenmaskyear2digits
+msgid "Year (2 digits)"
+msgstr "År (2 siffror)"
+
+#: ulng.rsmulrenmaskyear4digits
+msgid "Year (4 digits)"
+msgstr "År (4 siffror)"
+
+#: ulng.rsmulrenplugins
+msgctxt "ulng.rsmulrenplugins"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: ulng.rsmulrenpromptforsavedpresetname
+msgid "Save preset as"
+msgstr "Spara förinställning som"
+
+#: ulng.rsmulrenpromptnewnameexists
+msgid "Preset name already exists. Overwrite?"
+msgstr "Förinställningsnamnet finns redan. Skriva över?"
+
+#: ulng.rsmulrenpromptnewpresetname
+msgid "Enter new preset name"
+msgstr "Ange nytt namn på förinställningen"
+
+#: ulng.rsmulrensavemodifiedpreset
+#, object-pascal-format
+msgid ""
+"\"%s\" preset has been modified.\n"
+"Do you want to save it now?"
+msgstr ""
+"Förinställningen ”%s” har ändrats.\n"
+"Vill du spara den nu?"
+
+#: ulng.rsmulrensortingpresets
+msgid "Sorting presets"
+msgstr "Sortera förinställningar"
+
+#: ulng.rsmulrentime
+msgctxt "ulng.rsmulrentime"
+msgid "Time"
+msgstr "Tid"
+
+#: ulng.rsmulrenwarningduplicate
+msgid "Warning, duplicate names!"
+msgstr "Varning, dubbla namn!"
+
+#: ulng.rsmulrenwronglinesnumber
+#, object-pascal-format
+msgid "File contains wrong number of lines: %d, should be %d!"
+msgstr "Filen innehåller fel antal rader: %d, ska vara %d!"
+
+#: ulng.rsnewsearchclearfilteroptions
+msgid "Keep;Clear;Prompt"
+msgstr "Behåll;Rensa;Fråga"
+
+#: ulng.rsnoequivalentinternalcommand
+msgid "No internal equivalent command"
+msgstr "Inget internt motsvarande kommando"
+
+#: ulng.rsnofindfileswindowyet
+msgid "Sorry, no \"Find files\" window yet..."
+msgstr "Tyvärr, det finns inget fönster för ”Sök filer” ännu..."
+
+#: ulng.rsnootherfindfileswindowtoclose
+msgid "Sorry, no other \"Find files\" window to close and free from memory..."
+msgstr "Tyvärr, det finns inget annat ”Sök filer”-fönster att stänga och frigöra från minnet..."
+
+#: ulng.rsopenwithdevelopment
+msgid "Development"
+msgstr "Utveckling"
+
+#: ulng.rsopenwitheducation
+msgid "Education"
+msgstr "Utbildning"
+
+#: ulng.rsopenwithgames
+msgid "Games"
+msgstr "Spel"
+
+#: ulng.rsopenwithgraphics
+msgctxt "ulng.rsopenwithgraphics"
+msgid "Graphics"
+msgstr "Grafik"
+
+#: ulng.rsopenwithmacosfilter
+msgid "Applications (*.app)|*.app|All files (*)|*"
+msgstr "Program (*.app)|*.app|Alla filer (*)|*"
+
+#: ulng.rsopenwithmultimedia
+msgid "Multimedia"
+msgstr "Multimedia"
+
+#: ulng.rsopenwithnetwork
+msgctxt "ulng.rsopenwithnetwork"
+msgid "Network"
+msgstr "Nätverk"
+
+#: ulng.rsopenwithoffice
+msgid "Office"
+msgstr "Kontor"
+
+#: ulng.rsopenwithother
+msgctxt "ulng.rsopenwithother"
+msgid "Other"
+msgstr "Övrigt"
+
+#: ulng.rsopenwithscience
+msgid "Science"
+msgstr "Vetenskap"
+
+#: ulng.rsopenwithsettings
+msgid "Settings"
+msgstr "Inställningar"
+
+#: ulng.rsopenwithsystem
+msgctxt "ulng.rsopenwithsystem"
+msgid "System"
+msgstr "System"
+
+#: ulng.rsopenwithutility
+msgid "Accessories"
+msgstr "Tillbehör"
+
+#: ulng.rsoperaborted
+msgid "Aborted"
+msgstr "Avbruten"
+
+#: ulng.rsopercalculatingchecksum
+msgid "Calculating checksum"
+msgstr "Beräknar kontrollsumma"
+
+#: ulng.rsopercalculatingchecksumin
+#, object-pascal-format
+msgid "Calculating checksum in \"%s\""
+msgstr "Beräknar kontrollsumma i ”%s”"
+
+#: ulng.rsopercalculatingchecksumof
+#, object-pascal-format
+msgid "Calculating checksum of \"%s\""
+msgstr "Beräknar kontrollsumma för ”%s”"
+
+#: ulng.rsopercalculatingstatictics
+msgid "Calculating"
+msgstr "Beräknar"
+
+#: ulng.rsopercalculatingstatisticsin
+#, object-pascal-format
+msgid "Calculating \"%s\""
+msgstr "Beräknar ”%s”"
+
+#: ulng.rsopercombining
+msgid "Joining"
+msgstr "Sammanfogar"
+
+#: ulng.rsopercombiningfromto
+#, object-pascal-format
+msgid "Joining files in \"%s\" to \"%s\""
+msgstr "Sammanfogar filer i ”%s” till ”%s”"
+
+#: ulng.rsopercopying
+msgid "Copying"
+msgstr "Kopierar"
+
+#: ulng.rsopercopyingfromto
+#, object-pascal-format
+msgid "Copying from \"%s\" to \"%s\""
+msgstr "Kopierar från ”%s” till ”%s”"
+
+#: ulng.rsopercopyingsomethingto
+#, object-pascal-format
+msgid "Copying \"%s\" to \"%s\""
+msgstr "Kopierar ”%s” till ”%s”"
+
+#: ulng.rsopercreatingdirectory
+msgid "Creating directory"
+msgstr "Skapar katalog"
+
+#: ulng.rsopercreatingsomedirectory
+#, object-pascal-format
+msgid "Creating directory \"%s\""
+msgstr "Skapar katalogen ”%s”"
+
+#: ulng.rsoperdeleting
+msgid "Deleting"
+msgstr "Tar bort"
+
+#: ulng.rsoperdeletingin
+#, object-pascal-format
+msgid "Deleting in \"%s\""
+msgstr "Tar bort i ”%s”"
+
+#: ulng.rsoperdeletingsomething
+#, object-pascal-format
+msgid "Deleting \"%s\""
+msgstr "Tar bort ”%s”"
+
+#: ulng.rsoperexecuting
+msgid "Executing"
+msgstr "Kör"
+
+#: ulng.rsoperexecutingsomething
+#, object-pascal-format
+msgid "Executing \"%s\""
+msgstr "Kör ”%s”"
+
+#: ulng.rsoperextracting
+msgid "Extracting"
+msgstr "Packar upp"
+
+#: ulng.rsoperextractingfromto
+#, object-pascal-format
+msgid "Extracting from \"%s\" to \"%s\""
+msgstr "Packar upp från ”%s” till ”%s”"
+
+#: ulng.rsoperfinished
+msgid "Finished"
+msgstr "Slutförd"
+
+#: ulng.rsoperlisting
+msgid "Listing"
+msgstr "Listar"
+
+#: ulng.rsoperlistingin
+#, object-pascal-format
+msgid "Listing \"%s\""
+msgstr "Listar ”%s”"
+
+#: ulng.rsopermoving
+msgid "Moving"
+msgstr "Flyttar"
+
+#: ulng.rsopermovingfromto
+#, object-pascal-format
+msgid "Moving from \"%s\" to \"%s\""
+msgstr "Flyttar från ”%s” till ”%s”"
+
+#: ulng.rsopermovingsomethingto
+#, object-pascal-format
+msgid "Moving \"%s\" to \"%s\""
+msgstr "Flyttar ”%s” till ”%s”"
+
+#: ulng.rsopernotstarted
+msgid "Not started"
+msgstr "Inte startad"
+
+#: ulng.rsoperpacking
+msgid "Packing"
+msgstr "Packar"
+
+#: ulng.rsoperpackingfromto
+#, object-pascal-format
+msgid "Packing from \"%s\" to \"%s\""
+msgstr "Packar från ”%s” till ”%s”"
+
+#: ulng.rsoperpackingsomethingto
+#, object-pascal-format
+msgid "Packing \"%s\" to \"%s\""
+msgstr "Packar ”%s” till ”%s”"
+
+#: ulng.rsoperpaused
+msgid "Paused"
+msgstr "Pausad"
+
+#: ulng.rsoperpausing
+msgid "Pausing"
+msgstr "Pausar"
+
+#: ulng.rsoperrunning
+msgid "Running"
+msgstr "Körs"
+
+#: ulng.rsopersettingproperty
+msgid "Setting property"
+msgstr "Anger egenskap"
+
+#: ulng.rsopersettingpropertyin
+#, object-pascal-format
+msgid "Setting property in \"%s\""
+msgstr "Anger egenskap i ”%s”"
+
+#: ulng.rsopersettingpropertyof
+#, object-pascal-format
+msgid "Setting property of \"%s\""
+msgstr "Anger egenskap för ”%s”"
+
+#: ulng.rsopersplitting
+msgid "Splitting"
+msgstr "Delar upp"
+
+#: ulng.rsopersplittingfromto
+#, object-pascal-format
+msgid "Splitting \"%s\" to \"%s\""
+msgstr "Delar upp ”%s” till ”%s”"
+
+#: ulng.rsoperstarting
+msgid "Starting"
+msgstr "Startar"
+
+#: ulng.rsoperstopped
+msgid "Stopped"
+msgstr "Stoppad"
+
+#: ulng.rsoperstopping
+msgid "Stopping"
+msgstr "Stoppar"
+
+#: ulng.rsopertesting
+msgid "Testing"
+msgstr "Testar"
+
+#: ulng.rsopertestingin
+#, object-pascal-format
+msgid "Testing in \"%s\""
+msgstr "Testar i ”%s”"
+
+#: ulng.rsopertestingsomething
+#, object-pascal-format
+msgid "Testing \"%s\""
+msgstr "Testar ”%s”"
+
+#: ulng.rsoperverifyingchecksum
+msgid "Verifying checksum"
+msgstr "Verifierar kontrollsumma"
+
+#: ulng.rsoperverifyingchecksumin
+#, object-pascal-format
+msgid "Verifying checksum in \"%s\""
+msgstr "Verifierar kontrollsumma i ”%s”"
+
+#: ulng.rsoperverifyingchecksumof
+#, object-pascal-format
+msgid "Verifying checksum of \"%s\""
+msgstr "Verifierar kontrollsumma för ”%s”"
+
+#: ulng.rsoperwaitingforconnection
+msgid "Waiting for access to file source"
+msgstr "Väntar på åtkomst till filkällan"
+
+#: ulng.rsoperwaitingforfeedback
+msgid "Waiting for user response"
+msgstr "Väntar på användarsvar"
+
+#: ulng.rsoperwiping
+msgid "Wiping"
+msgstr "Säkerhetsraderar"
+
+#: ulng.rsoperwipingin
+#, object-pascal-format
+msgid "Wiping in \"%s\""
+msgstr "Säkerhetsraderar i ”%s”"
+
+#: ulng.rsoperwipingsomething
+#, object-pascal-format
+msgid "Wiping \"%s\""
+msgstr "Säkerhetsraderar ”%s”"
+
+#: ulng.rsoperworking
+msgid "Working"
+msgstr "Arbetar"
+
+#: ulng.rsoptaddfrommainpanel
+msgid "Add at &beginning;Add at the end;Smart add"
+msgstr "Lägg till i &början;Lägg till i slutet;Smart tillägg"
+
+#: ulng.rsoptaddingtooltipfiletype
+msgid "Adding new tooltip file type"
+msgstr "Lägger till ny filtyp för verktygstips"
+
+#: ulng.rsoptarchiveconfiguresavetochange
+msgid "To change current editing archive configuration, either APPLY or DELETE current editing one"
+msgstr ""
+"För att ändra den arkivkonfiguration som redigeras måste du antingen VERKSTÄLLA eller TA BORT den"
+" aktuella konfigurationen"
+
+#: ulng.rsoptarchiveradditonalcmd
+msgid "Mode dependent, additional command"
+msgstr "Lägesberoende extrakommando"
+
+#: ulng.rsoptarchiveraddonlynotempty
+msgid "Add if it is non-empty"
+msgstr "Lägg till om den inte är tom"
+
+#: ulng.rsoptarchiverarchivel
+msgid "Archive File (long name)"
+msgstr "Arkivfil (långt namn)"
+
+#: ulng.rsoptarchiverarchiver
+msgid "Select archiver executable"
+msgstr "Välj körbart arkiveringsprogram"
+
+#: ulng.rsoptarchiverarchives
+msgid "Archive file (short name)"
+msgstr "Arkivfil (kort namn)"
+
+#: ulng.rsoptarchiverchangeencoding
+msgid "Change Archiver Listing Encoding"
+msgstr "Ändra teckenkodning för arkiveringsprogrammets listning"
+
+#: ulng.rsoptarchiverconfirmdelete
+#, object-pascal-format
+msgctxt "ulng.rsoptarchiverconfirmdelete"
+msgid "Are you sure you want to delete: \"%s\"?"
+msgstr "Är du säker på att du vill ta bort: ”%s”?"
+
+#: ulng.rsoptarchiverdefaultexportfilename
+msgid "Exported Archiver Configuration"
+msgstr "Exporterad arkiveringskonfiguration"
+
+#: ulng.rsoptarchivererrorlevel
+msgid "errorlevel"
+msgstr "felnivå"
+
+#: ulng.rsoptarchiverexportcaption
+msgid "Export archiver configuration"
+msgstr "Exportera arkiveringskonfiguration"
+
+#: ulng.rsoptarchiverexportdone
+#, object-pascal-format
+msgctxt "ulng.rsoptarchiverexportdone"
+msgid "Exportation of %d elements to file \"%s\" completed."
+msgstr "Export av %d element till filen ”%s” slutförd."
+
+#: ulng.rsoptarchiverexportprompt
+msgctxt "ulng.rsoptarchiverexportprompt"
+msgid "Select the one(s) you want to export"
+msgstr "Välj den eller de som du vill exportera"
+
+#: ulng.rsoptarchiverfilelistl
+msgid "Filelist (long names)"
+msgstr "Fillista (långa namn)"
+
+#: ulng.rsoptarchiverfilelists
+msgid "Filelist (short names)"
+msgstr "Fillista (korta namn)"
+
+#: ulng.rsoptarchiverimportcaption
+msgid "Import archiver configuration"
+msgstr "Importera arkiveringskonfiguration"
+
+#: ulng.rsoptarchiverimportdone
+#, object-pascal-format
+msgctxt "ulng.rsoptarchiverimportdone"
+msgid "Importation of %d elements from file \"%s\" completed."
+msgstr "Import av %d element från filen ”%s” slutförd."
+
+#: ulng.rsoptarchiverimportfile
+msgid "Select the file to import archiver configuration(s)"
+msgstr "Välj filen som arkiveringskonfiguration(er) ska importeras från"
+
+#: ulng.rsoptarchiverimportprompt
+msgctxt "ulng.rsoptarchiverimportprompt"
+msgid "Select the one(s) you want to import"
+msgstr "Välj den eller de som du vill importera"
+
+#: ulng.rsoptarchiverjustname
+msgid "Use name only, without path"
+msgstr "Använd endast namn, utan sökväg"
+
+#: ulng.rsoptarchiverjustpath
+msgid "Use path only, without name"
+msgstr "Använd endast sökväg, utan namn"
+
+#: ulng.rsoptarchiverprograml
+msgid "Archive Program (long name)"
+msgstr "Arkiveringsprogram (långt namn)"
+
+#: ulng.rsoptarchiverprograms
+msgid "Archive Program (short name)"
+msgstr "Arkiveringsprogram (kort namn)"
+
+#: ulng.rsoptarchiverquoteall
+msgid "Quote all names"
+msgstr "Sätt alla namn inom citattecken"
+
+#: ulng.rsoptarchiverquotewithspace
+msgid "Quote names with spaces"
+msgstr "Sätt namn med blanksteg inom citattecken"
+
+#: ulng.rsoptarchiversinglefprocess
+msgid "Single filename to process"
+msgstr "Ett filnamn att bearbeta"
+
+#: ulng.rsoptarchivertargetsubdir
+msgid "Target subdirecory"
+msgstr "Målunderkatalog"
+
+#: ulng.rsoptarchiveruseansi
+msgid "Use ANSI encoding"
+msgstr "Använd ANSI-kodning"
+
+#: ulng.rsoptarchiveruseutf8
+msgid "Use UTF8 encoding"
+msgstr "Använd UTF-8-kodning"
+
+#: ulng.rsoptarchiverwheretosave
+msgid "Enter location and filename where to save archiver configuration"
+msgstr "Ange plats och filnamn där arkiveringskonfigurationen ska sparas"
+
+#: ulng.rsoptarchivetypename
+msgid "Archive type name:"
+msgstr "Arkivtypens namn:"
+
+#: ulng.rsoptassocpluginwith
+#, object-pascal-format
+msgid "Associate plugin \"%s\" with:"
+msgstr "Associera insticksmodulen ”%s” med:"
+
+#: ulng.rsoptautosizecolumn
+msgid "First;Last;"
+msgstr "Först;Sist;"
+
+#: ulng.rsoptconfigsortorder
+msgid "Classic, legacy order;Alphabetic order (but language still first)"
+msgstr "Klassisk äldre ordning;Alfabetisk ordning (men språk först)"
+
+#: ulng.rsoptconfigtreestate
+msgid "Full expand;Full collapse"
+msgstr "Fäll ut helt;Fäll ihop helt"
+
+#: ulng.rsoptdifferframeposition
+msgid "Active frame panel on left, inactive on right (legacy);Left frame panel on left, right on right"
+msgstr "Aktiv panel till vänster, inaktiv till höger (äldre);Vänster panel till vänster, höger till höger"
+
+#: ulng.rsoptenterext
+msgid "Enter extension"
+msgstr "Ange filändelse"
+
+#: ulng.rsoptfavoritetabswheretoaddinlist
+msgid "Add at beginning;Add at the end;Alphabetical sort"
+msgstr "Lägg till i början;Lägg till i slutet;Sortera alfabetiskt"
+
+#: ulng.rsoptfileoperationsprogresskind
+msgid "separate window;minimized separate window;operations panel"
+msgstr "separat fönster;minimerat separat fönster;åtgärdspanel"
+
+#: ulng.rsoptfilesizefloat
+msgid "float"
+msgstr "dynamisk"
+
+#: ulng.rsopthotkeysadddeleteshortcutlong
+#, object-pascal-format
+msgid "Shortcut %s for cm_Delete will be registered, so it can be used to reverse this setting."
+msgstr ""
+"Kortkommandot %s för cm_Delete registreras så att det kan användas för att vända på den här "
+"inställningen."
+
+#: ulng.rsopthotkeysaddhotkey
+#, object-pascal-format
+msgid "Add hotkey for %s"
+msgstr "Lägg till kortkommando för %s"
+
+#: ulng.rsopthotkeysaddshortcutbutton
+msgid "Add shortcut"
+msgstr "Lägg till kortkommando"
+
+#: ulng.rsopthotkeyscannotsetshortcut
+msgid "Cannot set shortcut"
+msgstr "Det går inte att ange kortkommandot"
+
+#: ulng.rsopthotkeyschangeshortcut
+msgid "Change shortcut"
+msgstr "Ändra kortkommando"
+
+#: ulng.rsopthotkeyscommand
+msgctxt "ulng.rsopthotkeyscommand"
+msgid "Command"
+msgstr "Kommando"
+
+#: ulng.rsopthotkeysdeletetrashcanoverrides
+#, object-pascal-format
+msgid ""
+"Shortcut %s for cm_Delete has a parameter that overrides this setting. Do you want to change this"
+" parameter to use the global setting?"
+msgstr ""
+"Kortkommandot %s för cm_Delete har en parameter som åsidosätter den här inställningen. Vill du "
+"ändra parametern så att den globala inställningen används?"
+
+#: ulng.rsopthotkeysdeletetrashcanparameterexists
+#, object-pascal-format
+msgid ""
+"Shortcut %s for cm_Delete needs to have a parameter changed to match shortcut %s. Do you want to "
+"change it?"
+msgstr ""
+"Kortkommandot %s för cm_Delete behöver få en parameter ändrad för att matcha kortkommandot %s. "
+"Vill du ändra den?"
+
+#: ulng.rsopthotkeysdescription
+msgctxt "ulng.rsopthotkeysdescription"
+msgid "Description"
+msgstr "Beskrivning"
+
+#: ulng.rsopthotkeysedithotkey
+#, object-pascal-format
+msgid "Edit hotkey for %s"
+msgstr "Redigera kortkommando för %s"
+
+#: ulng.rsopthotkeysfixparameter
+msgid "Fix parameter"
+msgstr "Korrigera parameter"
+
+#: ulng.rsopthotkeyshotkey
+msgctxt "ulng.rsopthotkeyshotkey"
+msgid "Hotkey"
+msgstr "Kortkommando"
+
+#: ulng.rsopthotkeyshotkeys
+msgctxt "ulng.rsopthotkeyshotkeys"
+msgid "Hotkeys"
+msgstr "Kortkommandon"
+
+#: ulng.rsopthotkeysnohotkey
+msgid "<none>"
+msgstr "<inget>"
+
+#: ulng.rsopthotkeysparameters
+msgctxt "ulng.rsopthotkeysparameters"
+msgid "Parameters"
+msgstr "Parametrar"
+
+#: ulng.rsopthotkeyssetdeleteshortcut
+msgid "Set shortcut to delete file"
+msgstr "Ange kortkommando för att ta bort fil"
+
+#: ulng.rsopthotkeysshortcutfordeletealreadyassigned
+#, object-pascal-format
+msgid ""
+"For this setting to work with shortcut %s, shortcut %s must be assigned to cm_Delete but it is "
+"already assigned to %s. Do you want to change it?"
+msgstr ""
+"För att den här inställningen ska fungera med kortkommandot %s måste kortkommandot %s tilldelas "
+"cm_Delete, men det är redan tilldelat %s. Vill du ändra det?"
+
+#: ulng.rsopthotkeysshortcutfordeleteissequence
+#, object-pascal-format
+msgid ""
+"Shortcut %s for cm_Delete is a sequence shortcut for which a hotkey with reversed Shift cannot be"
+" assigned. This setting might not work."
+msgstr ""
+"Kortkommandot %s för cm_Delete är ett sekvenskortkommando som inte kan tilldelas ett kortkommando"
+" med omvänd Skift. Den här inställningen kanske inte fungerar."
+
+#: ulng.rsopthotkeysshortcutused
+msgid "Shortcut in use"
+msgstr "Kortkommandot används"
+
+#: ulng.rsopthotkeysshortcutusedtext1
+#, object-pascal-format
+msgid "Shortcut %s is already used."
+msgstr "Kortkommandot %s används redan."
+
+#: ulng.rsopthotkeysshortcutusedtext2
+#, object-pascal-format
+msgid "Change it to %s?"
+msgstr "Ändra det till %s?"
+
+#: ulng.rsopthotkeysusedby
+#, object-pascal-format
+msgid "used for %s in %s"
+msgstr "används för %s i %s"
+
+#: ulng.rsopthotkeysusedwithdifferentparams
+msgid "used for this command but with different parameters"
+msgstr "används för det här kommandot men med andra parametrar"
+
+#: ulng.rsoptionseditorarchivers
+msgid "Archivers"
+msgstr "Arkiveringsprogram"
+
+#: ulng.rsoptionseditorautorefresh
+msgid "Auto refresh"
+msgstr "Automatisk uppdatering"
+
+#: ulng.rsoptionseditorbehavior
+msgid "Behaviors"
+msgstr "Beteenden"
+
+#: ulng.rsoptionseditorbriefview
+msgid "Brief"
+msgstr "Kompakt"
+
+#: ulng.rsoptionseditorcolors
+msgid "Colors"
+msgstr "Färger"
+
+#: ulng.rsoptionseditorcolumnsview
+msgid "Columns"
+msgstr "Kolumner"
+
+#: ulng.rsoptionseditorconfiguration
+msgctxt "ulng.rsoptionseditorconfiguration"
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: ulng.rsoptionseditorcustomcolumns
+msgid "Custom columns"
+msgstr "Anpassade kolumner"
+
+#: ulng.rsoptionseditordirectoryhotlist
+msgctxt "ulng.rsoptionseditordirectoryhotlist"
+msgid "Directory Hotlist"
+msgstr "Katalogfavoriter"
+
+#: ulng.rsoptionseditordirectoryhotlistextra
+msgid "Directory Hotlist Extra"
+msgstr "Katalogfavoriter – extra"
+
+#: ulng.rsoptionseditordraganddrop
+msgid "Drag & drop"
+msgstr "Dra och släpp"
+
+#: ulng.rsoptionseditordriveslistbutton
+msgid "Drives list button"
+msgstr "Knapp för enhetslista"
+
+#: ulng.rsoptionseditorfavoritetabs
+msgctxt "ulng.rsoptionseditorfavoritetabs"
+msgid "Favorite Tabs"
+msgstr "Favoritflikar"
+
+#: ulng.rsoptionseditorfileassicextra
+msgid "File associations extra"
+msgstr "Filassociationer – extra"
+
+#: ulng.rsoptionseditorfileassoc
+msgid "File associations"
+msgstr "Filassociationer"
+
+#: ulng.rsoptionseditorfilenewfiletypes
+msgctxt "ulng.rsoptionseditorfilenewfiletypes"
+msgid "New"
+msgstr "Ny"
+
+#: ulng.rsoptionseditorfileoperations
+msgctxt "ulng.rsoptionseditorfileoperations"
+msgid "File operations"
+msgstr "Filåtgärder"
+
+#: ulng.rsoptionseditorfilepanels
+msgid "File panels"
+msgstr "Filpaneler"
+
+#: ulng.rsoptionseditorfilesearch
+msgctxt "ulng.rsoptionseditorfilesearch"
+msgid "File search"
+msgstr "Filsökning"
+
+#: ulng.rsoptionseditorfilesviews
+msgid "Files views"
+msgstr "Filvyer"
+
+#: ulng.rsoptionseditorfilesviewscomplement
+msgid "Files views extra"
+msgstr "Filvyer – extra"
+
+#: ulng.rsoptionseditorfiletypes
+msgctxt "ulng.rsoptionseditorfiletypes"
+msgid "File types"
+msgstr "Filtyper"
+
+#: ulng.rsoptionseditorfoldertabs
+msgctxt "ulng.rsoptionseditorfoldertabs"
+msgid "Folder tabs"
+msgstr "Mappflikar"
+
+#: ulng.rsoptionseditorfoldertabsextra
+msgid "Folder tabs extra"
+msgstr "Mappflikar – extra"
+
+#: ulng.rsoptionseditorfonts
+msgctxt "ulng.rsoptionseditorfonts"
+msgid "Fonts"
+msgstr "Teckensnitt"
+
+#: ulng.rsoptionseditorhighlighters
+msgid "Highlighters"
+msgstr "Framhävningar"
+
+#: ulng.rsoptionseditorhotkeys
+msgid "Hot keys"
+msgstr "Kortkommandon"
+
+#: ulng.rsoptionseditoricons
+msgctxt "ulng.rsoptionseditoricons"
+msgid "Icons"
+msgstr "Ikoner"
+
+#: ulng.rsoptionseditorignorelist
+msgid "Ignore list"
+msgstr "Ignoreringslista"
+
+#: ulng.rsoptionseditorkeyboard
+msgid "Keys"
+msgstr "Tangenter"
+
+#: ulng.rsoptionseditorlanguage
+msgid "Language"
+msgstr "Språk"
+
+#: ulng.rsoptionseditorlayout
+msgid "Layout"
+msgstr "Layout"
+
+#: ulng.rsoptionseditorlog
+msgid "Log"
+msgstr "Logg"
+
+#: ulng.rsoptionseditormiscellaneous
+msgid "Miscellaneous"
+msgstr "Övrigt"
+
+#: ulng.rsoptionseditormouse
+msgid "Mouse"
+msgstr "Mus"
+
+#: ulng.rsoptionseditormultirename
+msgctxt "ulng.rsoptionseditormultirename"
+msgid "Multi-Rename Tool"
+msgstr "Verktyg för massomdöpning"
+
+#: ulng.rsoptionseditoroptionschanged
+#, object-pascal-format
+msgid ""
+"Options have changed in \"%s\"\n"
+"\n"
+"Do you want to save modifications?"
+msgstr ""
+"Alternativen har ändrats i ”%s”\n"
+"\n"
+"Vill du spara ändringarna?"
+
+#: ulng.rsoptionseditorplugins
+msgctxt "ulng.rsoptionseditorplugins"
+msgid "Plugins"
+msgstr "Insticksmoduler"
+
+#: ulng.rsoptionseditorpluginsdsx
+msgid "Search plugins"
+msgstr "Sökinsticksmoduler"
+
+#: ulng.rsoptionseditorpluginswcx
+msgid "Packer plugins"
+msgstr "Packningsinsticksmoduler"
+
+#: ulng.rsoptionseditorpluginswdx
+msgid "Content plugins"
+msgstr "Innehållsinsticksmoduler"
+
+#: ulng.rsoptionseditorpluginswfx
+msgid "File system plugins"
+msgstr "Filsysteminsticksmoduler"
+
+#: ulng.rsoptionseditorpluginswlx
+msgid "Viewer plugins"
+msgstr "Visningsinsticksmoduler"
+
+#: ulng.rsoptionseditorquicksearch
+msgid "Quick search/filter"
+msgstr "Snabbsökning/-filtrering"
+
+#: ulng.rsoptionseditorterminal
+msgctxt "ulng.rsoptionseditorterminal"
+msgid "Terminal"
+msgstr "Terminal"
+
+#: ulng.rsoptionseditortoolbar
+msgid "Toolbar"
+msgstr "Verktygsfält"
+
+#: ulng.rsoptionseditortoolbarextra
+msgid "Toolbar Extra"
+msgstr "Verktygsfält – extra"
+
+#: ulng.rsoptionseditortoolbarmiddle
+msgid "Toolbar Middle"
+msgstr "Mittenverktygsfält"
+
+#: ulng.rsoptionseditortools
+msgid "Tools"
+msgstr "Verktyg"
+
+#: ulng.rsoptionseditortooltips
+msgid "Tooltips"
+msgstr "Verktygstips"
+
+#: ulng.rsoptionseditortreeviewmenu
+msgctxt "ulng.rsoptionseditortreeviewmenu"
+msgid "Tree View Menu"
+msgstr "Trädvymeny"
+
+#: ulng.rsoptionseditortreeviewmenucolors
+msgid "Tree View Menu Colors"
+msgstr "Färger för trädvymeny"
+
+#: ulng.rsoptletters
+msgid "None;Command Line;Quick Search;Quick Filter"
+msgstr "Ingen;Kommandorad;Snabbsökning;Snabbfilter"
+
+#: ulng.rsoptmouseselectionbutton
+msgid "Left button;Right button;"
+msgstr "Vänster knapp;Höger knapp;"
+
+#: ulng.rsoptnewfilesposition
+msgid ""
+"at the top of the file list;after directories (if directories are sorted before files);at sorted "
+"position;at the bottom of the file list"
+msgstr ""
+"överst i fillistan;efter kataloger (om kataloger sorteras före filer);på sorterad plats;längst "
+"ned i fillistan"
+
+#: ulng.rsoptpersonalizedfilesizeformat
+msgid ""
+"Personalized float;Personalized byte;Personalized kilobyte;Personalized megabyte;Personalized "
+"gigabyte;Personalized terabyte"
+msgstr ""
+"Anpassad dynamisk;Anpassade byte;Anpassade kilobyte;Anpassade megabyte;Anpassade "
+"gigabyte;Anpassade terabyte"
+
+#: ulng.rsoptpluginalreadyassigned
+#, object-pascal-format
+msgid "Plugin %s is already assigned for the following extensions:"
+msgstr "Insticksmodulen %s är redan tilldelad följande filändelser:"
+
+#: ulng.rsoptplugindisable
+msgid "D&isable"
+msgstr "&Inaktivera"
+
+#: ulng.rsoptpluginenable
+msgctxt "ulng.rsoptpluginenable"
+msgid "E&nable"
+msgstr "&Aktivera"
+
+#: ulng.rsoptpluginsactive
+msgctxt "ulng.rsoptpluginsactive"
+msgid "Active"
+msgstr "Aktiv"
+
+#: ulng.rsoptpluginsdescription
+msgctxt "ulng.rsoptpluginsdescription"
+msgid "Description"
+msgstr "Beskrivning"
+
+#: ulng.rsoptpluginsfilename
+msgctxt "ulng.rsoptpluginsfilename"
+msgid "File name"
+msgstr "Filnamn"
+
+#: ulng.rsoptpluginshowbyextension
+msgid "By extension"
+msgstr "Efter filändelse"
+
+#: ulng.rsoptpluginshowbyplugin
+msgid "By Plugin"
+msgstr "Efter insticksmodul"
+
+#: ulng.rsoptpluginsname
+msgctxt "ulng.rsoptpluginsname"
+msgid "Name"
+msgstr "Namn"
+
+#: ulng.rsoptpluginsortonlywhenbyextension
+msgid "Sorting WCX plugins is only possible when showing plugins by extension!"
+msgstr "WCX-insticksmoduler kan endast sorteras när insticksmoduler visas efter filändelse!"
+
+#: ulng.rsoptpluginsregisteredfor
+msgctxt "ulng.rsoptpluginsregisteredfor"
+msgid "Registered for"
+msgstr "Registrerad för"
+
+#: ulng.rsoptpluginsselectlualibrary
+msgid "Select Lua library file"
+msgstr "Välj Lua-biblioteksfil"
+
+#: ulng.rsoptrenamingtooltipfiletype
+msgid "Renaming tooltip file type"
+msgstr "Byter namn på filtyp för verktygstips"
+
+#: ulng.rsoptsearchcase
+msgid "&Sensitive;&Insensitive"
+msgstr "&Skiftlägeskänslig;&Inte skiftlägeskänslig"
+
+#: ulng.rsoptsearchitems
+msgid "&Files;Di&rectories;Files a&nd Directories"
+msgstr "&Filer;&Kataloger;Filer &och kataloger"
+
+#: ulng.rsoptsearchopt
+msgid ""
+"Ignore &diacritics and ligatures;&Hide filter panel when not focused;Keep saving setting "
+"modifications for next session"
+msgstr ""
+"Ignorera &diakritiska tecken och ligaturer;&Dölj filterpanelen när den inte har fokus;Fortsätt "
+"spara ändrade inställningar till nästa session"
+
+#: ulng.rsoptsortcasesens
+msgid "not case sensitive;according to locale settings (aAbBcC);first upper then lower case (ABCabc)"
+msgstr ""
+"inte skiftlägeskänslig;enligt språkvariantens inställningar (aAbBcC);först versaler, sedan "
+"gemener (ABCabc)"
+
+#: ulng.rsoptsortfoldermode
+msgid "sort by name and show first;sort like files and show first;sort like files"
+msgstr "sortera efter namn och visa först;sortera som filer och visa först;sortera som filer"
+
+#: ulng.rsoptsortmethod
+msgid ""
+"Alphabetical, considering accents;Alphabetical with special characters sort;Natural sorting: "
+"alphabetical and numbers;Natural with special characters sort"
+msgstr ""
+"Alfabetiskt, med hänsyn till accenter;Alfabetiskt med sortering av specialtecken;Naturlig "
+"sortering: alfabetiskt och numeriskt;Naturlig sortering med specialtecken"
+
+#: ulng.rsopttabsposition
+msgid "Top;Bottom;"
+msgstr "Överst;Nederst;"
+
+#: ulng.rsopttoolbarbuttontype
+msgid "S&eparator;Inte&rnal command;E&xternal command;Men&u"
+msgstr "A&vgränsare;Inte&rnt kommando;E&xternt kommando;Men&y"
+
+#: ulng.rsopttooltipconfiguresavetochange
+msgid "To change file type tooltip configuration, either APPLY or DELETE current editing one"
+msgstr ""
+"För att ändra konfigurationen för filtypsverktygstips måste du antingen VERKSTÄLLA eller TA BORT "
+"den aktuella konfigurationen"
+
+#: ulng.rsopttooltipfiletype
+msgid "Tooltip file type name:"
+msgstr "Namn på filtyp för verktygstips:"
+
+#: ulng.rsopttooltipfiletypealreadyexists
+#, object-pascal-format
+msgid "\"%s\" already exists!"
+msgstr "”%s” finns redan!"
+
+#: ulng.rsopttooltipfiletypeconfirmdelete
+#, object-pascal-format
+msgctxt "ulng.rsopttooltipfiletypeconfirmdelete"
+msgid "Are you sure you want to delete: \"%s\"?"
+msgstr "Är du säker på att du vill ta bort: ”%s”?"
+
+#: ulng.rsopttooltipfiletypedefaultexportfilename
+msgid "Exported tooltip file type configuration"
+msgstr "Exporterad konfiguration för filtypsverktygstips"
+
+#: ulng.rsopttooltipfiletypeexportcaption
+msgid "Export tooltip file type configuration"
+msgstr "Exportera konfiguration för filtypsverktygstips"
+
+#: ulng.rsopttooltipfiletypeexportdone
+#, object-pascal-format
+msgctxt "ulng.rsopttooltipfiletypeexportdone"
+msgid "Exportation of %d elements to file \"%s\" completed."
+msgstr "Export av %d element till filen ”%s” slutförd."
+
+#: ulng.rsopttooltipfiletypeexportprompt
+msgctxt "ulng.rsopttooltipfiletypeexportprompt"
+msgid "Select the one(s) you want to export"
+msgstr "Välj den eller de som du vill exportera"
+
+#: ulng.rsopttooltipfiletypeimportcaption
+msgid "Import tooltip file type configuration"
+msgstr "Importera konfiguration för filtypsverktygstips"
+
+#: ulng.rsopttooltipfiletypeimportdone
+#, object-pascal-format
+msgctxt "ulng.rsopttooltipfiletypeimportdone"
+msgid "Importation of %d elements from file \"%s\" completed."
+msgstr "Import av %d element från filen ”%s” slutförd."
+
+#: ulng.rsopttooltipfiletypeimportfile
+msgid "Select the file to import tooltip file type configuration(s)"
+msgstr "Välj filen som konfiguration(er) för filtypsverktygstips ska importeras från"
+
+#: ulng.rsopttooltipfiletypeimportprompt
+msgctxt "ulng.rsopttooltipfiletypeimportprompt"
+msgid "Select the one(s) you want to import"
+msgstr "Välj den eller de som du vill importera"
+
+#: ulng.rsopttooltipfiletypewheretosave
+msgid "Enter location and filename where to save tooltip file type configuration"
+msgstr "Ange plats och filnamn där konfigurationen för filtypsverktygstips ska sparas"
+
+#: ulng.rsopttooltipsfiletypename
+msgid "Tooltip file type name"
+msgstr "Namn på filtyp för verktygstips"
+
+#: ulng.rsopttypeofduplicatedrename
+msgid "DC legacy - Copy (x) filename.ext;Windows - filename (x).ext;Other - filename(x).ext"
+msgstr "Äldre DC – Kopia (x) filnamn.ext;Windows – filnamn (x).ext;Övrigt – filnamn(x).ext"
+
+#: ulng.rsoptupdatedfilesposition
+msgid "don't change position;use the same setting as for new files;to sorted position"
+msgstr "ändra inte position;använd samma inställning som för nya filer;till sorterad position"
+
+#: ulng.rspluginfilenamestylelist
+msgid "With complete absolute path;Path relative to %COMMANDER_PATH%;Relative to the following"
+msgstr "Med fullständig absolut sökväg;Sökväg relativ till %COMMANDER_PATH%;Relativ till följande"
+
+#: ulng.rspluginsearchcontainscasesenstive
+msgid "contains(case)"
+msgstr "innehåller(skiftläge)"
+
+#: ulng.rspluginsearchcontainsnotcase
+msgid "contains"
+msgstr "innehåller"
+
+#: ulng.rspluginsearchequalcasesensitive
+msgid "=(case)"
+msgstr "=(skiftläge)"
+
+#: ulng.rspluginsearchequalnotcase
+msgctxt "ulng.rspluginsearchequalnotcase"
+msgid "="
+msgstr "="
+
+#: ulng.rspluginsearchfieldnotfound
+#, object-pascal-format
+msgid "Field \"%s\" not found!"
+msgstr "Fältet ”%s” hittades inte!"
+
+#: ulng.rspluginsearchnotcontainscasesenstive
+msgid "!contains(case)"
+msgstr "!innehåller(skiftläge)"
+
+#: ulng.rspluginsearchnotcontainsnotcase
+msgid "!contains"
+msgstr "!innehåller"
+
+#: ulng.rspluginsearchnotequacasesensitive
+msgid "!=(case)"
+msgstr "!=(skiftläge)"
+
+#: ulng.rspluginsearchnotequalnotcase
+msgctxt "ulng.rspluginsearchnotequalnotcase"
+msgid "!="
+msgstr "!="
+
+#: ulng.rspluginsearchnotregexpr
+msgid "!regexp"
+msgstr "!reguttr"
+
+#: ulng.rspluginsearchpluginnotfound
+#, object-pascal-format
+msgid "Plugin \"%s\" not found!"
+msgstr "Insticksmodulen ”%s” hittades inte!"
+
+#: ulng.rspluginsearchregexpr
+msgid "regexp"
+msgstr "reguttr"
+
+#: ulng.rspluginsearchunitnotfoundforfield
+#, object-pascal-format
+msgctxt "ulng.rspluginsearchunitnotfoundforfield"
+msgid "Unit \"%s\" not found for field \"%s\" !"
+msgstr "Enheten ”%s” hittades inte för fältet ”%s”!"
+
+#: ulng.rspropscontains
+#, object-pascal-format
+msgid "Files: %d, folders: %d"
+msgstr "Filer: %d, mappar: %d"
+
+#: ulng.rspropserrchmod
+#, object-pascal-format
+msgid "Can not change access rights for \"%s\""
+msgstr "Det går inte att ändra åtkomsträttigheter för ”%s”"
+
+#: ulng.rspropserrchown
+#, object-pascal-format
+msgid "Can not change owner for \"%s\""
+msgstr "Det går inte att ändra ägare för ”%s”"
+
+#: ulng.rspropsfile
+msgid "File"
+msgstr "Fil"
+
+#: ulng.rspropsfolder
+msgctxt "ulng.rspropsfolder"
+msgid "Directory"
+msgstr "Katalog"
+
+#: ulng.rspropsmultipletypes
+msgid "Multiple types"
+msgstr "Flera typer"
+
+#: ulng.rspropsnmdpipe
+msgid "Named pipe"
+msgstr "Namngiven pipe"
+
+#: ulng.rspropssocket
+msgid "Socket"
+msgstr "Socket"
+
+#: ulng.rspropsspblkdev
+msgid "Special block device"
+msgstr "Särskild blockenhet"
+
+#: ulng.rspropsspchrdev
+msgid "Special character device"
+msgstr "Särskild teckenenhet"
+
+#: ulng.rspropssymlink
+msgid "Symbolic link"
+msgstr "Symbolisk länk"
+
+#: ulng.rspropsunknowntype
+msgid "Unknown type"
+msgstr "Okänd typ"
+
+#: ulng.rssearchresult
+msgid "Search result"
+msgstr "Sökresultat"
+
+#: ulng.rssearchstatus
+msgid "SEARCH"
+msgstr "SÖK"
+
+#: ulng.rssearchtemplateunnamed
+msgid "<unnamed template>"
+msgstr "<namnlös mall>"
+
+#: ulng.rssearchwithdsxplugininprogress
+msgid ""
+"A file search using DSX plugin is already in progress.\n"
+"We need that one to be completed before to launch a new one."
+msgstr ""
+"En filsökning med en DSX-insticksmodul pågår redan.\n"
+"Den måste slutföras innan en ny kan startas."
+
+#: ulng.rssearchwithwdxplugininprogress
+msgid ""
+"A file search using WDX plugin is already in progress.\n"
+"We need that one to be completed before to launch a new one."
+msgstr ""
+"En filsökning med en WDX-insticksmodul pågår redan.\n"
+"Den måste slutföras innan en ny kan startas."
+
+#: ulng.rsselectdir
+msgid "Select a directory"
+msgstr "Välj en katalog"
+
+#: ulng.rsselectduplicatemethod
+msgid "Newest;Oldest;Largest;Smallest;First in group;Last in group"
+msgstr "Nyast;Äldst;Störst;Minst;Först i grupp;Sist i grupp"
+
+#: ulng.rsselectyoufindfileswindow
+msgid "Select your window"
+msgstr "Välj fönster"
+
+#: ulng.rsshowhelpfor
+#, object-pascal-format
+msgid "&Show help for %s"
+msgstr "&Visa hjälp för %s"
+
+#: ulng.rssimplewordall
+msgctxt "ulng.rssimplewordall"
+msgid "All"
+msgstr "Alla"
+
+#: ulng.rssimplewordcategory
+msgctxt "ulng.rssimplewordcategory"
+msgid "Category"
+msgstr "Kategori"
+
+#: ulng.rssimplewordcolumnsingular
+msgid "Column"
+msgstr "Kolumn"
+
+#: ulng.rssimplewordcommand
+msgctxt "ulng.rssimplewordcommand"
+msgid "Command"
+msgstr "Kommando"
+
+#: ulng.rssimpleworderror
+msgid "Error"
+msgstr "Fel"
+
+#: ulng.rssimplewordfailedexcla
+msgid "Failed!"
+msgstr "Misslyckades!"
+
+#: ulng.rssimplewordfalse
+msgid "False"
+msgstr "Falskt"
+
+#: ulng.rssimplewordfilename
+msgctxt "ulng.rssimplewordfilename"
+msgid "Filename"
+msgstr "Filnamn"
+
+#: ulng.rssimplewordfiles
+msgid "files"
+msgstr "filer"
+
+#: ulng.rssimplewordletter
+msgid "Letter"
+msgstr "Bokstav"
+
+#: ulng.rssimplewordparameter
+msgid "Param"
+msgstr "Param"
+
+#: ulng.rssimplewordresult
+msgid "Result"
+msgstr "Resultat"
+
+#: ulng.rssimplewordsuccessexcla
+msgid "Success!"
+msgstr "Lyckades!"
+
+#: ulng.rssimplewordtrue
+msgid "True"
+msgstr "Sant"
+
+#: ulng.rssimplewordvariable
+msgid "Variable"
+msgstr "Variabel"
+
+#: ulng.rssimplewordworkdir
+msgid "WorkDir"
+msgstr "Arbetskatalog"
+
+#: ulng.rssizeunitbytes
+msgid "Bytes"
+msgstr "Byte"
+
+#: ulng.rssizeunitgbytes
+msgid "Gigabytes"
+msgstr "Gigabyte"
+
+#: ulng.rssizeunitkbytes
+msgid "Kilobytes"
+msgstr "Kilobyte"
+
+#: ulng.rssizeunitmbytes
+msgid "Megabytes"
+msgstr "Megabyte"
+
+#: ulng.rssizeunittbytes
+msgid "Terabytes"
+msgstr "Terabyte"
+
+#: ulng.rsspacemsg
+#, object-pascal-format
+msgid "Files: %d, Dirs: %d, Size: %s (%s bytes)"
+msgstr "Filer: %d, kataloger: %d, storlek: %s (%s byte)"
+
+#: ulng.rsspliterrdirectory
+msgid "Unable to create target directory!"
+msgstr "Det går inte att skapa målkatalogen!"
+
+#: ulng.rsspliterrfilesize
+msgid "Incorrect file size format!"
+msgstr "Felaktigt filstorleksformat!"
+
+#: ulng.rsspliterrsplitfile
+msgid "Unable to split the file!"
+msgstr "Det går inte att dela upp filen!"
+
+#: ulng.rssplitmsgmanyparts
+msgid "The number of parts is more than 100! Continue?"
+msgstr "Antalet delar är fler än 100! Fortsätta?"
+
+#: ulng.rssplitpredefinedsizes
+msgid ""
+"Automatic;1457664B - 3.5\" High Density 1.44M;1213952B - 5.25\" High Density 1.2M;730112B - 3.5\""
+" Double Density 720K;362496B - 5.25\" Double Density 360K;98078KB - ZIP 100MB;650MB - CD "
+"650MB;700MB - CD 700MB;4482MB - DVD+R"
+msgstr ""
+"Automatiskt;1457664B - 3.5\" High Density 1.44M;1213952B - 5.25\" High Density 1.2M;730112B - "
+"3.5\" Double Density 720K;362496B - 5.25\" Double Density 360K;98078KB - ZIP 100MB;650MB - CD "
+"650MB;700MB - CD 700MB;4482MB - DVD+R"
+
+#: ulng.rssplitseldir
+msgid "Select directory:"
+msgstr "Välj katalog:"
+
+#: ulng.rsstashname
+msgid "Stash"
+msgstr "Stash"
+
+#: ulng.rsstrpreviewjustpreview
+msgid "Just preview"
+msgstr "Endast förhandsgranskning"
+
+#: ulng.rsstrpreviewothers
+msgid "Others"
+msgstr "Övriga"
+
+#: ulng.rsstrpreviewsearchingletters
+msgid "OU"
+msgstr "OU"
+
+#: ulng.rsstrpreviewsidenote
+msgid "Side note"
+msgstr "Sidokommentar"
+
+#: ulng.rsstrpreviewwordwithoutsearched1
+msgid "Flat"
+msgstr "Platt"
+
+#: ulng.rsstrpreviewwordwithoutsearched2
+msgid "Limited"
+msgstr "Begränsad"
+
+#: ulng.rsstrpreviewwordwithoutsearched3
+msgid "Simple"
+msgstr "Enkel"
+
+#: ulng.rsstrpreviewwordwithsearched1
+msgid "Fabulous"
+msgstr "Fantastisk"
+
+#: ulng.rsstrpreviewwordwithsearched2
+msgid "Marvelous"
+msgstr "Strålande"
+
+#: ulng.rsstrpreviewwordwithsearched3
+msgid "Tremendous"
+msgstr "Enastående"
+
+#: ulng.rsstrtvmchoosedirhistory
+msgid "Choose your directory from Dir History"
+msgstr "Välj katalog från kataloghistoriken"
+
+#: ulng.rsstrtvmchoosefavoritetabs
+msgid "Choose you Favorite Tabs:"
+msgstr "Välj bland dina favoritflikar:"
+
+#: ulng.rsstrtvmchoosefromcmdlinehistory
+msgid "Choose your command from Command Line History"
+msgstr "Välj kommando från kommandoradshistoriken"
+
+#: ulng.rsstrtvmchoosefrommainmenu
+msgid "Choose your action from Main Menu"
+msgstr "Välj åtgärd från huvudmenyn"
+
+#: ulng.rsstrtvmchoosefromtoolbar
+msgid "Choose your action from Maintool bar"
+msgstr "Välj åtgärd från huvudverktygsfältet"
+
+#: ulng.rsstrtvmchoosehotdirectory
+msgid "Choose your directory from Hot Directory:"
+msgstr "Välj katalog från Katalogfavoriter:"
+
+#: ulng.rsstrtvmchooseviewhistory
+msgid "Choose your directory from File View History"
+msgstr "Välj katalog från filvyhistoriken"
+
+#: ulng.rsstrtvmchooseyourfileordir
+msgid "Choose your file or your directory"
+msgstr "Välj fil eller katalog"
+
+#: ulng.rssymerrcreate
+msgid "Error creating symlink."
+msgstr "Fel när den symboliska länken skapades."
+
+#: ulng.rssyndefaulttext
+msgid "Default text"
+msgstr "Standardtext"
+
+#: ulng.rssynlangplaintext
+msgid "Plain text"
+msgstr "Oformaterad text"
+
+#: ulng.rstabsactionondoubleclickchoices
+msgid "Do nothing;Close tab;Access Favorite Tabs;Tabs popup menu"
+msgstr "Gör ingenting;Stäng flik;Öppna Favoritflikar;Flikarnas popup-meny"
+
+#: ulng.rstimeunitday
+msgid "Day(s)"
+msgstr "Dag(ar)"
+
+#: ulng.rstimeunithour
+msgid "Hour(s)"
+msgstr "Timme/timmar"
+
+#: ulng.rstimeunitminute
+msgid "Minute(s)"
+msgstr "Minut(er)"
+
+#: ulng.rstimeunitmonth
+msgid "Month(s)"
+msgstr "Månad(er)"
+
+#: ulng.rstimeunitsecond
+msgid "Second(s)"
+msgstr "Sekund(er)"
+
+#: ulng.rstimeunitweek
+msgid "Week(s)"
+msgstr "Vecka/veckor"
+
+#: ulng.rstimeunityear
+msgid "Year(s)"
+msgstr "År"
+
+#: ulng.rstitlerenamefavtabs
+msgid "Rename Favorite Tabs"
+msgstr "Byt namn på Favoritflikar"
+
+#: ulng.rstitlerenamefavtabsmenu
+msgid "Rename Favorite Tabs sub-menu"
+msgstr "Byt namn på undermeny i Favoritflikar"
+
+#: ulng.rstooldiffer
+msgctxt "ulng.rstooldiffer"
+msgid "Differ"
+msgstr "Jämförelseprogram"
+
+#: ulng.rstooleditor
+msgctxt "ulng.rstooleditor"
+msgid "Editor"
+msgstr "Redigerare"
+
+#: ulng.rstoolerroropeningdiffer
+msgid "Error opening differ"
+msgstr "Fel när jämförelseprogrammet öppnades"
+
+#: ulng.rstoolerroropeningeditor
+msgid "Error opening editor"
+msgstr "Fel när redigeraren öppnades"
+
+#: ulng.rstoolerroropeningterminal
+msgid "Error opening terminal"
+msgstr "Fel när terminalen öppnades"
+
+#: ulng.rstoolerroropeningviewer
+msgid "Error opening viewer"
+msgstr "Fel när visaren öppnades"
+
+#: ulng.rstoolterminal
+msgctxt "ulng.rstoolterminal"
+msgid "Terminal"
+msgstr "Terminal"
+
+#: ulng.rstooltiphidetimeoutlist
+msgid "System default;1 sec;2 sec;3 sec;5 sec;10 sec;30 sec;1 min;Never hide"
+msgstr "Systemstandard;1 sek;2 sek;3 sek;5 sek;10 sek;30 sek;1 min;Dölj aldrig"
+
+#: ulng.rstooltipmodelist
+msgid ""
+"Combine DC and system tooltip, DC first (legacy);Combine DC and system tooltip, system first;Show"
+" DC tooltip when possible and system when not;Show DC tooltip only;Show system tooltip only"
+msgstr ""
+"Kombinera DC:s och systemets verktygstips, DC först (äldre);Kombinera DC:s och systemets "
+"verktygstips, systemet först;Visa DC:s verktygstips när det går, annars systemets;Visa endast "
+"DC:s verktygstips;Visa endast systemets verktygstips"
+
+#: ulng.rstoolviewer
+msgctxt "ulng.rstoolviewer"
+msgid "Viewer"
+msgstr "Visare"
+
+#: ulng.rsunhandledexceptionmessage
+#, object-pascal-format
+msgid ""
+"Please report this error to the bug tracker with a description of what you were doing and the "
+"following file:%sPress %s to continue or %s to abort the program."
+msgstr ""
+"Rapportera felet i felrapporteringssystemet med en beskrivning av vad du gjorde och följande "
+"fil:%sTryck %s för att fortsätta eller %s för att avbryta programmet."
+
+#: ulng.rsvarbothpanelactivetoinactive
+msgid "Both panels, from active to inactive"
+msgstr "Båda panelerna, från aktiv till inaktiv"
+
+#: ulng.rsvarbothpanellefttoright
+msgid "Both panels, from left to right"
+msgstr "Båda panelerna, från vänster till höger"
+
+#: ulng.rsvarcurrentpath
+msgid "Path of panel"
+msgstr "Panelens sökväg"
+
+#: ulng.rsvarencloseelement
+msgid "Enclose each name in brackets or what you want"
+msgstr "Omge varje namn med parenteser eller valfria tecken"
+
+#: ulng.rsvarfilenamenoext
+msgid "Just filename, no extension"
+msgstr "Endast filnamn, ingen filändelse"
+
+#: ulng.rsvarfullpath
+msgid "Complete filename (path+filename)"
+msgstr "Fullständigt filnamn (sökväg+filnamn)"
+
+#: ulng.rsvarhelpwith
+msgid "Help with \"%\" variables"
+msgstr "Hjälp om ”%”-variabler"
+
+#: ulng.rsvarinputparam
+msgid "Will request request user to enter a parameter with a default suggested value"
+msgstr "Ber användaren ange en parameter med ett föreslaget standardvärde"
+
+#: ulng.rsvarlastdircurrentpath
+msgid "Last directory of panel's path"
+msgstr "Sista katalogen i panelens sökväg"
+
+#: ulng.rsvarlastdirofpath
+msgid "Last directory of file's path"
+msgstr "Sista katalogen i filens sökväg"
+
+#: ulng.rsvarleftpanel
+msgid "Left panel"
+msgstr "Vänster panel"
+
+#: ulng.rsvarlistfilename
+msgid "Temporary filename of list of filenames"
+msgstr "Tillfälligt filnamn för lista över filnamn"
+
+#: ulng.rsvarlistfullfilename
+msgid "Temporary filename of list of complete filenames (path+filename)"
+msgstr "Tillfälligt filnamn för lista över fullständiga filnamn (sökväg+filnamn)"
+
+#: ulng.rsvarlistinutf16
+msgid "Filenames in list in UTF-16 with BOM"
+msgstr "Filnamn i listan i UTF-16 med BOM"
+
+#: ulng.rsvarlistinutf16quoted
+msgid "Filenames in list in UTF-16 with BOM, inside double quotes"
+msgstr "Filnamn i listan i UTF-16 med BOM, inom dubbla citattecken"
+
+#: ulng.rsvarlistinutf8
+msgid "Filenames in list in UTF-8"
+msgstr "Filnamn i listan i UTF-8"
+
+#: ulng.rsvarlistinutf8quoted
+msgid "Filenames in list in UTF-8, inside double quotes"
+msgstr "Filnamn i listan i UTF-8, inom dubbla citattecken"
+
+#: ulng.rsvarlistrelativefilename
+msgid "Temporary filename of list of filenames with relative path"
+msgstr "Tillfälligt filnamn för lista över filnamn med relativ sökväg"
+
+#: ulng.rsvaronlyextension
+msgid "Only file extension"
+msgstr "Endast filändelse"
+
+#: ulng.rsvaronlyfilename
+msgid "Only filename"
+msgstr "Endast filnamn"
+
+#: ulng.rsvarotherexamples
+msgid "Other example of what's possible"
+msgstr "Annat exempel på vad som är möjligt"
+
+#: ulng.rsvarpath
+msgid "Path, without ending delimiter"
+msgstr "Sökväg utan avslutande avgränsare"
+
+#: ulng.rsvarpercentchangetopound
+msgid "From here to the end of the line, the percent-variable indicator is the \"#\" sign"
+msgstr "Från och med här till radens slut är tecknet ”#” indikator för procentvariabler"
+
+#: ulng.rsvarpercentsign
+msgid "Return the percent sign"
+msgstr "Returnera procenttecknet"
+
+#: ulng.rsvarpoundchangetopercent
+msgid "From here to the end of the line, the percent-variable indicator is back the \"%\" sign"
+msgstr "Från och med här till radens slut är tecknet ”%” åter indikator för procentvariabler"
+
+#: ulng.rsvarprependelement
+msgid "Prepend each name with \"-a \" or what you want"
+msgstr "Lägg ”-a ” eller valfri text före varje namn"
+
+#: ulng.rsvarpromptuserforparam
+msgid "%[Prompt user for param;Default value proposed]"
+msgstr "%[Fråga användaren efter parameter;Föreslaget standardvärde]"
+
+#: ulng.rsvarrelativepathandfilename
+msgid "Filename with relative path"
+msgstr "Filnamn med relativ sökväg"
+
+#: ulng.rsvarrightpanel
+msgid "Right panel"
+msgstr "Höger panel"
+
+#: ulng.rsvarsecondelementrightpanel
+msgid "Full path of second selected file in right panel"
+msgstr "Fullständig sökväg till den andra valda filen i höger panel"
+
+#: ulng.rsvarshowcommandprior
+msgid "Show command prior execute"
+msgstr "Visa kommandot innan det körs"
+
+#: ulng.rsvarsimplemessage
+msgid "%[Simple message]"
+msgstr "%[Enkelt meddelande]"
+
+#: ulng.rsvarsimpleshowmessage
+msgid "Will show a simple message"
+msgstr "Visar ett enkelt meddelande"
+
+#: ulng.rsvarsourcepanel
+msgid "Active panel (source)"
+msgstr "Aktiv panel (källa)"
+
+#: ulng.rsvartargetpanel
+msgid "Inactive panel (target)"
+msgstr "Inaktiv panel (mål)"
+
+#: ulng.rsvarwillbequoted
+msgid "Filenames will be quoted from here (default)"
+msgstr "Filnamn omges av citattecken från och med här (standard)"
+
+#: ulng.rsvarwilldointerminal
+msgid "Command will be done in terminal, remaining opened at the end"
+msgstr "Kommandot körs i terminalen, som förblir öppen efteråt"
+
+#: ulng.rsvarwillhaveendingdelimiter
+msgid "Paths will have ending delimiter"
+msgstr "Sökvägar får en avslutande avgränsare"
+
+#: ulng.rsvarwillnotbequoted
+msgid "Filenames will not be quoted from here"
+msgstr "Filnamn omges inte av citattecken från och med här"
+
+#: ulng.rsvarwillnotdointerminal
+msgid "Command will be done in terminal, closed at the end"
+msgstr "Kommandot körs i terminalen, som stängs efteråt"
+
+#: ulng.rsvarwillnothaveendingdelimiter
+msgid "Paths will not have ending delimiter (default)"
+msgstr "Sökvägar får ingen avslutande avgränsare (standard)"
+
+#: ulng.rsvfsnetwork
+msgctxt "ulng.rsvfsnetwork"
+msgid "Network"
+msgstr "Nätverk"
+
+#: ulng.rsvfsrecyclebin
+msgid "Recycle Bin"
+msgstr "Papperskorgen"
+
+#: ulng.rsviewabouttext
+msgid "Internal Viewer of Double Commander."
+msgstr "Double Commanders interna visare."
+
+#: ulng.rsviewbadquality
+msgid "Bad Quality"
+msgstr "Dålig kvalitet"
+
+#: ulng.rsviewencoding
+msgctxt "ulng.rsviewencoding"
+msgid "Encoding"
+msgstr "Teckenkodning"
+
+#: ulng.rsviewimagetype
+msgid "Image Type"
+msgstr "Bildtyp"
+
+#: ulng.rsviewnewsize
+msgctxt "ulng.rsviewnewsize"
+msgid "New Size"
+msgstr "Ny storlek"
+
+#: ulng.rsviewnotfound
+#, object-pascal-format
+msgid "%s not found!"
+msgstr "%s hittades inte!"
+
+#: ulng.rsviewpainttoolslist
+msgid "Pen;Rect;Ellipse"
+msgstr "Penna;Rektangel;Ellips"
+
+#: ulng.rsviewwithexternalviewer
+msgid "with external viewer"
+msgstr "med extern visare"
+
+#: ulng.rsviewwithinternalviewer
+msgid "with internal viewer"
+msgstr "med intern visare"
+
+#: ulng.rsxreplacements
+#, object-pascal-format
+msgid "Number of replacement: %d"
+msgstr "Antal ersättningar: %d"
+
+#: ulng.rszeroreplacement
+msgid "No replacement took place."
+msgstr "Ingen ersättning gjordes."
+
+#: umaincommands.rsfavoritetabs_setupnotexist
+#, object-pascal-format
+msgid "No setup named \"%s\""
+msgstr "Ingen konfiguration med namnet ”%s”"

--- a/language/lcl/lclstrconsts.sv.po
+++ b/language/lcl/lclstrconsts.sv.po
@@ -1,0 +1,1639 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander LCL\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: lclstrconsts.hhshelpbrowsernotexecutable
+#, object-pascal-format
+msgid "Browser \"%s\" not executable."
+msgstr "Webbläsaren ”%s” kan inte köras."
+
+#: lclstrconsts.hhshelpbrowsernotfound
+#, object-pascal-format
+msgid "Browser \"%s\" not found."
+msgstr "Webbläsaren ”%s” hittades inte."
+
+#: lclstrconsts.hhshelperrorwhileexecuting
+#, object-pascal-format
+msgid "Error while executing \"%s\":%s%s"
+msgstr "Fel vid körning av ”%s”:%s%s"
+
+#: lclstrconsts.hhshelpnohtmlbrowserfound
+msgid "Unable to find a HTML browser."
+msgstr "Det går inte att hitta en HTML-webbläsare."
+
+#: lclstrconsts.hhshelpnohtmlbrowserfoundpleasedefineone
+#, object-pascal-format
+msgid "No HTML Browser found.%sPlease define one in Tools -> Options -> Help -> Help Options."
+msgstr "Ingen HTML-webbläsare hittades.%sAnge en under Verktyg -> Alternativ -> Hjälp -> Hjälpalternativ."
+
+#: lclstrconsts.hhshelpthehelpdatabasewasunabletofindfile
+#, object-pascal-format
+msgid "The help database \"%s\" was unable to find file \"%s\"."
+msgstr "Hjälpdatabasen ”%s” kunde inte hitta filen ”%s”."
+
+#: lclstrconsts.hhshelpthemacrosinbrowserparamswillbereplacedbytheurl
+#, object-pascal-format
+msgid "The macro %s in BrowserParams will be replaced by the URL."
+msgstr "Makrot %s i BrowserParams ersätts med URL:en."
+
+#: lclstrconsts.ifsalt
+msgid "Alt"
+msgstr "Alt"
+
+#: lclstrconsts.ifsctrl
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: lclstrconsts.ifsvk_cmd
+msgid "Cmd"
+msgstr "Cmd"
+
+#: lclstrconsts.ifsvk_fn
+msgctxt "lclstrconsts.ifsvk_fn"
+msgid "Fn"
+msgstr "Fn"
+
+#: lclstrconsts.ifsvk_help
+msgctxt "lclstrconsts.ifsvk_help"
+msgid "Help"
+msgstr "Hjälp"
+
+#: lclstrconsts.ifsvk_meta
+msgid "Meta"
+msgstr "Meta"
+
+#: lclstrconsts.ifsvk_shift
+msgid "Shift"
+msgstr "Skift"
+
+#: lclstrconsts.ifsvk_super
+msgid "Super"
+msgstr "Super"
+
+#: lclstrconsts.ifsvk_unknown
+msgid "Unknown"
+msgstr "Okänd"
+
+#: lclstrconsts.lislclresourcesnotfound
+#, object-pascal-format
+msgctxt "lclstrconsts.lislclresourcesnotfound"
+msgid "Resource %s not found"
+msgstr "Resursen %s hittades inte"
+
+#: lclstrconsts.rs3ddkshadowcolorcaption
+msgid "3D Dark Shadow"
+msgstr "Mörk 3D-skugga"
+
+#: lclstrconsts.rs3dlightcolorcaption
+msgid "3D Light"
+msgstr "3D-ljus"
+
+#: lclstrconsts.rsacontrolcannothaveitselfasparent
+msgid "A control can't have itself as a parent"
+msgstr "En kontroll kan inte ha sig själv som överordnad"
+
+#: lclstrconsts.rsactivebordercolorcaption
+msgid "Active Border"
+msgstr "Aktiv kant"
+
+#: lclstrconsts.rsactivecaptioncolorcaption
+msgid "Active Caption"
+msgstr "Aktiv namnlist"
+
+#: lclstrconsts.rsallfiles
+#, object-pascal-format
+msgid "All files (%s)|%s|%s"
+msgstr "Alla filer (%s)|%s|%s"
+
+#: lclstrconsts.rsappworkspacecolorcaption
+msgid "Application Workspace"
+msgstr "Programarbetsyta"
+
+#: lclstrconsts.rsaquacolorcaption
+msgid "Aqua"
+msgstr "Akvamarin"
+
+#: lclstrconsts.rsascannothaveasparent
+#, object-pascal-format
+msgid "Class %s cannot have %s as parent."
+msgstr "Klassen %s kan inte ha %s som överordnad."
+
+#: lclstrconsts.rsbackgroundcolorcaption
+msgid "Desktop"
+msgstr "Skrivbord"
+
+#: lclstrconsts.rsbackward
+msgid "Backward"
+msgstr "Bakåt"
+
+#: lclstrconsts.rsbitmaps
+msgid "Bitmap Files"
+msgstr "Bitmapfiler"
+
+#: lclstrconsts.rsblackcolorcaption
+msgid "Black"
+msgstr "Svart"
+
+#: lclstrconsts.rsblank
+msgid "Blank"
+msgstr "Tom"
+
+#: lclstrconsts.rsbluecolorcaption
+msgid "Blue"
+msgstr "Blå"
+
+#: lclstrconsts.rsbtnfacecolorcaption
+msgid "Button Face"
+msgstr "Knappyta"
+
+#: lclstrconsts.rsbtnhighlightcolorcaption
+msgid "Button Highlight"
+msgstr "Knappmarkering"
+
+#: lclstrconsts.rsbtnshadowcolorcaption
+msgid "Button Shadow"
+msgstr "Knappskugga"
+
+#: lclstrconsts.rsbtntextcolorcaption
+msgid "Button Text"
+msgstr "Knapptext"
+
+#: lclstrconsts.rscalculator
+msgid "Calculator"
+msgstr "Kalkylator"
+
+#: lclstrconsts.rscancelrecordhint
+msgctxt "lclstrconsts.rscancelrecordhint"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: lclstrconsts.rscannotfocus
+msgid "Cannot focus"
+msgstr "Det går inte att sätta fokus"
+
+#: lclstrconsts.rscanvasdoesnotallowdrawing
+msgid "Canvas does not allow drawing"
+msgstr "Ritytan tillåter inte ritning"
+
+#: lclstrconsts.rscaptiontextcolorcaption
+msgid "Caption Text"
+msgstr "Namnlisttext"
+
+#: lclstrconsts.rscasesensitive
+msgid "Case sensitive"
+msgstr "Skiftlägeskänslig"
+
+#: lclstrconsts.rscontrolclasscantcontainchildclass
+#, object-pascal-format
+msgid "Control of class '%s' can't have control of class '%s' as a child"
+msgstr "En kontroll av klassen ”%s” kan inte ha en kontroll av klassen ”%s” som underordnad"
+
+#: lclstrconsts.rscontrolhasnoparentformorframe
+#, object-pascal-format
+msgid "Control '%s' has no parent form or frame"
+msgstr "Kontrollen ”%s” har inget överordnat formulär eller någon ram"
+
+#: lclstrconsts.rscontrolisnotaparent
+#, object-pascal-format
+msgid "'%s' is not a parent of '%s'"
+msgstr "”%s” är inte överordnad till ”%s”"
+
+#: lclstrconsts.rscreamcolorcaption
+msgid "Cream"
+msgstr "Krämfärgad"
+
+#: lclstrconsts.rscursor
+msgid "Cursor Files"
+msgstr "Markörfiler"
+
+#: lclstrconsts.rscustomcolorcaption
+msgid "Custom ..."
+msgstr "Anpassad ..."
+
+#: lclstrconsts.rsdatetoolarge
+#, object-pascal-format
+msgid "Date cannot be past %s"
+msgstr "Datumet får inte vara senare än %s"
+
+#: lclstrconsts.rsdatetoosmall
+#, object-pascal-format
+msgid "Date cannot be before %s"
+msgstr "Datumet får inte vara före %s"
+
+#: lclstrconsts.rsdefaultcolorcaption
+msgid "Default"
+msgstr "Standard"
+
+#: lclstrconsts.rsdefaultfileinfovalue
+msgid "permissions user group size date time"
+msgstr "behörigheter användare grupp storlek datum tid"
+
+#: lclstrconsts.rsdeleterecord
+msgid "Delete record?"
+msgstr "Ta bort posten?"
+
+#: lclstrconsts.rsdeleterecordhint
+msgctxt "lclstrconsts.rsdeleterecordhint"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: lclstrconsts.rsdirection
+msgid "Direction"
+msgstr "Riktning"
+
+#: lclstrconsts.rsdirectory
+msgid "&Directory"
+msgstr "&Katalog"
+
+#: lclstrconsts.rsdocopy
+msgctxt "lclstrconsts.rsdocopy"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: lclstrconsts.rsdopaste
+msgctxt "lclstrconsts.rsdopaste"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: lclstrconsts.rsduplicateiconformat
+msgid "Duplicate icon format."
+msgstr "Dubblerat ikonformat."
+
+#: lclstrconsts.rseditrecordhint
+msgctxt "lclstrconsts.rseditrecordhint"
+msgid "Edit"
+msgstr "Redigera"
+
+#: lclstrconsts.rsentirescope
+msgid "Search entire file"
+msgstr "Sök i hela filen"
+
+#: lclstrconsts.rserror
+msgctxt "lclstrconsts.rserror"
+msgid "Error"
+msgstr "Fel"
+
+#: lclstrconsts.rserrorcreatingdevicecontext
+#, object-pascal-format
+msgid "Error creating device context for %s.%s"
+msgstr "Fel när enhetskontext skapades för %s.%s"
+
+#: lclstrconsts.rserroroccurredinataddressframe
+#, object-pascal-format
+msgid "Error occurred in %s at %sAddress %s%s Frame %s"
+msgstr "Fel inträffade i %s vid %sAdress %s%s Ram %s"
+
+#: lclstrconsts.rserrorwhilesavingbitmap
+msgid "Error while saving bitmap."
+msgstr "Fel när bitmappen sparades."
+
+#: lclstrconsts.rsexception
+msgid "Exception"
+msgstr "Undantag"
+
+#: lclstrconsts.rsfddirectorymustexist
+msgid "Directory must exist"
+msgstr "Katalogen måste finnas"
+
+#: lclstrconsts.rsfddirectorynotexist
+#, object-pascal-format
+msgid "The directory \"%s\" does not exist."
+msgstr "Katalogen ”%s” finns inte."
+
+#: lclstrconsts.rsfdfilealreadyexists
+#, object-pascal-format
+msgid "The file \"%s\" already exists. Overwrite ?"
+msgstr "Filen ”%s” finns redan. Skriva över?"
+
+#: lclstrconsts.rsfdfilemustexist
+msgid "File must exist"
+msgstr "Filen måste finnas"
+
+#: lclstrconsts.rsfdfilenotexist
+#, object-pascal-format
+msgid "The file \"%s\" does not exist."
+msgstr "Filen ”%s” finns inte."
+
+#: lclstrconsts.rsfdfilereadonly
+#, object-pascal-format
+msgid "The file \"%s\" is not writable."
+msgstr "Filen ”%s” är skrivskyddad."
+
+#: lclstrconsts.rsfdfilereadonlytitle
+msgid "File is not writable"
+msgstr "Filen är skrivskyddad"
+
+#: lclstrconsts.rsfdfilesaveas
+msgid "Save file as"
+msgstr "Spara fil som"
+
+#: lclstrconsts.rsfdopenfile
+msgid "Open existing file"
+msgstr "Öppna befintlig fil"
+
+#: lclstrconsts.rsfdoverwritefile
+msgid "Overwrite file ?"
+msgstr "Skriva över filen?"
+
+#: lclstrconsts.rsfdpathmustexist
+msgid "Path must exist"
+msgstr "Sökvägen måste finnas"
+
+#: lclstrconsts.rsfdpathnoexist
+#, object-pascal-format
+msgid "The path \"%s\" does not exist."
+msgstr "Sökvägen ”%s” finns inte."
+
+#: lclstrconsts.rsfdselectdirectory
+msgid "Select Directory"
+msgstr "Välj katalog"
+
+#: lclstrconsts.rsfileinfofilenotfound
+#, object-pascal-format
+msgid "(file not found: \"%s\")"
+msgstr "(filen hittades inte: ”%s”)"
+
+#: lclstrconsts.rsfileinformation
+msgid "File information"
+msgstr "Filinformation"
+
+#: lclstrconsts.rsfilter
+msgctxt "lclstrconsts.rsfilter"
+msgid "(filter)"
+msgstr "(filter)"
+
+#: lclstrconsts.rsfind
+msgid "Find"
+msgstr "Sök"
+
+#: lclstrconsts.rsfindmore
+msgid "Find more"
+msgstr "Sök nästa"
+
+#: lclstrconsts.rsfirstrecordhint
+msgid "First"
+msgstr "Första"
+
+#: lclstrconsts.rsfixedcolstoobig
+msgid "FixedCols can't be > ColCount"
+msgstr "FixedCols får inte vara > ColCount"
+
+#: lclstrconsts.rsfixedrowstoobig
+msgid "FixedRows can't be > RowCount"
+msgstr "FixedRows får inte vara > RowCount"
+
+#: lclstrconsts.rsformcolorcaption
+msgid "Form"
+msgstr "Formulär"
+
+#: lclstrconsts.rsformresourcesnotfoundforresourcelessformscreatenew
+#, object-pascal-format
+msgid ""
+"Form resource %s not found. For resourceless forms CreateNew constructor must be used. See the "
+"global variable RequireDerivedFormResource."
+msgstr ""
+"Formulärresursen %s hittades inte. För formulär utan resurser måste konstruktorn CreateNew "
+"användas. Se den globala variabeln RequireDerivedFormResource."
+
+#: lclstrconsts.rsformstreamingerror
+#, object-pascal-format
+msgid "Form streaming \"%s\" error: %s"
+msgstr "Fel vid strömning av formuläret ”%s”: %s"
+
+#: lclstrconsts.rsforward
+msgid "Forward"
+msgstr "Framåt"
+
+#: lclstrconsts.rsfuchsiacolorcaption
+msgid "Fuchsia"
+msgstr "Fuchsia"
+
+#: lclstrconsts.rsgdkoptiondebug
+msgid "Turn on specific GDK trace/debug messages."
+msgstr "Aktivera specifika GDK-spårnings-/felsökningsmeddelanden."
+
+#: lclstrconsts.rsgdkoptionnodebug
+msgid "Turn off specific GDK trace/debug messages."
+msgstr "Inaktivera specifika GDK-spårnings-/felsökningsmeddelanden."
+
+#: lclstrconsts.rsgif
+msgid "Graphics Interchange Format Files"
+msgstr "GIF-filer"
+
+#: lclstrconsts.rsgoptionfatalwarnings
+msgid "Warnings and errors generated by Gtk+/GDK will halt the application."
+msgstr "Varningar och fel som genereras av Gtk+/GDK stoppar programmet."
+
+#: lclstrconsts.rsgradientactivecaptioncolorcaption
+msgid "Gradient Active Caption"
+msgstr "Övertoning för aktiv namnlist"
+
+#: lclstrconsts.rsgradientinactivecaptioncolorcaption
+msgid "Gradient Inactive Caption"
+msgstr "Övertoning för inaktiv namnlist"
+
+#: lclstrconsts.rsgraphic
+msgid "Graphic"
+msgstr "Grafik"
+
+#: lclstrconsts.rsgraycolorcaption
+msgid "Gray"
+msgstr "Grå"
+
+#: lclstrconsts.rsgraytextcolorcaption
+msgid "Gray Text"
+msgstr "Grå text"
+
+#: lclstrconsts.rsgreencolorcaption
+msgid "Green"
+msgstr "Grön"
+
+#: lclstrconsts.rsgridfiledoesnotexist
+msgid "Grid file doesn't exist"
+msgstr "Rutnätsfilen finns inte"
+
+#: lclstrconsts.rsgridhasnocols
+msgid "Cannot insert rows into a grid when it has no columns"
+msgstr "Det går inte att infoga rader i ett rutnät som saknar kolumner"
+
+#: lclstrconsts.rsgridhasnorows
+msgid "Cannot insert columns into a grid when it has no rows"
+msgstr "Det går inte att infoga kolumner i ett rutnät som saknar rader"
+
+#: lclstrconsts.rsgridindexoutofrange
+msgid "Grid index out of range."
+msgstr "Rutnätsindex utanför intervallet."
+
+#: lclstrconsts.rsgtkfilter
+msgid "Filter:"
+msgstr "Filter:"
+
+#: lclstrconsts.rsgtkhistory
+msgid "History:"
+msgstr "Historik:"
+
+#: lclstrconsts.rsgtkoptionclass
+msgid ""
+"Following Xt conventions, the class of a program is the program name with the initial character "
+"capitalized. For example, the classname for gimp is \"Gimp\". If --class is specified, the class "
+"of the program will be set to \"classname\"."
+msgstr ""
+"Enligt Xt-konventionerna är ett programs klass programnamnet med första tecknet som versal. "
+"Klassnamnet för gimp är till exempel ”Gimp”. Om --class anges sätts programmets klass till "
+"”classname”."
+
+#: lclstrconsts.rsgtkoptiondebug
+msgid "Turn on specific Gtk+ trace/debug messages."
+msgstr "Aktivera specifika Gtk+-spårnings-/felsökningsmeddelanden."
+
+#: lclstrconsts.rsgtkoptiondisplay
+msgid ""
+"Connect to the specified X server, where \"h\" is the hostname, \"s\" is the server number "
+"(usually 0), and \"d\" is the display number (typically omitted). If --display is not specified, "
+"the DISPLAY environment variable is used."
+msgstr ""
+"Anslut till den angivna X-servern, där ”h” är värdnamnet, ”s” är servernumret (vanligen 0) och "
+"”d” är bildskärmsnumret (utelämnas normalt). Om --display inte anges används miljövariabeln "
+"DISPLAY."
+
+#: lclstrconsts.rsgtkoptionmodule
+msgid "Load the specified module at startup."
+msgstr "Läs in den angivna modulen vid start."
+
+#: lclstrconsts.rsgtkoptionname
+msgid "Set program name to \"progname\". If not specified, program name will be set to ParamStrUTF8(0)."
+msgstr "Ange programnamnet som ”progname”. Om inget anges sätts programnamnet till ParamStrUTF8(0)."
+
+#: lclstrconsts.rsgtkoptionnodebug
+msgid "Turn off specific Gtk+ trace/debug messages."
+msgstr "Inaktivera specifika Gtk+-spårnings-/felsökningsmeddelanden."
+
+#: lclstrconsts.rsgtkoptionnotransient
+msgid "Do not set transient order for modal forms."
+msgstr "Ange inte transient ordning för modala formulär."
+
+#: lclstrconsts.rsgtkoptionnoxshm
+msgid "Disable use of the X Shared Memory Extension."
+msgstr "Inaktivera X Shared Memory-tillägget."
+
+#: lclstrconsts.rsgtkoptionsync
+msgid ""
+"Call XSynchronize (display, True) after the Xserver connection has been established. This makes "
+"debugging X protocol errors easier, because X request buffering will be disabled and X errors "
+"will be received immediately after the protocol request that generated the error has been "
+"processed by the X server."
+msgstr ""
+"Anropa XSynchronize (display, True) efter att anslutningen till X-servern har upprättats. Det gör"
+" felsökning av X-protokollfel enklare eftersom buffring av X-förfrågningar inaktiveras och X-fel "
+"tas emot direkt efter att protokollförfrågan som orsakade felet har behandlats av X-servern."
+
+#: lclstrconsts.rshelp
+msgctxt "lclstrconsts.rshelp"
+msgid "Help"
+msgstr "Hjälp"
+
+#: lclstrconsts.rshelpalreadyregistered
+#, object-pascal-format
+msgid "%s: already registered."
+msgstr "%s: redan registrerad."
+
+#: lclstrconsts.rshelpcontextnotfound
+msgid "A help database was found for this topic, but this topic was not found"
+msgstr "En hjälpdatabas hittades för det här ämnet, men ämnet hittades inte"
+
+#: lclstrconsts.rshelpdatabasenotfound
+msgid "There is no help database installed for this topic"
+msgstr "Ingen hjälpdatabas är installerad för det här ämnet"
+
+#: lclstrconsts.rshelperror
+msgid "Help Error"
+msgstr "Hjälpfel"
+
+#: lclstrconsts.rshelphelpcontextnotfound
+#, object-pascal-format
+msgid "Help context %s not found."
+msgstr "Hjälpkontexten %s hittades inte."
+
+#: lclstrconsts.rshelphelpcontextnotfoundindatabase
+#, object-pascal-format
+msgid "Help context %s not found in Database \"%s\"."
+msgstr "Hjälpkontexten %s hittades inte i databasen ”%s”."
+
+#: lclstrconsts.rshelphelpdatabasedidnotfoundaviewerforahelppageoftype
+#, object-pascal-format
+msgid "Help Database \"%s\" did not find a viewer for a help page of type %s."
+msgstr "Hjälpdatabasen ”%s” hittade ingen visare för en hjälpsida av typen %s."
+
+#: lclstrconsts.rshelphelpdatabasenotfound
+#, object-pascal-format
+msgid "Help Database \"%s\" not found."
+msgstr "Hjälpdatabasen ”%s” hittades inte."
+
+#: lclstrconsts.rshelphelpfordirectivenotfound
+#, object-pascal-format
+msgid "Help for directive \"%s\" not found."
+msgstr "Hjälp för direktivet ”%s” hittades inte."
+
+#: lclstrconsts.rshelphelpfordirectivenotfoundindatabase
+#, object-pascal-format
+msgid "Help for directive \"%s\" not found in Database \"%s\"."
+msgstr "Hjälp för direktivet ”%s” hittades inte i databasen ”%s”."
+
+#: lclstrconsts.rshelphelpkeywordnotfound
+#, object-pascal-format
+msgid "Help keyword \"%s\" not found."
+msgstr "Hjälpnyckelordet ”%s” hittades inte."
+
+#: lclstrconsts.rshelphelpkeywordnotfoundindatabase
+#, object-pascal-format
+msgid "Help keyword \"%s\" not found in Database \"%s\"."
+msgstr "Hjälpnyckelordet ”%s” hittades inte i databasen ”%s”."
+
+#: lclstrconsts.rshelphelpnodehasnohelpdatabase
+#, object-pascal-format
+msgid "Help node \"%s\" has no Help Database."
+msgstr "Hjälpnoden ”%s” har ingen hjälpdatabas."
+
+#: lclstrconsts.rshelpnohelpfoundforsource
+#, object-pascal-format
+msgid "No help found for line %d, column %d of %s."
+msgstr "Ingen hjälp hittades för rad %d, kolumn %d i %s."
+
+#: lclstrconsts.rshelpnohelpnodesavailable
+msgid "No help entries available for this topic."
+msgstr "Inga hjälpposter är tillgängliga för det här ämnet."
+
+#: lclstrconsts.rshelpnotfound
+msgid "No help found for this topic"
+msgstr "Ingen hjälp hittades för det här ämnet"
+
+#: lclstrconsts.rshelpnotregistered
+#, object-pascal-format
+msgid "%s: not registered."
+msgstr "%s: inte registrerad."
+
+#: lclstrconsts.rshelpselectorerror
+msgid "Help Selector Error"
+msgstr "Fel i hjälpval"
+
+#: lclstrconsts.rshelpthereisnoviewerforhelptype
+#, object-pascal-format
+msgid "There is no viewer for help type \"%s\"."
+msgstr "Det finns ingen visare för hjälptypen ”%s”."
+
+#: lclstrconsts.rshelpviewererror
+msgid "Help Viewer Error"
+msgstr "Fel i hjälpvisare"
+
+#: lclstrconsts.rshelpviewernotfound
+msgid "No viewer was found for this type of help content"
+msgstr "Ingen visare hittades för den här typen av hjälpinnehåll"
+
+#: lclstrconsts.rshidedetails
+msgid "Hide details"
+msgstr "Dölj detaljer"
+
+#: lclstrconsts.rshighlightcolorcaption
+msgid "Highlight"
+msgstr "Framhäv"
+
+#: lclstrconsts.rshighlighttextcolorcaption
+msgid "Highlight Text"
+msgstr "Framhäv text"
+
+#: lclstrconsts.rshotlightcolorcaption
+msgid "Hot Light"
+msgstr "Aktiv framhävning"
+
+#: lclstrconsts.rsicns
+msgid "macOS Icon Files"
+msgstr "macOS-ikonfiler"
+
+#: lclstrconsts.rsicon
+msgid "Icon Files"
+msgstr "Ikonfiler"
+
+#: lclstrconsts.rsiconimageempty
+msgid "Icon image cannot be empty"
+msgstr "Ikonbilden får inte vara tom"
+
+#: lclstrconsts.rsiconimageformat
+msgid "Icon image must have the same format"
+msgstr "Ikonbilden måste ha samma format"
+
+#: lclstrconsts.rsiconimageformatchange
+msgid "Cannot change format of icon image"
+msgstr "Det går inte att ändra ikonbildens format"
+
+#: lclstrconsts.rsiconimagesize
+msgid "Icon image must have the same size"
+msgstr "Ikonbilden måste ha samma storlek"
+
+#: lclstrconsts.rsiconimagesizechange
+msgid "Cannot change size of icon image"
+msgstr "Det går inte att ändra ikonbildens storlek"
+
+#: lclstrconsts.rsiconnocurrent
+msgid "Icon has no current image"
+msgstr "Ikonen har ingen aktuell bild"
+
+#: lclstrconsts.rsinactivebordercolorcaption
+msgid "Inactive Border"
+msgstr "Inaktiv kant"
+
+#: lclstrconsts.rsinactivecaptioncolorcaption
+msgctxt "lclstrconsts.rsinactivecaptioncolorcaption"
+msgid "Inactive Caption"
+msgstr "Inaktiv namnlist"
+
+#: lclstrconsts.rsinactivecaptiontext
+msgctxt "lclstrconsts.rsinactivecaptiontext"
+msgid "Inactive Caption"
+msgstr "Inaktiv namnlist"
+
+#: lclstrconsts.rsindexoutofbounds
+#, object-pascal-format
+msgid "%s Index %d out of bounds 0 .. %d"
+msgstr "%s Index %d utanför intervallet 0 .. %d"
+
+#: lclstrconsts.rsindexoutofboundsminusone
+#, object-pascal-format
+msgid "%s Index %d out of bounds -1 .. %d"
+msgstr "%s Index %d utanför intervallet -1 .. %d"
+
+#: lclstrconsts.rsindexoutofrange
+#, object-pascal-format
+msgid "Index Out of range Cell[Col=%d Row=%d]"
+msgstr "Index utanför intervallet Cell[Col=%d Row=%d]"
+
+#: lclstrconsts.rsinfobkcolorcaption
+msgid "Info Background"
+msgstr "Informationsbakgrund"
+
+#: lclstrconsts.rsinfotextcolorcaption
+msgid "Info Text"
+msgstr "Informationstext"
+
+#: lclstrconsts.rsinsertrecordhint
+msgctxt "lclstrconsts.rsinsertrecordhint"
+msgid "Insert"
+msgstr "Infoga"
+
+#: lclstrconsts.rsinvaliddate
+#, object-pascal-format
+msgid "Invalid Date : %s"
+msgstr "Ogiltigt datum: %s"
+
+#: lclstrconsts.rsinvaliddaterangehint
+#, object-pascal-format
+msgid "Invalid Date: %s. Must be between %s and %s"
+msgstr "Ogiltigt datum: %s. Måste vara mellan %s och %s"
+
+#: lclstrconsts.rsinvalidformobjectstream
+msgid "invalid Form object stream"
+msgstr "ogiltig formulärobjektström"
+
+#: lclstrconsts.rsinvalidpropertyvalue
+msgid "Invalid property value"
+msgstr "Ogiltigt egenskapsvärde"
+
+#: lclstrconsts.rsinvalidstreamformat
+msgid "Invalid stream format"
+msgstr "Ogiltigt strömformat"
+
+#: lclstrconsts.rsisalreadyassociatedwith
+#, object-pascal-format
+msgid "%s is already associated with %s"
+msgstr "%s är redan associerad med %s"
+
+#: lclstrconsts.rsjpeg
+msgid "JPEG Files"
+msgstr "JPEG-filer"
+
+#: lclstrconsts.rslastrecordhint
+msgid "Last"
+msgstr "Sista"
+
+#: lclstrconsts.rslimecolorcaption
+msgid "Lime"
+msgstr "Limegrön"
+
+#: lclstrconsts.rslistindexexceedsbounds
+#, object-pascal-format
+msgid "List index exceeds bounds (%d)"
+msgstr "Listindex överskrider gränserna (%d)"
+
+#: lclstrconsts.rsmacoscolordialogmbpick
+msgid "Pick"
+msgstr "Välj"
+
+#: lclstrconsts.rsmacoseditmenu
+msgctxt "lclstrconsts.rsmacoseditmenu"
+msgid "Edit"
+msgstr "Redigera"
+
+#: lclstrconsts.rsmacoseditmenucopy
+msgctxt "lclstrconsts.rsmacoseditmenucopy"
+msgid "Copy"
+msgstr "Kopiera"
+
+#: lclstrconsts.rsmacoseditmenucut
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: lclstrconsts.rsmacoseditmenupaste
+msgctxt "lclstrconsts.rsmacoseditmenupaste"
+msgid "Paste"
+msgstr "Klistra in"
+
+#: lclstrconsts.rsmacoseditmenuredo
+msgid "Redo"
+msgstr "Gör om"
+
+#: lclstrconsts.rsmacoseditmenuselectall
+msgid "Select All"
+msgstr "Markera allt"
+
+#: lclstrconsts.rsmacoseditmenuundo
+msgid "Undo"
+msgstr "Ångra"
+
+#: lclstrconsts.rsmacosfiledialogpackageswitchtips
+msgid "Treat File Packages (such as *.app files) as Directories to access their internal files"
+msgstr "Behandla filpaket (t.ex. *.app-filer) som kataloger för åtkomst till deras interna filer"
+
+#: lclstrconsts.rsmacosfiledialogpackageswitchtitle
+msgid "Show File Package Contents"
+msgstr "Visa innehållet i filpaket"
+
+#: lclstrconsts.rsmacosfileformat
+msgid "File Format:"
+msgstr "Filformat:"
+
+#: lclstrconsts.rsmacosfontdialogmbselect
+msgid "Select"
+msgstr "Välj"
+
+#: lclstrconsts.rsmacosmenuabout
+#, object-pascal-format
+msgid "About %s"
+msgstr "Om %s"
+
+#: lclstrconsts.rsmacosmenuhide
+#, object-pascal-format
+msgid "Hide %s"
+msgstr "Dölj %s"
+
+#: lclstrconsts.rsmacosmenuhideothers
+msgid "Hide Others"
+msgstr "Dölj övriga"
+
+#: lclstrconsts.rsmacosmenupreferences
+msgid "Preferences..."
+msgstr "Inställningar..."
+
+#: lclstrconsts.rsmacosmenuquit
+#, object-pascal-format
+msgid "Quit %s"
+msgstr "Avsluta %s"
+
+#: lclstrconsts.rsmacosmenuservices
+msgid "Services"
+msgstr "Tjänster"
+
+#: lclstrconsts.rsmacosmenushowall
+msgid "Show All"
+msgstr "Visa alla"
+
+#: lclstrconsts.rsmacosmenutogglefullscreen
+msgid "Toggle Full Screen"
+msgstr "Växla helskärm"
+
+#: lclstrconsts.rsmarooncolorcaption
+msgid "Maroon"
+msgstr "Rödbrun"
+
+#: lclstrconsts.rsmbabort
+msgid "Abort"
+msgstr "Avbryt"
+
+#: lclstrconsts.rsmball
+msgid "&All"
+msgstr "&Alla"
+
+#: lclstrconsts.rsmbcancel
+msgctxt "lclstrconsts.rsmbcancel"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: lclstrconsts.rsmbclose
+msgid "&Close"
+msgstr "&Stäng"
+
+#: lclstrconsts.rsmbhelp
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: lclstrconsts.rsmbignore
+msgid "&Ignore"
+msgstr "&Ignorera"
+
+#: lclstrconsts.rsmbno
+msgid "&No"
+msgstr "&Nej"
+
+#: lclstrconsts.rsmbnotoall
+msgid "No to all"
+msgstr "Nej till alla"
+
+#: lclstrconsts.rsmbok
+msgid "&OK"
+msgstr "&OK"
+
+#: lclstrconsts.rsmbopen
+msgid "&Open"
+msgstr "&Öppna"
+
+#: lclstrconsts.rsmbretry
+msgid "&Retry"
+msgstr "&Försök igen"
+
+#: lclstrconsts.rsmbsave
+msgid "&Save"
+msgstr "&Spara"
+
+#: lclstrconsts.rsmbunlock
+msgid "&Unlock"
+msgstr "&Lås upp"
+
+#: lclstrconsts.rsmbyes
+msgid "&Yes"
+msgstr "&Ja"
+
+#: lclstrconsts.rsmbyestoall
+msgid "Yes to &All"
+msgstr "Ja till &alla"
+
+#: lclstrconsts.rsmedgraycolorcaption
+msgid "Medium Gray"
+msgstr "Mellangrå"
+
+#: lclstrconsts.rsmenubarcolorcaption
+msgid "Menu Bar"
+msgstr "Menyrad"
+
+#: lclstrconsts.rsmenucolorcaption
+msgctxt "lclstrconsts.rsmenucolorcaption"
+msgid "Menu"
+msgstr "Meny"
+
+#: lclstrconsts.rsmenuhighlightcolorcaption
+msgid "Menu Highlight"
+msgstr "Menymarkering"
+
+#: lclstrconsts.rsmenutextcolorcaption
+msgid "Menu Text"
+msgstr "Menytext"
+
+#: lclstrconsts.rsmoneygreencolorcaption
+msgid "Money Green"
+msgstr "Penninggrön"
+
+#: lclstrconsts.rsmtauthentication
+msgid "Authentication"
+msgstr "Autentisering"
+
+#: lclstrconsts.rsmtconfirmation
+msgid "Confirmation"
+msgstr "Bekräftelse"
+
+#: lclstrconsts.rsmtcustom
+msgid "Custom"
+msgstr "Anpassat"
+
+#: lclstrconsts.rsmterror
+msgctxt "lclstrconsts.rsmterror"
+msgid "Error"
+msgstr "Fel"
+
+#: lclstrconsts.rsmtinformation
+msgid "Information"
+msgstr "Information"
+
+#: lclstrconsts.rsmtwarning
+msgid "Warning"
+msgstr "Varning"
+
+#: lclstrconsts.rsnavycolorcaption
+msgid "Navy"
+msgstr "Marinblå"
+
+#: lclstrconsts.rsnextrecordhint
+msgctxt "lclstrconsts.rsnextrecordhint"
+msgid "Next"
+msgstr "Nästa"
+
+#: lclstrconsts.rsnonecolorcaption
+msgid "None"
+msgstr "Ingen"
+
+#: lclstrconsts.rsnotavalidgridfile
+msgid "Not a valid grid file"
+msgstr "Inte en giltig rutnätsfil"
+
+#: lclstrconsts.rsnowidgetset
+msgid ""
+"No widgetset object. Please check if the unit \"interfaces\" was added to the programs uses "
+"clause."
+msgstr ""
+"Inget widgetset-objekt. Kontrollera att enheten ”interfaces” har lagts till i programmets uses-"
+"sats."
+
+#: lclstrconsts.rsolivecolorcaption
+msgid "Olive"
+msgstr "Olivgrön"
+
+#: lclstrconsts.rspickdate
+msgid "Select a date"
+msgstr "Välj ett datum"
+
+#: lclstrconsts.rspixmap
+msgid "Pixmap Files"
+msgstr "Pixmap-filer"
+
+#: lclstrconsts.rsportablenetworkgraphic
+msgid "PNG Files"
+msgstr "PNG-filer"
+
+#: lclstrconsts.rsportablepixmap
+msgid "Portable Pixmap Files"
+msgstr "Portable Pixmap-filer"
+
+#: lclstrconsts.rspostrecordhint
+msgid "Post"
+msgstr "Skicka"
+
+#: lclstrconsts.rspressoktoignoreandriskdatacorruptionpressaborttok
+#, object-pascal-format
+msgid "%s%sPress OK to ignore and risk data corruption.%sPress Abort to kill the program."
+msgstr ""
+"%s%sTryck på OK för att ignorera och riskera dataskada.%sTryck på Avbryt för att avsluta "
+"programmet."
+
+#: lclstrconsts.rspriorrecordhint
+msgctxt "lclstrconsts.rspriorrecordhint"
+msgid "Prior"
+msgstr "Föregående"
+
+#: lclstrconsts.rspromptonreplace
+msgid "Prompt on replace"
+msgstr "Fråga vid ersättning"
+
+#: lclstrconsts.rspropertydoesnotexist
+#, object-pascal-format
+msgid "Property %s does not exist"
+msgstr "Egenskapen %s finns inte"
+
+#: lclstrconsts.rspurplecolorcaption
+msgid "Purple"
+msgstr "Lila"
+
+#: lclstrconsts.rsqtoptiondisableaccurateframe
+msgid ""
+"Disables fully accurate window frame under X11. This feature is implemented for Qt, Qt5 and Gtk2 "
+"interfaces and used mostly by GetWindowRect()."
+msgstr ""
+"Inaktiverar helt exakt fönsterram under X11. Funktionen är implementerad för gränssnitten Qt, Qt5"
+" och Gtk2 och används främst av GetWindowRect()."
+
+#: lclstrconsts.rsqtoptiondograb
+msgid ""
+"Running under a debugger can cause an implicit -nograb, use -dograb to override. Works only under"
+" X11, needs QT_DEBUG."
+msgstr ""
+"Körning under en felsökare kan orsaka ett implicit -nograb. Använd -dograb för att åsidosätta "
+"detta. Fungerar endast under X11 och kräver QT_DEBUG."
+
+#: lclstrconsts.rsqtoptiongraphicsstyle
+msgid ""
+"Sets the backend to be used for on-screen widgets and QPixmaps. Available options are native, "
+"raster and opengl. OpenGL is still unstable."
+msgstr ""
+"Anger vilken backend som ska användas för skärmwidgetar och QPixmap. Tillgängliga alternativ är "
+"native, raster och opengl. OpenGL är fortfarande instabilt."
+
+#: lclstrconsts.rsqtoptionnograb
+msgid "Tells Qt that it must never grab the mouse or the keyboard. Needs QT_DEBUG."
+msgstr "Anger för Qt att musen eller tangentbordet aldrig får fångas. Kräver QT_DEBUG."
+
+#: lclstrconsts.rsqtoptionreverse
+msgid "Sets the application's layout direction to Qt::RightToLeft."
+msgstr "Anger programmets layoutriktning till Qt::RightToLeft."
+
+#: lclstrconsts.rsqtoptionsession
+msgid "Restores the application from an earlier session."
+msgstr "Återställer programmet från en tidigare session."
+
+#: lclstrconsts.rsqtoptionstyle
+msgid ""
+"Sets the application GUI style. Possible values are motif, windows, and platinum. If you compiled"
+" Qt with additional styles or have additional styles as plugins these will be available to the "
+"-style command line option. NOTE: Not all styles are available on all platforms. If style param "
+"does not exist Qt will start an application with default common style (windows)."
+msgstr ""
+"Anger programmets GUI-stil. Möjliga värden är motif, windows och platinum. Om Qt har kompilerats "
+"med ytterligare stilar eller om ytterligare stilar finns som insticksmoduler blir de tillgängliga"
+" för kommandoradsalternativet -style. OBS: Alla stilar finns inte på alla plattformar. Om "
+"stilparametern inte finns startar Qt programmet med den gemensamma standardstilen (windows)."
+
+#: lclstrconsts.rsqtoptionstylesheet
+msgid ""
+"Sets the application Style Sheet. The value must be a path to a file that contains the Style "
+"Sheet. Note: Relative URLs in the Style Sheet file are relative to the Style Sheet file's path."
+msgstr ""
+"Anger programmets stilmall. Värdet måste vara en sökväg till en fil som innehåller stilmallen. "
+"Obs: Relativa URL:er i stilmallsfilen är relativa till stilmallsfilens sökväg."
+
+#: lclstrconsts.rsqtoptionsync
+msgid "Switches to synchronous mode for debugging. Works only under X11."
+msgstr "Växlar till synkront läge för felsökning. Fungerar endast under X11."
+
+#: lclstrconsts.rsqtoptionwidgetcount
+msgid ""
+"Prints debug message at the end about number of widgets left undestroyed and maximum number of "
+"widgets existed at the same time."
+msgstr ""
+"Skriver ett felsökningsmeddelande i slutet om antalet widgetar som inte förstörts och det högsta "
+"antalet widgetar som funnits samtidigt."
+
+#: lclstrconsts.rsqtoptionx11bgcolor
+msgid ""
+"Sets the default background color and an application palette (light and dark shades are "
+"calculated)."
+msgstr "Anger standardbakgrundsfärg och en programpalett (ljusa och mörka nyanser beräknas)."
+
+#: lclstrconsts.rsqtoptionx11btncolor
+msgid "Sets the default button color."
+msgstr "Anger standardfärg för knappar."
+
+#: lclstrconsts.rsqtoptionx11cmap
+msgid "Causes the application to install a private color map on an 8-bit display."
+msgstr "Gör att programmet installerar en privat färgkarta på en 8-bitarsbildskärm."
+
+#: lclstrconsts.rsqtoptionx11display
+msgid "Sets the X display. Default is $DISPLAY."
+msgstr "Anger X-bildskärmen. Standard är $DISPLAY."
+
+#: lclstrconsts.rsqtoptionx11fgcolor
+msgid "Sets the default foreground color."
+msgstr "Anger standardförgrundsfärg."
+
+#: lclstrconsts.rsqtoptionx11font
+msgid "Defines the application font. The font should be specified using an X logical font description."
+msgstr ""
+"Definierar programmets teckensnitt. Teckensnittet ska anges med en logisk "
+"X-teckensnittsbeskrivning."
+
+#: lclstrconsts.rsqtoptionx11geometry
+msgid "Sets the client geometry of the first window that is shown."
+msgstr "Anger klientgeometrin för det första fönster som visas."
+
+#: lclstrconsts.rsqtoptionx11im
+msgid "Sets the input method server (equivalent to setting the XMODIFIERS environment variable)."
+msgstr "Anger inmatningsmetodservern (motsvarar att ställa in miljövariabeln XMODIFIERS)."
+
+#: lclstrconsts.rsqtoptionx11inputstyle
+msgid ""
+"Defines how the input is inserted into the given widget, e.g. onTheSpot makes the input appear "
+"directly in the widget, while overTheSpot makes the input appear in a box floating over the "
+"widget and is not inserted until the editing is done."
+msgstr ""
+"Definierar hur inmatningen infogas i den angivna widgeten, t.ex. gör onTheSpot att inmatningen "
+"visas direkt i widgeten, medan overTheSpot visar inmatningen i en ruta ovanpå widgeten och inte "
+"infogar den förrän redigeringen är klar."
+
+#: lclstrconsts.rsqtoptionx11name
+msgid "Sets the application name."
+msgstr "Anger programnamnet."
+
+#: lclstrconsts.rsqtoptionx11ncols
+msgid ""
+"Limits the number of colors allocated in the color cube on an 8-bit display, if the application "
+"is using the QApplication::ManyColor color specification. If count is 216 then a 6x6x6 color cube"
+" is used (i.e. 6 levels of red, 6 of green, and 6 of blue); for other values, a cube "
+"approximately proportional to a 2x3x1 cube is used."
+msgstr ""
+"Begränsar antalet färger som allokeras i färgkuben på en 8-bitarsbildskärm om programmet använder"
+" färgspecifikationen QApplication::ManyColor. Om count är 216 används en färgkub på 6x6x6 (dvs. 6"
+" nivåer av rött, 6 av grönt och 6 av blått); för andra värden används en kub som är ungefär "
+"proportionell mot en 2x3x1-kub."
+
+#: lclstrconsts.rsqtoptionx11title
+msgid "Sets the application title."
+msgstr "Anger programmets titel."
+
+#: lclstrconsts.rsqtoptionx11visual
+msgid "Forces the application to use a TrueColor visual on an 8-bit display."
+msgstr "Tvingar programmet att använda en TrueColor-visual på en 8-bitarsbildskärm."
+
+#: lclstrconsts.rsrasterimageendupdate
+msgid "Endupdate while no update in progress"
+msgstr "Endupdate medan ingen uppdatering pågår"
+
+#: lclstrconsts.rsrasterimagesaveinupdate
+msgid "Cannot save image while update in progress"
+msgstr "Det går inte att spara bilden medan en uppdatering pågår"
+
+#: lclstrconsts.rsrasterimageupdateall
+msgid "Cannot begin update all when canvas only update in progress"
+msgstr "Det går inte att starta uppdatering av allt när endast uppdatering av ritytan pågår"
+
+#: lclstrconsts.rsredcolorcaption
+msgid "Red"
+msgstr "Röd"
+
+#: lclstrconsts.rsrefreshrecordshint
+msgid "Refresh"
+msgstr "Uppdatera"
+
+#: lclstrconsts.rsreplace
+msgid "Replace"
+msgstr "Ersätt"
+
+#: lclstrconsts.rsreplaceall
+msgid "Replace all"
+msgstr "Ersätt alla"
+
+#: lclstrconsts.rsresourcenotfound
+#, object-pascal-format
+msgctxt "lclstrconsts.rsresourcenotfound"
+msgid "Resource %s not found"
+msgstr "Resursen %s hittades inte"
+
+#: lclstrconsts.rsscrollbarcolorcaption
+msgid "ScrollBar"
+msgstr "Rullningslist"
+
+#: lclstrconsts.rsscrollbaroutofrange
+msgid "ScrollBar property out of range"
+msgstr "Egenskap för rullningslist utanför intervallet"
+
+#: lclstrconsts.rsselectcolortitle
+msgid "Select color"
+msgstr "Välj färg"
+
+#: lclstrconsts.rsselectfonttitle
+msgid "Select a font"
+msgstr "Välj ett teckensnitt"
+
+#: lclstrconsts.rsshowdetails
+msgid "Show details"
+msgstr "Visa detaljer"
+
+#: lclstrconsts.rssilvercolorcaption
+msgid "Silver"
+msgstr "Silver"
+
+#: lclstrconsts.rsskybluecolorcaption
+msgid "Sky Blue"
+msgstr "Himmelsblå"
+
+#: lclstrconsts.rstcustomtabcontrolaccessibilitydescription
+msgid "A control with tabs"
+msgstr "En kontroll med flikar"
+
+#: lclstrconsts.rstealcolorcaption
+msgid "Teal"
+msgstr "Blågrön"
+
+#: lclstrconsts.rstext
+msgid "Text"
+msgstr "Text"
+
+#: lclstrconsts.rstga
+msgid "TGA Image Files"
+msgstr "TGA-bildfiler"
+
+#: lclstrconsts.rsthebuiltinurlisreadonlychangethebaseurlinstead
+msgid "The built-in URL is read only. Change the BaseURL instead."
+msgstr "Den inbyggda URL:en är skrivskyddad. Ändra BaseURL i stället."
+
+#: lclstrconsts.rstiff
+msgid "Tagged Image File Format Files"
+msgstr "TIFF-bildfiler"
+
+#: lclstrconsts.rstpanelaccessibilitydescription
+msgctxt "lclstrconsts.rstpanelaccessibilitydescription"
+msgid "Panel"
+msgstr "Panel"
+
+#: lclstrconsts.rstsplitteraccessibilitydescription
+msgctxt "lclstrconsts.rstsplitteraccessibilitydescription"
+msgid "A grip to control how much size to give two parts of an area"
+msgstr "Ett handtag som styr hur mycket utrymme två delar av ett område får"
+
+#: lclstrconsts.rsttreeviewaccessibilitydescription
+msgctxt "lclstrconsts.rsttreeviewaccessibilitydescription"
+msgid "A tree of items"
+msgstr "Ett träd med objekt"
+
+#: lclstrconsts.rsunabletoloaddefaultfont
+msgid "Unable to load default font"
+msgstr "Det går inte att läsa in standardteckensnittet"
+
+#: lclstrconsts.rsunknownerrorpleasereportthisbug
+msgid "Unknown Error, please report this bug"
+msgstr "Okänt fel, rapportera felet"
+
+#: lclstrconsts.rsunknownpictureextension
+msgid "Unknown picture extension"
+msgstr "Okänd bildfiländelse"
+
+#: lclstrconsts.rsunknownpictureformat
+msgid "Unknown picture format"
+msgstr "Okänt bildformat"
+
+#: lclstrconsts.rsunsupportedbitmapformat
+msgid "Unsupported bitmap format."
+msgstr "Bitmapformatet stöds inte."
+
+#: lclstrconsts.rsunsupportedclipboardformat
+#, object-pascal-format
+msgid "Unsupported clipboard format: %s"
+msgstr "Urklippsformatet stöds inte: %s"
+
+#: lclstrconsts.rswarningunreleaseddcsdump
+#, object-pascal-format
+msgid " WARNING: There are %d unreleased DCs, a detailed dump follows:"
+msgstr " VARNING: Det finns %d ej frigivna DC:er, en detaljerad dump följer:"
+
+#: lclstrconsts.rswarningunreleasedgdiobjectsdump
+#, object-pascal-format
+msgid " WARNING: There are %d unreleased GDIObjects, a detailed dump follows:"
+msgstr " VARNING: Det finns %d ej frigivna GDIObjects, en detaljerad dump följer:"
+
+#: lclstrconsts.rswarningunreleasedmessagesinqueue
+#, object-pascal-format
+msgid " WARNING: There are %d messages left in the queue! I'll free them"
+msgstr " VARNING: Det finns %d meddelanden kvar i kön! De frigörs nu"
+
+#: lclstrconsts.rswarningunreleasedtimerinfos
+#, object-pascal-format
+msgid " WARNING: There are %d TimerInfo structures left, I'll free them"
+msgstr " VARNING: Det finns %d TimerInfo-strukturer kvar. De frigörs nu"
+
+#: lclstrconsts.rswarningunremovedpaintmessages
+#, object-pascal-format
+msgid " WARNING: There are %s unremoved LM_PAINT/LM_GtkPAINT message links left."
+msgstr " VARNING: Det finns %s ej borttagna LM_PAINT/LM_GtkPAINT-meddelandelänkar kvar."
+
+#: lclstrconsts.rswhitecolorcaption
+msgid "White"
+msgstr "Vit"
+
+#: lclstrconsts.rswholewordsonly
+msgid "Whole words only"
+msgstr "Endast hela ord"
+
+#: lclstrconsts.rswin32error
+msgid "Error:"
+msgstr "Fel:"
+
+#: lclstrconsts.rswin32warning
+msgid "Warning:"
+msgstr "Varning:"
+
+#: lclstrconsts.rswindowcolorcaption
+msgid "Window"
+msgstr "Fönster"
+
+#: lclstrconsts.rswindowframecolorcaption
+msgid "Window Frame"
+msgstr "Fönsterram"
+
+#: lclstrconsts.rswindowtextcolorcaption
+msgid "Window Text"
+msgstr "Fönstertext"
+
+#: lclstrconsts.rsyellowcolorcaption
+msgid "Yellow"
+msgstr "Gul"
+
+#: lclstrconsts.scannotfocus
+#, object-pascal-format
+msgid "Cannot focus a disabled or invisible window \"%s\""
+msgstr "Det går inte att sätta fokus på ett inaktiverat eller osynligt fönster ”%s”"
+
+#: lclstrconsts.sduplicatemenus
+msgid "Duplicate menus"
+msgstr "Dubblerade menyer"
+
+#: lclstrconsts.sinvalidactioncreation
+msgid "Invalid action creation"
+msgstr "Ogiltigt skapande av åtgärd"
+
+#: lclstrconsts.sinvalidactionenumeration
+msgid "Invalid action enumeration"
+msgstr "Ogiltig uppräkning av åtgärd"
+
+#: lclstrconsts.sinvalidactionregistration
+msgid "Invalid action registration"
+msgstr "Ogiltig registrering av åtgärd"
+
+#: lclstrconsts.sinvalidactionunregistration
+msgid "Invalid action unregistration"
+msgstr "Ogiltig avregistrering av åtgärd"
+
+#: lclstrconsts.sinvalidimagesize
+msgid "Invalid image size"
+msgstr "Ogiltig bildstorlek"
+
+#: lclstrconsts.sinvalidindex
+msgid "Invalid ImageList Index"
+msgstr "Ogiltigt ImageList-index"
+
+#: lclstrconsts.smaskeditnomatch
+msgid "The current text does not match the specified mask."
+msgstr "Den aktuella texten matchar inte den angivna masken."
+
+#: lclstrconsts.smenuindexerror
+msgid "Menu index out of range"
+msgstr "Menyindex utanför intervallet"
+
+#: lclstrconsts.smenuitemisnil
+msgid "MenuItem is nil"
+msgstr "MenuItem är nil"
+
+#: lclstrconsts.smenunotfound
+msgid "Sub-menu is not in menu"
+msgstr "Undermenyn finns inte i menyn"
+
+#: lclstrconsts.smkcalt
+msgid "Alt+"
+msgstr "Alt+"
+
+#: lclstrconsts.smkcbksp
+msgid "BkSp"
+msgstr "Backsteg"
+
+#: lclstrconsts.smkcctrl
+msgid "Ctrl+"
+msgstr "Ctrl+"
+
+#: lclstrconsts.smkcdel
+msgid "Del"
+msgstr "Del"
+
+#: lclstrconsts.smkcdown
+msgctxt "lclstrconsts.smkcdown"
+msgid "Down"
+msgstr "Ned"
+
+#: lclstrconsts.smkcend
+msgctxt "lclstrconsts.smkcend"
+msgid "End"
+msgstr "End"
+
+#: lclstrconsts.smkcenter
+msgid "Enter"
+msgstr "Enter"
+
+#: lclstrconsts.smkcesc
+msgid "Esc"
+msgstr "Esc"
+
+#: lclstrconsts.smkcfn
+msgid "Fn+"
+msgstr "Fn+"
+
+#: lclstrconsts.smkchome
+msgctxt "lclstrconsts.smkchome"
+msgid "Home"
+msgstr "Home"
+
+#: lclstrconsts.smkcins
+msgid "Ins"
+msgstr "Ins"
+
+#: lclstrconsts.smkcleft
+msgctxt "lclstrconsts.smkcleft"
+msgid "Left"
+msgstr "Vänster"
+
+#: lclstrconsts.smkcmeta
+msgid "Meta+"
+msgstr "Meta+"
+
+#: lclstrconsts.smkcpgdn
+msgid "PgDn"
+msgstr "PgDn"
+
+#: lclstrconsts.smkcpgup
+msgid "PgUp"
+msgstr "PgUp"
+
+#: lclstrconsts.smkcright
+msgctxt "lclstrconsts.smkcright"
+msgid "Right"
+msgstr "Höger"
+
+#: lclstrconsts.smkcshift
+msgid "Shift+"
+msgstr "Skift+"
+
+#: lclstrconsts.smkcspace
+msgid "Space"
+msgstr "Blanksteg"
+
+#: lclstrconsts.smkctab
+msgctxt "lclstrconsts.smkctab"
+msgid "Tab"
+msgstr "Tab"
+
+#: lclstrconsts.smkcup
+msgctxt "lclstrconsts.smkcup"
+msgid "Up"
+msgstr "Upp"
+
+#: lclstrconsts.snotimers
+msgid "No timers available"
+msgstr "Inga timers är tillgängliga"
+
+#: lclstrconsts.sparentrequired
+#, object-pascal-format
+msgid "Control \"%s\" has no parent window."
+msgstr "Kontrollen ”%s” har inget överordnat fönster."
+
+#: lclstrconsts.sparexpected
+#, object-pascal-format
+msgid "Wrong token type: %s expected"
+msgstr "Fel token-typ: %s förväntades"
+
+#: lclstrconsts.sparinvalidfloat
+#, object-pascal-format
+msgid "Invalid floating point number: %s"
+msgstr "Ogiltigt flyttal: %s"
+
+#: lclstrconsts.sparinvalidinteger
+#, object-pascal-format
+msgid "Invalid integer number: %s"
+msgstr "Ogiltigt heltal: %s"
+
+#: lclstrconsts.sparlocinfo
+#, object-pascal-format
+msgid " (at %d,%d, stream offset %d)"
+msgstr " (vid %d,%d, strömoffset %d)"
+
+#: lclstrconsts.sparunterminatedbinvalue
+msgid "Unterminated byte value"
+msgstr "Oavslutat bytevärde"
+
+#: lclstrconsts.sparunterminatedstring
+msgid "Unterminated string"
+msgstr "Oavslutad sträng"
+
+#: lclstrconsts.sparwrongtokensymbol
+#, object-pascal-format
+msgid "Wrong token symbol: %s expected but %s found"
+msgstr "Fel tokensymbol: %s förväntades men %s hittades"
+
+#: lclstrconsts.sparwrongtokentype
+#, object-pascal-format
+msgid "Wrong token type: %s expected but %s found"
+msgstr "Fel token-typ: %s förväntades men %s hittades"
+
+#: lclstrconsts.sshellctrlsattributes
+msgid "Attributes"
+msgstr "Attribut"
+
+#: lclstrconsts.sshellctrlsbytes
+#, object-pascal-format
+msgid "%s bytes"
+msgstr "%s byte"
+
+#: lclstrconsts.sshellctrlsfolder
+msgid "Folder"
+msgstr "Mapp"
+
+#: lclstrconsts.sshellctrlsgb
+#, object-pascal-format
+msgid "%s GB"
+msgstr "%s GB"
+
+#: lclstrconsts.sshellctrlsinvalidpath
+#, object-pascal-format
+msgctxt "lclstrconsts.sshellctrlsinvalidpath"
+msgid ""
+"Invalid pathname:\n"
+"\"%s\""
+msgstr ""
+"Ogiltig sökväg:\n"
+"”%s”"
+
+#: lclstrconsts.sshellctrlsinvalidpathrelative
+#, object-pascal-format
+msgid ""
+"Invalid relative pathname:\n"
+"\"%s\"\n"
+"in relation to rootpath:\n"
+"\"%s\""
+msgstr ""
+"Ogiltig relativ sökväg:\n"
+"”%s”\n"
+"i förhållande till rotsökvägen:\n"
+"”%s”"
+
+#: lclstrconsts.sshellctrlsinvalidroot
+#, object-pascal-format
+msgctxt "lclstrconsts.sshellctrlsinvalidroot"
+msgid ""
+"Invalid pathname:\n"
+"\"%s\""
+msgstr ""
+"Ogiltig sökväg:\n"
+"”%s”"
+
+#: lclstrconsts.sshellctrlskb
+#, object-pascal-format
+msgid "%s kB"
+msgstr "%s kB"
+
+#: lclstrconsts.sshellctrlsmb
+#, object-pascal-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#: lclstrconsts.sshellctrlsmodificationdate
+msgid "Date modified"
+msgstr "Ändringsdatum"
+
+#: lclstrconsts.sshellctrlsname
+msgid "Name"
+msgstr "Namn"
+
+#: lclstrconsts.sshellctrlsselecteditemdoesnotexists
+#, object-pascal-format
+msgid ""
+"The selected item does not exist on disk:\n"
+"\"%s\""
+msgstr ""
+"Det valda objektet finns inte på disken:\n"
+"”%s”"
+
+#: lclstrconsts.sshellctrlssize
+msgid "Size"
+msgstr "Storlek"
+
+#: lclstrconsts.sshellctrlstype
+msgid "Type"
+msgstr "Typ"

--- a/plugins/wcx/sevenzip/language/sevenzip.sv.po
+++ b/plugins/wcx/sevenzip/language/sevenzip.sv.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander Plugin - sevenzip\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: tdialogbox.btnapply.caption
+msgid "Apply"
+msgstr "Verkställ"
+
+#: tdialogbox.caption
+msgid "Options"
+msgstr "Alternativ"
+
+#: tdialogbox.lblarchiveformat.caption
+msgid "Archive &format:"
+msgstr "Arkiv&format:"
+
+#: tdialogbox.lblcompressiondictionary.caption
+msgid "&Dictionary size:"
+msgstr "&Ordboksstorlek:"
+
+#: tdialogbox.lblcompressionlevel.caption
+msgid "Compression &level:"
+msgstr "Komprimerings&nivå:"
+
+#: tdialogbox.lblcompressionmethod.caption
+msgid "Compression &method:"
+msgstr "Komprimerings&metod:"
+
+#: tdialogbox.lblcompressionsolid.caption
+msgid "&Solid Block size:"
+msgstr "Storlek på &solid block:"
+
+#: tdialogbox.lblcompressionword.caption
+msgid "&Word size:"
+msgstr "&Ordstorlek:"
+
+#: tdialogbox.lblmemorycompression.caption
+msgid "Memory usage for Compressing:"
+msgstr "Minnesanvändning vid komprimering:"
+
+#: tdialogbox.lblmemorydecompression.caption
+msgid "Memory usage for Decompressing:"
+msgstr "Minnesanvändning vid dekomprimering:"
+
+#: tdialogbox.lblparameters.caption
+msgid "&Parameters:"
+msgstr "&Parametrar:"
+
+#: tdialogbox.lblthreads.caption
+msgid "&Number of CPU threads:"
+msgstr "&Antal CPU-trådar:"
+
+#: tpasswordbox.caption
+msgid "Enter password"
+msgstr "Ange lösenord"
+
+#: tpasswordbox.cbencryptnames.caption
+msgid "Encrypt file &names"
+msgstr "Kryptera fil&namn"
+
+#: tpasswordbox.cbshowpassword.caption
+msgid "&Show password"
+msgstr "&Visa lösenord"
+
+#: tpasswordbox.lblpassword.caption
+msgid "&Enter password:"
+msgstr "&Ange lösenord:"
+
+#: sevenziplng.rscompressionlevelfast
+msgid "Fast"
+msgstr "Snabb"
+
+#: sevenziplng.rscompressionlevelfastest
+msgid "Fastest"
+msgstr "Snabbast"
+
+#: sevenziplng.rscompressionlevelmaximum
+msgid "Maximum"
+msgstr "Maximal"
+
+#: sevenziplng.rscompressionlevelnormal
+msgid "Normal"
+msgstr "Normal"
+
+#: sevenziplng.rscompressionlevelstore
+msgid "Store"
+msgstr "Lagra"
+
+#: sevenziplng.rscompressionlevelultra
+msgid "Ultra"
+msgstr "Ultra"
+
+#: sevenziplng.rssevenziploaderror
+#, object-pascal-format
+msgid "Failed to load 7-Zip library (%s)!"
+msgstr "Det gick inte att läsa in 7-Zip-biblioteket (%s)!"
+
+#: sevenziplng.rssevenzipsfxnotfound
+msgid "Cannot find specified SFX module!"
+msgstr "Det går inte att hitta den angivna SFX-modulen!"
+
+#: sevenziplng.rssolidblocknonsolid
+msgid "Non-solid"
+msgstr "Icke-solid"
+
+#: sevenziplng.rssolidblocksolid
+msgid "Solid"
+msgstr "Solid"

--- a/plugins/wcx/unrar/language/unrar.sv.po
+++ b/plugins/wcx/unrar/language/unrar.sv.po
@@ -1,0 +1,94 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander Plugin - unrar\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: tdialogbox.caption
+msgid "Options"
+msgstr "Alternativ"
+
+#: tdialogbox.lblpath.caption
+msgid "Path to Win&RAR executable"
+msgstr "Sökväg till körbar Win&RAR-fil"
+
+#: tdialogbox.gboptions.caption
+msgid "Archiving options"
+msgstr "Arkiveringsalternativ"
+
+#: tdialogbox.gboptions.chkrecovery.caption
+msgid "Add r&ecovery record"
+msgstr "Lägg till &återställningspost"
+
+#: tdialogbox.gboptions.chkencrypt.caption
+msgid "Encrypt file &names"
+msgstr "Kryptera fil&namn"
+
+#: tdialogbox.gboptions.chksolid.caption
+msgid "Create &solid archive"
+msgstr "Skapa &solitt arkiv"
+
+#: tdialogbox.lblmethod.caption
+msgid "&Compression method"
+msgstr "&Komprimeringsmetod"
+
+#: tdialogbox.brncancel.caption
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tdialogbox.btnsave.caption
+msgid "OK"
+msgstr "OK"
+
+#: tdialogbox.lblargs.caption
+msgid "Additional parameters"
+msgstr "Ytterligare parametrar"
+
+#: rarlng.rsdictlargewarning
+msgid "Large dictionary warning"
+msgstr "Varning för stor ordbok"
+
+#: rarlng.rsdictnotallowed
+#, object-pascal-format
+msgid "%u GB dictionary exceeds %u GB limit and needs more than %u GB memory to unpack."
+msgstr "En ordbok på %u GB överskrider gränsen på %u GB och kräver mer än %u GB minne för uppackning."
+
+#: rarlng.rsmsgbuttoncancel
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: rarlng.rsmsgbuttonextract
+msgid "&Extract"
+msgstr "&Packa upp"
+
+#: rarlng.rsmsgpasswordenter
+msgid "Please enter the password:"
+msgstr "Ange lösenordet:"
+
+#: rarlng.rsmsgexecutablenotfound
+#, object-pascal-format
+msgid ""
+"Cannot find RAR executable!\n"
+"\n"
+"%s\n"
+"\n"
+"Please check the plugin settings."
+msgstr ""
+"Det går inte att hitta den körbara RAR-filen!\n"
+"\n"
+"%s\n"
+"\n"
+"Kontrollera insticksmodulens inställningar."
+
+#: rarlng.rsmsglibrarynotfound
+#, object-pascal-format
+msgid "Cannot load library %s! Please check your installation."
+msgstr "Det går inte att läsa in biblioteket %s! Kontrollera installationen."

--- a/plugins/wfx/MacCloud/language/MacCloud.sv.po
+++ b/plugins/wfx/MacCloud/language/MacCloud.sv.po
@@ -1,0 +1,204 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander Plugin - MacCloud\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: uwfxconfig.rsaliyunossdisplayname
+msgctxt "uwfxconfig.rsaliyunossdisplayname"
+msgid "Alibaba Cloud OSS"
+msgstr "Alibaba Cloud OSS"
+
+#: uwfxconfig.rsamazons3displayname
+msgctxt "uwfxconfig.rsamazons3displayname"
+msgid "Amazon S3"
+msgstr "Amazon S3"
+
+#: uwfxconfig.rsbackblazeb2displayname
+msgid "BackBlaze B2"
+msgstr "BackBlaze B2"
+
+#: uwfxconfig.rsboxdisplayname
+msgctxt "uwfxconfig.rsboxdisplayname"
+msgid "Box"
+msgstr "Box"
+
+#: uwfxconfig.rsdropboxdisplayname
+msgctxt "uwfxconfig.rsdropboxdisplayname"
+msgid "DropBox"
+msgstr "DropBox"
+
+#: uwfxconfig.rshuaweiobsdisplayname
+msgctxt "uwfxconfig.rshuaweiobsdisplayname"
+msgid "Huawei Cloud OBS"
+msgstr "Huawei Cloud OBS"
+
+#: uwfxconfig.rsoauth2authnotes
+#
+msgctxt "uwfxconfig.rsoauth2authnotes"
+msgid ""
+"1. Before successfully enabling the connection, Double Commander needs to obtain authorization "
+"from {driverName}\n"
+"\n"
+"2. Click the connect button to be redirected to the {driverName} official website in the Safari "
+"browser\n"
+"\n"
+"3. Please login your {driverName} account in Safari and authorize Double Commander to access\n"
+"\n"
+"4. The authorization is completed on the {driverName} official website, Double Commander will not"
+" get your password"
+msgstr ""
+"1. Innan anslutningen kan aktiveras behöver Double Commander få behörighet från {driverName}\n"
+"\n"
+"2. Klicka på anslutningsknappen för att omdirigeras till {driverName}s officiella webbplats i "
+"Safari\n"
+"\n"
+"3. Logga in på ditt {driverName}-konto i Safari och ge Double Commander åtkomst\n"
+"\n"
+"4. Auktoriseringen slutförs på {driverName}s officiella webbplats. Double Commander får inte "
+"tillgång till ditt lösenord"
+
+#: uwfxconfig.rsonedrivedisplayname
+msgctxt "uwfxconfig.rsonedrivedisplayname"
+msgid "OneDrive"
+msgstr "OneDrive"
+
+#: uwfxconfig.rsqiniukododisplayname
+msgid "Qiniu Cloud KODO"
+msgstr "Qiniu Cloud KODO"
+
+#: uwfxconfig.rss3autoconfignotes
+msgid ""
+"1. AccessKeyID and SerectAccessKey will be saved in the macOS KeyChains to obtain system-level "
+"security. The confidential data can only be read by your own macOS permissions.\n"
+"\n"
+"2. Access Key ID and Secret Access Key are required, and the others are optional. Double "
+"Commander can usually automatically obtain others such as Buckets. Therefore, Region / EndPoint /"
+" Bucket are only required if Access Key permissions are insufficient."
+msgstr ""
+"1. AccessKeyID och SecretAccessKey sparas i macOS-nyckelringen för säkerhet på systemnivå. De "
+"konfidentiella uppgifterna kan endast läsas med dina egna macOS-behörigheter.\n"
+"\n"
+"2. Access Key ID och Secret Access Key krävs, övriga uppgifter är valfria. Double Commander kan "
+"vanligtvis hämta övriga uppgifter, till exempel bucketar, automatiskt. Region / EndPoint / Bucket"
+" behövs därför bara om behörigheterna för Access Key inte är tillräckliga."
+
+#: uwfxconfig.rss3compatibledisplayname
+msgctxt "uwfxconfig.rss3compatibledisplayname"
+msgid "S3 Compatible"
+msgstr "S3-kompatibel"
+
+#: uwfxconfig.rss3manualconfignotes
+#
+msgid ""
+"1. AccessKeyID and SerectAccessKey will be saved in the macOS KeyChains to obtain system-level "
+"security. The confidential data can only be read by your own macOS permissions.\n"
+"\n"
+"2. Access Key ID / Secret Access Key / Region / EndPoint / Bucket are required for {driverName}"
+msgstr ""
+"1. AccessKeyID och SecretAccessKey sparas i macOS-nyckelringen för säkerhet på systemnivå. De "
+"konfidentiella uppgifterna kan endast läsas med dina egna macOS-behörigheter.\n"
+"\n"
+"2. Access Key ID / Secret Access Key / Region / EndPoint / Bucket krävs för {driverName}"
+
+#: uwfxconfig.rstencentcosdisplayname
+msgctxt "uwfxconfig.rstencentcosdisplayname"
+msgid "Tencent Cloud COS"
+msgstr "Tencent Cloud COS"
+
+#: uwfxconfig.rsupyunussdisplayname
+msgid "Upyun USS"
+msgstr "Upyun USS"
+
+#: uwfxconfig.rsyandexdisplayname
+msgctxt "uwfxconfig.rsyandexdisplayname"
+msgid "Yandex"
+msgstr "Yandex"
+
+#: uwfxoptionscommonrs.rsaddnewconnection
+msgctxt "uwfxoptionscommonrs.rsaddnewconnection"
+msgid "<Add New Connection>"
+msgstr "<Lägg till ny anslutning>"
+
+#: uwfxoptionscommonrs.rscancelbuttontitle
+msgctxt "uwfxoptionscommonrs.rscancelbuttontitle"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: uwfxoptionscommonrs.rsconnectbuttontitle
+msgctxt "uwfxoptionscommonrs.rsconnectbuttontitle"
+msgid "Connect"
+msgstr "Anslut"
+
+#: uwfxoptionscommonrs.rsdisconnectbuttontitle
+msgctxt "uwfxoptionscommonrs.rsdisconnectbuttontitle"
+msgid "Disconnect"
+msgstr "Koppla från"
+
+#: uwfxoptionscommonrs.rsnamelabel
+msgctxt "uwfxoptionscommonrs.rsnamelabel"
+msgid "Name:"
+msgstr "Namn:"
+
+#: uwfxoptionscommonrs.rsokbuttontitle
+msgctxt "uwfxoptionscommonrs.rsokbuttontitle"
+msgid "OK"
+msgstr "OK"
+
+#: uwfxoptionscommonrs.rssavebuttontitle
+msgctxt "uwfxoptionscommonrs.rssavebuttontitle"
+msgid "Save"
+msgstr "Spara"
+
+#: uwfxoptionss3.rsaccesskeyidlabel
+msgid "Access Key ID:"
+msgstr "Access Key ID:"
+
+#: uwfxoptionss3.rsbucketlabel
+msgid "Bucket:"
+msgstr "Bucket:"
+
+#: uwfxoptionss3.rsendpointlabel
+msgid "Endpoint:"
+msgstr "Endpoint:"
+
+#: uwfxoptionss3.rsparamsalerttext
+msgid ""
+"Access Key ID and Secret Access Key are required, please make sure they are correct. If "
+"permissions are insufficient or you are setting \"S3 Compatible\", Region / Endpoint / Bucket is "
+"also required."
+msgstr ""
+"Access Key ID och Secret Access Key krävs. Kontrollera att de är korrekta. Om behörigheterna är "
+"otillräckliga eller om du konfigurerar ”S3-kompatibel” krävs även Region / Endpoint / Bucket."
+
+#: uwfxoptionss3.rsparamsalerttitle
+msgid "Incomplete Parameters"
+msgstr "Ofullständiga parametrar"
+
+#: uwfxoptionss3.rsregionlabel
+msgid "Region:"
+msgstr "Region:"
+
+#: uwfxoptionss3.rsregionlistlabel
+msgid "Region List:"
+msgstr "Regionlista:"
+
+#: uwfxoptionss3.rsregionusercustom
+msgid "(User Custom)"
+msgstr "(Användardefinierad)"
+
+#: uwfxoptionss3.rssecretaccesskeylabel
+msgid "Secret Access Key:"
+msgstr "Secret Access Key:"
+
+#: uwfxoptionss3.rstemporarytokenlabel
+msgid "Temporary Token:"
+msgstr "Tillfällig token:"

--- a/plugins/wfx/ftp/language/ftp.sv.po
+++ b/plugins/wfx/ftp/language/ftp.sv.po
@@ -1,0 +1,172 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Double Commander Plugin - ftp\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-09-04 23:30+0300\n"
+"Last-Translator: Jonatan Nyberg <84130654+NickWick13@users.noreply.github.com>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Native-Language: Svenska\n"
+
+#: tdialogbox.btnadd.caption
+msgid "+"
+msgstr "+"
+
+#: tdialogbox.btnanonymous.caption
+msgid "Anonymous"
+msgstr "Anonym"
+
+#: tdialogbox.btncancel.caption
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: tdialogbox.btnchangepassword.caption
+msgid "Change password..."
+msgstr "Ändra lösenord..."
+
+#: tdialogbox.btndelete.caption
+msgid "-"
+msgstr "-"
+
+#: tdialogbox.btnok.caption
+msgid "&OK"
+msgstr "&OK"
+
+#: tdialogbox.caption
+msgctxt "tdialogbox.caption"
+msgid "FTP"
+msgstr "FTP"
+
+#: tdialogbox.chkagentssh.caption
+msgid "Use SSH-agent authentication"
+msgstr "Använd SSH-agentautentisering"
+
+#: tdialogbox.chkcopyscp.caption
+msgid "Copy using SCP protocol (faster)"
+msgstr "Kopiera med SCP-protokollet (snabbare)"
+
+#: tdialogbox.chkkeepalivetransfer.caption
+msgid "Send keepalive during a transfer"
+msgstr "Skicka keepalive under en överföring"
+
+#: tdialogbox.chkmasterpassword.caption
+msgid "Use main password to protect the password"
+msgstr "Använd huvudlösenordet för att skydda lösenordet"
+
+#: tdialogbox.chkpassivemode.caption
+msgid "Use passive mode for transfers (like a WWW browser)"
+msgstr "Använd passivt läge för överföringar (som en webbläsare)"
+
+#: tdialogbox.chkshowhidden.caption
+msgid "Use 'LIST -la' command to reveal hidden items"
+msgstr "Använd kommandot 'LIST -la' för att visa dolda objekt"
+
+#: tdialogbox.cmbencoding.text
+msgid "Auto"
+msgstr "Automatiskt"
+
+#: tdialogbox.dividerbevel.caption
+msgid "Client certificate for authentication:"
+msgstr "Klientcertifikat för autentisering:"
+
+#: tdialogbox.gbftp.caption
+msgctxt "tdialogbox.gbftp.caption"
+msgid "FTP"
+msgstr "FTP"
+
+#: tdialogbox.gblogon.caption
+msgid "Firewall logon"
+msgstr "Brandväggsinloggning"
+
+#: tdialogbox.gbssh.caption
+msgctxt "tdialogbox.gbssh.caption"
+msgid "SSH"
+msgstr "SSH"
+
+#: tdialogbox.lblencoding.caption
+msgid "Encoding:"
+msgstr "Teckenkodning:"
+
+#: tdialogbox.lblhost.caption
+msgid "Host[:Port]:"
+msgstr "Värd[:Port]:"
+
+#: tdialogbox.lblinitcommands.caption
+msgid "Init commands:"
+msgstr "Initieringskommandon:"
+
+#: tdialogbox.lblname.caption
+msgid "Connection name:"
+msgstr "Anslutningsnamn:"
+
+#: tdialogbox.lblprotocol.caption
+msgid "Protocol:"
+msgstr "Protokoll:"
+
+#: tdialogbox.lblpassword.caption
+msgid "Password:"
+msgstr "Lösenord:"
+
+#: tdialogbox.lblprivatekey.caption
+msgid "Private key file (*.pem):"
+msgstr "Privat nyckelfil (*.pem):"
+
+#: tdialogbox.lblproxy.caption
+msgid "Use firewall (proxy server)"
+msgstr "Använd brandvägg (proxyserver)"
+
+#: tdialogbox.lblproxyhost.caption
+msgid "&Host name:"
+msgstr "&Värdnamn:"
+
+#: tdialogbox.lblproxypassword.caption
+msgid "&Password:"
+msgstr "&Lösenord:"
+
+#: tdialogbox.lblproxyuser.caption
+msgid "&User name:"
+msgstr "&Användarnamn:"
+
+#: tdialogbox.lblpublickey.caption
+msgid "Public key file (*.pub):"
+msgstr "Publik nyckelfil (*.pub):"
+
+#: tdialogbox.lblremotedir.caption
+msgid "Remote dir:"
+msgstr "Fjärrkatalog:"
+
+#: tdialogbox.lblusername.caption
+msgid "User name:"
+msgstr "Användarnamn:"
+
+#: tdialogbox.rgproxytype.caption
+msgid "Connect method"
+msgstr "Anslutningsmetod"
+
+#: tdialogbox.tsadvanced.caption
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: tdialogbox.tsgeneral.caption
+msgid "General"
+msgstr "Allmänt"
+
+#: tdialogbox.tsproxy.caption
+msgid "Proxy"
+msgstr "Proxy"
+
+#: tfrmfileproperties.caption
+msgid "Properties"
+msgstr "Egenskaper"
+
+#: ftplng.rsaddconnection
+msgid "Add connection"
+msgstr "Lägg till anslutning"
+
+#: ftplng.rsquickconnection
+msgid "Quick connection"
+msgstr "Snabbanslutning"


### PR DESCRIPTION
## Summary

Add Swedish translations for Double Commander and several bundled plugins and components.

## Changes

This PR adds Swedish translations for:

- `language/doublecmd.sv.po` — main Double Commander interface
- `language/lcl/lclstrconsts.sv.po` — Lazarus/LCL interface strings
- `plugins/wcx/sevenzip/language/sevenzip.sv.po`
- `plugins/wcx/unrar/language/unrar.sv.po`
- `plugins/wfx/MacCloud/language/MacCloud.sv.po`
- `plugins/wfx/ftp/language/ftp.sv.po`

The translations use consistent Swedish UI terminology and preserve format placeholders, variables, line breaks, and plural forms.

The WCX Zip plugin translation is intentionally handled separately in PR #3072.

## Validation

- All six PO files pass `msgfmt --check`
- `git diff --cached --check` passes
- Only the six new Swedish translation files are added
