### PR TITLE
FIX: macOS drag&drop - follow-up to #3082

### DIFF
--- a/src/fileviews/ufileview.pas
+++ b/src/fileviews/ufileview.pas
@@ -2284,12 +2284,11 @@ begin
           fileNamesList.Add(DragFile.FSFile.FullPath);
 
         // Initiate external drag&drop operation.
+        // Note that this does not necessarily block until the drag has finished:
+        // on GTK and Cocoa the drag session is asynchronous and this returns
+        // right after the drag has been started. Anything that has to happen
+        // after the drop belongs into the drag-end event, not here.
         Result := DragDropSource.DoDragDrop(fileNamesList, MouseButton, ScreenStartPoint);
-
-        // Refresh source file panel after drop to (possibly) another application
-        // (files could have been moved for example).
-        // 'draggedFileItem' is invalid after this.
-        Reload;
       end;
 
     finally

--- a/src/fileviews/ufileviewwithmainctrl.pas
+++ b/src/fileviews/ufileviewwithmainctrl.pas
@@ -1354,38 +1354,47 @@ var
   currentPoint: TPoint;
 {$ENDIF}
 begin
+  // Refresh source file panel after the drop to (possibly) another application
+  // (files could have been moved for example). This has to be done here, when
+  // the drag has really ended, and not right after starting it: on GTK and
+  // Cocoa the drag session is asynchronous, so TFileView.BeginDragExternal()
+  // returns long before the user has dropped anything.
+  try
 {$IF DEFINED(MSWINDOWS)}
-  // On windows dragging can be transformed back into internal.
-  // Check if drag was aborted due to mouse moving back into
-  // the application window or the user just cancelled it.
-  if TransformDragging and (FDragDropSource.GetLastStatus = DragDropAborted) then
-  begin
-    // Transform to internal dragging again.
+    // On windows dragging can be transformed back into internal.
+    // Check if drag was aborted due to mouse moving back into
+    // the application window or the user just cancelled it.
+    if TransformDragging and (FDragDropSource.GetLastStatus = DragDropAborted) then
+    begin
+      // Transform to internal dragging again.
 
-    // Save current mouse position.
-    GetCursorPos(currentPoint);
+      // Save current mouse position.
+      GetCursorPos(currentPoint);
 
-    // Temporarily set cursor position to the point where the drag was started
-    // so that DragManager can properly read the control being dragged.
-    startPoint := MainControl.ClientToScreen(FDragStartPoint);
-    SetCursorPos(startPoint.X, startPoint.Y);
+      // Temporarily set cursor position to the point where the drag was started
+      // so that DragManager can properly read the control being dragged.
+      startPoint := MainControl.ClientToScreen(FDragStartPoint);
+      SetCursorPos(startPoint.X, startPoint.Y);
 
-    // Begin internal dragging.
-    MainControl.BeginDrag(True);
+      // Begin internal dragging.
+      MainControl.BeginDrag(True);
 
-    // Move cursor back.
-    SetCursorPos(currentPoint.X, currentPoint.Y);
+      // Move cursor back.
+      SetCursorPos(currentPoint.X, currentPoint.Y);
 
-    // Clear flag.
-    TransformDragging := False;
+      // Clear flag.
+      TransformDragging := False;
 
-    Exit(True);
-  end;
+      Exit(True);
+    end;
 {$ENDIF}
 
-  ClearAfterDragDrop;
+    ClearAfterDragDrop;
 
-  Result := True;
+    Result := True;
+  finally
+    Reload;
+  end;
 end;
 
 function TFileViewWithMainCtrl.OnExDragEnter(var DropEffect: TDropEffect; ScreenPoint: TPoint): Boolean;

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -224,7 +224,10 @@ begin
       DragItem.setDraggingFrame_contents(ItemFrame, ItemIcon);
     end
     else
-      DragItem.setDraggingFrame(ItemFrame);
+      // setDraggingFrame: keeps the item's default contents, which still get
+      // drawn. Clearing the contents explicitly is what leaves the trailing
+      // items out of the stack, the way Finder does it.
+      DragItem.setDraggingFrame_contents(ItemFrame, nil);
 
     DragItems.addObject(DragItem);
     DragItem.release;

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -32,7 +32,11 @@ uses
 
 type
   TDragDropSourceCocoa = class(TDragDropSource)
-
+  private
+    { Called by the drag session delegate once AppKit reports the session
+      as finished. }
+    procedure DragSessionEnded(Succeeded: Boolean);
+  public
     function RegisterEvents(DragBeginEvent  : uDragDropEx.TDragBeginEvent;
                             RequestDataEvent: uDragDropEx.TRequestDataEvent;
                             DragEndEvent    : uDragDropEx.TDragEndEvent): Boolean; override;
