### PR TITLE
ADD: cm_AddTargetPathToCmdLine command

### DIFF
--- a/src/uglobs.pas
+++ b/src/uglobs.pas
@@ -1209,6 +1209,7 @@ begin
       AddIfNotExists(['Ctrl+M'],[],'cm_MultiRename');
       AddIfNotExists(['Ctrl+O'],[],'cm_ToggleFullscreenConsole');
       AddIfNotExists(['Ctrl+P'],[],'cm_AddPathToCmdLine');
+      AddIfNotExists(['Ctrl+Shift+P'],[],'cm_AddTargetPathToCmdLine');
       AddIfNotExists(['Ctrl+Q'],[],'cm_QuickView');
       AddIfNotExists(['Ctrl+S'],[],'cm_QuickSearch');
       AddIfNotExists(['Ctrl+R'],[],'cm_Refresh');

--- a/src/umaincommands.pas
+++ b/src/umaincommands.pas
@@ -167,6 +167,7 @@ type
    // 35. Make sure we see the shortcut if any and that the description is correct.
    // 36. Test the help for the command from there to make sure it links to the correct place in the help file.
    procedure cm_AddPathToCmdLine(const {%H-}Params: array of string);
+   procedure cm_AddTargetPathToCmdLine(const {%H-}Params: array of string);
    procedure cm_AddFilenameToCmdLine(const {%H-}Params: array of string);
    procedure cm_AddPathAndFilenameToCmdLine(const {%H-}Params: array of string);
    procedure cm_CmdLineNext(const {%H-}Params: array of string);
@@ -1052,6 +1053,12 @@ end;
 procedure TMainCommands.cm_AddPathToCmdLine(const Params: array of string);
 begin
   DoActualAddToCommandLine(Params, frmMain.ActiveFrame.CurrentPath, False);
+end;
+
+{ TMainCommands.cm_AddTargetPathToCmdLine }
+procedure TMainCommands.cm_AddTargetPathToCmdLine(const Params: array of string);
+begin
+  DoActualAddToCommandLine(Params, frmMain.NotActiveFrame.CurrentPath, False);
 end;
 
 { TMainCommands.cm_AddFilenameToCmdLine }


### PR DESCRIPTION
Adds `cm_AddTargetPathToCmdLine`, the inactive-panel counterpart of `cm_AddPathToCmdLine`: it adds the inactive panel's current path to the command line instead of the active panel's.

### Why

From outside Double Commander a panel's path can only be read through `cm_AddPathToCmdLine` (the text is read back from the command line), and that command always reports the *active* panel. Tools that keep a list of the folders currently open in file managers (for example the Lertaro launcher's Double Commander plugin) therefore cannot see the other panel without switching to it, which visibly changes the active panel. This adds the missing half.

### Notes

- Implementation mirrors `cm_AddPathToCmdLine`: `DoActualAddToCommandLine(Params, frmMain.NotActiveFrame.CurrentPath, False)`.
- Default hotkey: `Ctrl+Shift+P` (free in the current default set). Easy to drop if you would rather not add a default binding.
- I intentionally skipped the toolbar action/caption/icon and the help entry from the "RECIPE TO ADD A cm_ COMMAND": the command targets external tools rather than the toolbar. Happy to add them if you want it fully user-facing.
- Verified before opening this PR with a Windows build (Lazarus, win32 + win64) from a fork:
  - `Ctrl+P` with the right panel active → `"C:\Program Files"`
  - `Ctrl+Shift+P` → `C:\Windows` (the inactive left panel)