### PR TITLE
FIX: icon theme and MIME icon lookup ignoring $XDG_DATA_DIRS/$XDG_DATA_HOME

### DIFF
--- a/src/platform/unix/uunixicontheme.pas
+++ b/src/platform/unix/uunixicontheme.pas
@@ -316,22 +316,35 @@ end;
 procedure InitIconThemesBaseDirList;
 var
   Home: String;
-  I: Integer = 1;
+  I: Integer;
+  SystemDataDirs: TDynamicStringArray;
+  DirList: TStringList;
 begin
   Home := GetHomeDir;
-  SetLength(UnixIconThemesBaseDirList, 6);
-  UnixIconThemesBaseDirList[0] := Home + '/.icons';
-  UnixIconThemesBaseDirList[1] := Home + '/.local/share/icons';
-  if DesktopEnv = DE_KDE then
-  begin
-    I:= 2;
-    SetLength(UnixIconThemesBaseDirList, 7);
-    UnixIconThemesBaseDirList[2] := Home + '/.kde/share/icons';
+  DirList := TStringList.Create;
+  try
+    DirList.Add(Home + '/.icons');
+    // Respect $XDG_DATA_HOME instead of assuming the default '~/.local/share'
+    DirList.Add(IncludeTrailingBackslash(GetUserDataDir) + 'icons');
+    if DesktopEnv = DE_KDE then
+      DirList.Add(Home + '/.kde/share/icons');
+
+    // Respect $XDG_DATA_DIRS instead of hardcoding '/usr/local/share' and
+    // '/usr/share' (falls back to the same two paths when unset, per spec)
+    SystemDataDirs := GetSystemDataDirs;
+    for I := Low(SystemDataDirs) to High(SystemDataDirs) do
+      DirList.Add(IncludeTrailingBackslash(SystemDataDirs[I]) + 'icons');
+
+    // Unthemed pixmaps fallback directories are not part of $XDG_DATA_DIRS
+    DirList.Add('/usr/local/share/pixmaps');
+    DirList.Add('/usr/share/pixmaps');
+
+    SetLength(UnixIconThemesBaseDirList, DirList.Count);
+    for I := 0 to DirList.Count - 1 do
+      UnixIconThemesBaseDirList[I] := DirList[I];
+  finally
+    DirList.Free;
   end;
-  UnixIconThemesBaseDirList[I + 1] := '/usr/local/share/icons';
-  UnixIconThemesBaseDirList[I + 2] := '/usr/local/share/pixmaps';
-  UnixIconThemesBaseDirList[I + 3] := '/usr/share/icons';
-  UnixIconThemesBaseDirList[I + 4] := '/usr/share/pixmaps';
 end;
 
 initialization

--- a/src/platform/unix/uunixicontheme.pas
+++ b/src/platform/unix/uunixicontheme.pas
@@ -315,10 +315,10 @@ end;
 
 procedure InitIconThemesBaseDirList;
 var
-  Home: String;
   I: Integer;
-  SystemDataDirs: TDynamicStringArray;
+  Home: String;
   DirList: TStringList;
+  SystemDataDirs: TDynamicStringArray;
 begin
   Home := GetHomeDir;
   DirList := TStringList.Create;
@@ -326,6 +326,8 @@ begin
     DirList.Add(Home + '/.icons');
     // Respect $XDG_DATA_HOME instead of assuming the default '~/.local/share'
     DirList.Add(IncludeTrailingBackslash(GetUserDataDir) + 'icons');
+
+    // Legacy KDE 4 path
     if DesktopEnv = DE_KDE then
       DirList.Add(Home + '/.kde/share/icons');
 

--- a/src/platform/upixmapmanager.pas
+++ b/src/platform/upixmapmanager.pas
@@ -917,12 +917,12 @@ var
   I, J, K: Integer;
   mTime: TFileTime;
   LocalMime: String;
-  SystemMimeDirs: TDynamicStringArray;
   iconsList: TStringList;
   nodeList: TFPObjectList;
   node: THTDataNode = nil;
   cache: TFileStreamEx = nil;
   EntriesCount, IconsCount: Cardinal;
+  SystemMimeDirs: TDynamicStringArray;
   sMimeType, sMimeIconName, sExtension: String;
 
   procedure LoadGlobs(const APath: String);
@@ -1027,7 +1027,10 @@ begin
 
   mTime:= mbFileAge(LocalMime + mime_globs);
   for K:= Low(SystemMimeDirs) to High(SystemMimeDirs) do
-    mTime:= Max(mTime, mbFileAge(IncludeTrailingBackslash(SystemMimeDirs[K]) + 'mime/' + mime_globs));
+  begin
+    SystemMimeDirs[K]:= IncludeTrailingBackslash(SystemMimeDirs[K]) + 'mime/';
+    mTime:= Max(mTime, mbFileAge(SystemMimeDirs[K] + mime_globs));
+  end;
 
   // Try to load from cache.
   if (mbFileAge(gpCfgDir + pixmaps_cache) = mTime) and