@@ -64,7 +68,7 @@ type
     drag session actually ends (draggingSession:endedAt:operation:). }
   TCocoaDragSource = objcclass(NSObject, NSDraggingSourceProtocol)
   public
-    DragEndEvent: uDragDropEx.TDragEndEvent;
+    Owner: TDragDropSourceCocoa;
 
     function draggingSession_sourceOperationMaskForDraggingContext(
       session: NSDraggingSession; context: NSDraggingContext): NSDragOperation;
@@ -118,10 +122,11 @@ end;
 procedure TCocoaDragSource.draggingSession_endedAtPoint_operation(
   session: NSDraggingSession; screenPoint: NSPoint; operation: NSDragOperation);
 begin
-  // Simulate drag-end event. This is where drag completion is reported now
-  // that the drag session is asynchronous (unlike the old, blocking
+  // Report drag completion. This is where it happens now that the drag session
+  // is asynchronous (unlike the old, blocking
   // dragImage:at:offset:event:pasteboard:source:slideBack: call).
-  if Assigned(DragEndEvent) then DragEndEvent();
+  if Assigned(Owner) then
+    Owner.DragSessionEnded(operation <> NSDragOperationNone);
 
   // Balance the .alloc.init done in TDragDropSourceCocoa.DoDragDrop -- this
   // instance's whole lifetime is exactly one drag operation.
@@ -129,6 +134,17 @@ begin
 end;
 
 { ---------- TDragDropSourceCocoa ---------- }