@@ -1069,7 +1072,7 @@ begin
   EntriesCount := 0;
   LoadGlobs(LocalMime);
   for K:= Low(SystemMimeDirs) to High(SystemMimeDirs) do
-    LoadGlobs(IncludeTrailingBackslash(SystemMimeDirs[K]) + 'mime/');
+    LoadGlobs(SystemMimeDirs[K]);
 
   // save to cache
   if EntriesCount > 0 then

--- a/src/platform/upixmapmanager.pas
+++ b/src/platform/upixmapmanager.pas
@@ -917,12 +917,12 @@ var
   I, J, K: Integer;
   mTime: TFileTime;
   LocalMime: String;
+  SystemMimeDirs: TDynamicStringArray;
   iconsList: TStringList;
   nodeList: TFPObjectList;
   node: THTDataNode = nil;
   cache: TFileStreamEx = nil;
   EntriesCount, IconsCount: Cardinal;
-  GlobalMime: String = '/usr/share/mime/';
   sMimeType, sMimeIconName, sExtension: String;
 
   procedure LoadGlobs(const APath: String);
@@ -1022,9 +1022,12 @@ var
 
 begin
   LocalMime:= IncludeTrailingBackslash(GetUserDataDir) + 'mime/';
+  // Respect $XDG_DATA_DIRS instead of hardcoding '/usr/share/mime/'
+  SystemMimeDirs:= GetSystemDataDirs;
 
-  mTime:= Max(mbFileAge(LocalMime + mime_globs),
-              mbFileAge(GlobalMime + mime_globs));
+  mTime:= mbFileAge(LocalMime + mime_globs);
+  for K:= Low(SystemMimeDirs) to High(SystemMimeDirs) do
+    mTime:= Max(mTime, mbFileAge(IncludeTrailingBackslash(SystemMimeDirs[K]) + 'mime/' + mime_globs));
 
   // Try to load from cache.
   if (mbFileAge(gpCfgDir + pixmaps_cache) = mTime) and
@@ -1065,7 +1068,8 @@ begin
 
   EntriesCount := 0;
   LoadGlobs(LocalMime);
-  LoadGlobs(GlobalMime);
+  for K:= Low(SystemMimeDirs) to High(SystemMimeDirs) do
+    LoadGlobs(IncludeTrailingBackslash(SystemMimeDirs[K]) + 'mime/');
 
   // save to cache
   if EntriesCount > 0 then


### PR DESCRIPTION
## The issue

`InitIconThemesBaseDirList()` (uunixicontheme.pas) and `LoadMimeIconNames()`
(upixmapmanager.pas) both hardcode `/usr/share`, `/usr/local/share`, and
`~/.local/share` as the only places to look for icon themes and the MIME
database, instead of reading `$XDG_DATA_DIRS` / `$XDG_DATA_HOME`.

On any distro where application data doesn't live under `/usr/share` (NixOS
being the clearest example — everything lives under `/run/current-system/sw/share`
and various store paths, all correctly listed in `$XDG_DATA_DIRS`), Double
Commander silently never finds the desktop's real icon theme or MIME
database, even though both are installed and correctly exported via XDG.
Every file falls back to a generic icon and the whole app looks visually
broken next to the rest of the desktop.

## The fix

Good news: nothing new needed to be built here. `uXdg.pas` already has
correct, working `GetSystemDataDirs()` / `GetUserDataDir()` helpers (XDG
Base Directory spec compliant, including the right fallback when the env
vars are unset) — they're already used elsewhere in this exact codebase,
e.g. `uXdg.pas`'s own `GetDesktopPath()`. This PR just wires the two
outlying functions into that same existing helper instead of duplicating
hardcoded paths, so all XDG-aware path lookups in the Unix platform code
now go through one consistent, already-tested mechanism.

Legacy unthemed pixmaps directories (`/usr/local/share/pixmaps`,
`/usr/share/pixmaps`) are left as literal paths since they predate the XDG
Base Directory spec and were never part of `$XDG_DATA_DIRS`.

## Testing

- Built both current `master` and this branch via nixpkgs' own `doublecmd`
  derivation (unmodified `build.sh`/`install.sh`).
- A/B tested with a synthetic `$XDG_DATA_DIRS` pointing at a throwaway icon
  theme and MIME `globs` file: unpatched build logs `Theme ... not found`
  and never touches the custom MIME path; patched build finds and loads
  both.
- Verified visually against a real desktop theme, with no other
  icon-lookup mechanism (no symlinks, no local overrides) in place — just
  this code change.

## Before / after

### Before
<img width="2690" height="1570" alt="dc-before" src="https://github.com/user-attachments/assets/7e4f58c4-5eee-40e1-bfb6-b46a1a07403c" />

### After
<img width="2690" height="1570" alt="dc-after" src="https://github.com/user-attachments/assets/3f8ede7f-440a-40a2-be21-01b3103adcb0" />