+
+procedure TDragDropSourceCocoa.DragSessionEnded(Succeeded: Boolean);
+begin
+  if Succeeded then
+    FLastStatus:= DragDropSuccessful
+  else
+    FLastStatus:= DragDropAborted;
+
+  // Simulate drag-end event.
+  if Assigned(GetDragEndEvent) then GetDragEndEvent()();
+end;
 
 function TDragDropSourceCocoa.RegisterEvents(DragBeginEvent  : uDragDropEx.TDragBeginEvent;
                                              RequestDataEvent: uDragDropEx.TRequestDataEvent;
@@ -201,9 +217,9 @@ begin
   if StartEvent = nil then Exit;
 
   Source:= TCocoaDragSource.alloc.init;
-  Source.DragEndEvent:= GetDragEndEvent;
+  Source.Owner:= Self;
 
-  View.beginDraggingSessionWithItems_event_source(DragItems, StartEvent, Source);
+  Result:= View.beginDraggingSessionWithItems_event_source(DragItems, StartEvent, Source) <> nil;
 
   // Note: the drag session started above is asynchronous -- it returns
   // immediately, before the user has dropped or cancelled anything.

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -47,6 +47,15 @@ implementation
 uses
   CocoaAll, uDarwinUtil;
 
+const
+  // Size of the drag image drawn for a dragged file.
+  DragImageSize = 32;
+  // AppKit only ever draws a small stack of images plus the item count badge,
+  // so only the leading items need an image. Asking NSWorkspace for an icon of
+  // every single dragged file would just burn LaunchServices lookups when a
+  // large selection is dragged.
+  MaxDragImageCount = 3;
+
 type
   { TCocoaDragSource }
 
@@ -135,6 +144,10 @@ begin
   WindowPoint:= WindowRect.origin;
   ViewPoint:= View.convertPoint_fromView(WindowPoint, nil);
 
+  ItemFrame:= NSMakeRect(ViewPoint.x - DragImageSize div 2,
+                         ViewPoint.y - DragImageSize div 2,
+                         DragImageSize, DragImageSize);
+
   // Build one NSDraggingItem per file, each backed by its own file URL
   // pasteboard writer. This -- instead of a single item carrying all paths
   // via the legacy NSFilenamesPboardType property list -- is what makes
@@ -149,9 +162,13 @@ begin
     // doesn't list that protocol, so the cast has to be made explicit.
     DragItem:= NSDraggingItem.alloc.initWithPasteboardWriter(NSPasteboardWritingProtocol(ItemURL));
 
-    ItemIcon:= NSWorkspace.sharedWorkspace.iconForFile(StringToNSString(FileNamesList[I]));
-    ItemFrame:= NSMakeRect(ViewPoint.x - 16, ViewPoint.y - 16, 32, 32);
-    DragItem.setDraggingFrame_contents(ItemFrame, ItemIcon);
+    if I < MaxDragImageCount then
+    begin
+      ItemIcon:= NSWorkspace.sharedWorkspace.iconForFile(StringToNSString(FileNamesList[I]));
+      DragItem.setDraggingFrame_contents(ItemFrame, ItemIcon);
+    end
+    else
+      DragItem.setDraggingFrame(ItemFrame);
 
     DragItems.addObject(DragItem);
     DragItem.release;

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -75,6 +75,38 @@ type
       message 'draggingSession:endedAtPoint:operation:';
   end;
 
+{ ---------- Helpers ---------- }
+
+{ -beginDraggingSessionWithItems:event:source: requires a mouse event.
+  The application's current event is not necessarily one: an external drag can
+  also be started from a key press (see TFileViewWithMainCtrl.MainControlKeyDown,
+  where holding Command turns an internal drag into an external one). }
+function MouseEventForDrag(View: NSView): NSEvent;
+var
+  Timestamp: NSTimeInterval = 0;
+begin
+  Result:= NSApplication.sharedApplication.currentEvent;
+
+  if Assigned(Result) then
+  begin
+    case Result.type_ of
+      NSLeftMouseDown,  NSLeftMouseDragged,
+      NSRightMouseDown, NSRightMouseDragged,
+      NSOtherMouseDown, NSOtherMouseDragged: Exit;
+    end;
+    Timestamp:= Result.timestamp;
+  end;
+
+  // Not a mouse event, synthesize one at the current mouse position instead.
+  Result:= NSEvent.mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
+             NSLeftMouseDragged,
+             View.window.mouseLocationOutsideOfEventStream,
+             0,
+             Timestamp,
+             View.window.windowNumber,
+             nil, 0, 1, 1.0);
+end;
+
 { ---------- TCocoaDragSource ---------- }
 
 function TCocoaDragSource.draggingSession_sourceOperationMaskForDraggingContext(
@@ -165,10 +197,12 @@ begin
     DragItem.release;
   end;
 
+  StartEvent:= MouseEventForDrag(View);
+  if StartEvent = nil then Exit;
+
   Source:= TCocoaDragSource.alloc.init;
   Source.DragEndEvent:= GetDragEndEvent;
 
-  StartEvent:= NSApplication.sharedApplication.currentEvent;
   View.beginDraggingSessionWithItems_event_source(DragItems, StartEvent, Source);
 
   // Note: the drag session started above is asynchronous -- it returns

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -116,8 +116,6 @@ var
   I: Integer;
   View: NSView;
   StartEvent: NSEvent;
-  WindowRect: NSRect;
-  WindowPoint, ViewPoint: NSPoint;
   DragItem: NSDraggingItem;
   DragItems: NSMutableArray;
   ItemURL: NSUrl;
@@ -137,16 +135,9 @@ begin
   View:= NSView(GetControl.Handle);
   if View = nil then Exit;
 
-  // Convert the screen-coordinate start point into View's own coordinate
-  // system, as needed by each NSDraggingItem's draggingFrame. NSWindow only
-  // exposes a rect-based screen conversion, not a point-only one.
-  WindowRect:= View.window.convertRectFromScreen(NSMakeRect(ScreenStartPoint.X, ScreenStartPoint.Y, 0, 0));
-  WindowPoint:= WindowRect.origin;
-  ViewPoint:= View.convertPoint_fromView(WindowPoint, nil);
-
-  ItemFrame:= NSMakeRect(ViewPoint.x - DragImageSize div 2,
-                         ViewPoint.y - DragImageSize div 2,
-                         DragImageSize, DragImageSize);
+  // AppKit places the drag images relative to the event that starts the
+  // session, so a fixed frame is enough here and all items may share it.
+  ItemFrame:= NSMakeRect(0, 0, DragImageSize, DragImageSize);
 
   // Build one NSDraggingItem per file, each backed by its own file URL
   // pasteboard writer. This -- instead of a single item carrying all paths

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -58,10 +58,8 @@ uses
 const
   // Size of the drag image drawn for a dragged file.
   DragImageSize = 32;
-  // AppKit only ever draws a small stack of images plus the item count badge,
-  // so only the leading items need an image. Asking NSWorkspace for an icon of
-  // every single dragged file would just burn LaunchServices lookups when a
-  // large selection is dragged.
+  // Only the leading items get a drag image. NSWorkspace.iconForFile is not
+  // called for the rest.
   MaxDragImageCount = 3;
 
 type
@@ -200,8 +198,7 @@ begin
   View:= NSView(GetControl.Handle);
   if View = nil then Exit;
 
-  // AppKit places the drag images relative to the event that starts the
-  // session, so a fixed frame is enough here and all items may share it.
+  // One fixed frame, shared by all items.
   ItemFrame:= NSMakeRect(0, 0, DragImageSize, DragImageSize);
 
   // Build one NSDraggingItem per file, each backed by its own file URL
@@ -224,9 +221,7 @@ begin
       DragItem.setDraggingFrame_contents(ItemFrame, ItemIcon);
     end
     else
-      // setDraggingFrame: keeps the item's default contents, which still get
-      // drawn. Clearing the contents explicitly is what leaves the trailing
-      // items out of the stack, the way Finder does it.
+      // Not setDraggingFrame: -- it does not give the same result here.
       DragItem.setDraggingFrame_contents(ItemFrame, nil);
 
     DragItems.addObject(DragItem);

--- a/src/platform/udragdropcocoa.pas
+++ b/src/platform/udragdropcocoa.pas
@@ -33,10 +33,14 @@ uses
 type
   TDragDropSourceCocoa = class(TDragDropSource)
   private
+    { Delegate of the drag session that is currently running, if any. }
+    FActiveSource: Pointer;
     { Called by the drag session delegate once AppKit reports the session
       as finished. }
     procedure DragSessionEnded(Succeeded: Boolean);
   public
+    destructor Destroy; override;
+
     function RegisterEvents(DragBeginEvent  : uDragDropEx.TDragBeginEvent;
                             RequestDataEvent: uDragDropEx.TRequestDataEvent;
                             DragEndEvent    : uDragDropEx.TDragEndEvent): Boolean; override;
@@ -63,8 +67,8 @@ const
 type
   { TCocoaDragSource }
 
-  { Bridges AppKit's NSDraggingSource callbacks back to a Pascal closure.
-    One instance is created per drag operation and released once the
+  { Bridges AppKit's NSDraggingSource callbacks back to the Pascal source.
+    One instance is created per drag operation and releases itself once the
     drag session actually ends (draggingSession:endedAt:operation:). }
   TCocoaDragSource = objcclass(NSObject, NSDraggingSourceProtocol)
   public
@@ -135,8 +139,21 @@ end;
 
 { ---------- TDragDropSourceCocoa ---------- }
 
+destructor TDragDropSourceCocoa.Destroy;
+begin
+  // The drag session outlives this object when the file view is destroyed
+  // while a drag is still running. Detach the delegate, it must not call back
+  // into a freed object; it still releases itself when the session ends.
+  if Assigned(FActiveSource) then
+    TCocoaDragSource(FActiveSource).Owner:= nil;
+
+  inherited Destroy;
+end;
+
 procedure TDragDropSourceCocoa.DragSessionEnded(Succeeded: Boolean);
 begin
+  FActiveSource:= nil;
+
   if Succeeded then
     FLastStatus:= DragDropSuccessful
   else
@@ -216,8 +233,13 @@ begin
   StartEvent:= MouseEventForDrag(View);
   if StartEvent = nil then Exit;
 
+  // A previous session, if any, must not report back into this object anymore.
+  if Assigned(FActiveSource) then
+    TCocoaDragSource(FActiveSource).Owner:= nil;
+
   Source:= TCocoaDragSource.alloc.init;
   Source.Owner:= Self;
+  FActiveSource:= Source;
 
   Result:= View.beginDraggingSessionWithItems_event_source(DragItems, StartEvent, Source) <> nil;
 


### PR DESCRIPTION
Follow-up to #3082, addressing @rich2014's review comments.

1. `Reload` now runs when the drag ends, not right after starting it. Moved from `TFileView.BeginDragExternal` to `TFileViewWithMainCtrl.OnExDragEnd`. `DoDragDrop` only blocks on Windows and Qt — GTK (`gtk_drag_begin`) has always been asynchronous too, so this fixes GTK as well. The Windows transform-back branch keeps its order via `try/finally`.
2. Drag images only for the first 3 items, instead of one `NSWorkspace.iconForFile` per dragged file.
3. Fixed dragging frame. The old conversion was also wrong: `ScreenStartPoint` is LCL top-left origin, `convertRectFromScreen` expects Cocoa bottom-left.

Three more issues found on the way:

4. The session was started with whatever `currentEvent` happened to be — a key event when Command turns an internal drag into an external one.
5. `DoDragDrop` always returned False and never set `FLastStatus`.
6. The session delegate could call back into a file view freed while the drag was still running. Defensive, no hand reproduction.

Built and manually tested on Apple Silicon, Cocoa: multi-file drag into WhatsApp and onto Finder, Command during an internal drag, cancel, large selections.

Item 1 is in shared code, so it compiles everywhere, but only GTK and Cocoa change behaviour. On Windows and Qt the drag-end callback already runs synchronously inside `DoDragDrop`, so the reload still happens after the drop, just a few statements earlier. It was only built and run on macOS.
